### PR TITLE
feat(cli): use server.runner config to start dev API server

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -334,7 +334,7 @@ export default defineConfig({
 ## Rules
 
 1. **Imports**: All imports at top of file. Use `import type` for type-only imports.
-2. **Linting**: Biome — no `any`, no `import * as` unless necessary.
+2. **Linting**: Biome — no `any`, no `import * as` unless necessary. **After editing files, run `npx biome check --write` to fix lint/format issues before committing.**
 3. **No manual server entries**: The framework generates server entry dynamically.
 4. **No manual webpack configs**: Use `ev.config.ts` or zero-config defaults.
 5. **No webpack.config.cjs fallback**: `ev.config.ts` is the sole config source.

--- a/AGENT.md
+++ b/AGENT.md
@@ -334,7 +334,7 @@ export default defineConfig({
 ## Rules
 
 1. **Imports**: All imports at top of file. Use `import type` for type-only imports.
-2. **Linting**: Biome — no `any`, no `import * as` unless necessary. **After editing files, run `npx biome check --write` to fix lint/format issues before committing.**
+2. **Linting**: Biome — no `any`, no `import * as` unless necessary. 
 3. **No manual server entries**: The framework generates server entry dynamically.
 4. **No manual webpack configs**: Use `ev.config.ts` or zero-config defaults.
 5. **No webpack.config.cjs fallback**: `ev.config.ts` is the sole config source.

--- a/AGENT.md
+++ b/AGENT.md
@@ -334,7 +334,7 @@ export default defineConfig({
 ## Rules
 
 1. **Imports**: All imports at top of file. Use `import type` for type-only imports.
-2. **Linting**: Biome — no `any`, no `import * as` unless necessary. 
+2. **Linting**: Biome — no `any`, no `import * as` unless necessary.
 3. **No manual server entries**: The framework generates server entry dynamically.
 4. **No manual webpack configs**: Use `ev.config.ts` or zero-config defaults.
 5. **No webpack.config.cjs fallback**: `ev.config.ts` is the sole config source.

--- a/e2e/cases/complex-routing.ts
+++ b/e2e/cases/complex-routing.ts
@@ -47,7 +47,7 @@ test.describe("complex-routing", () => {
     await postLink.click();
 
     // Post detail renders with resolved params
-    await expect(page.getByRole("heading", { name: postTitle! })).toBeVisible({
+    await expect(page.getByRole("heading", { name: postTitle as string })).toBeVisible({
       timeout: 5_000,
     });
 

--- a/e2e/cases/complex-routing.ts
+++ b/e2e/cases/complex-routing.ts
@@ -47,7 +47,9 @@ test.describe("complex-routing", () => {
     await postLink.click();
 
     // Post detail renders with resolved params
-    await expect(page.getByRole("heading", { name: postTitle as string })).toBeVisible({
+    await expect(
+      page.getByRole("heading", { name: postTitle as string }),
+    ).toBeVisible({
       timeout: 5_000,
     });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -202,18 +202,19 @@ program
               // node gets --watch flags; other runtimes use their own args as-is
               const runnerArgs =
                 runner === "node"
-                  ? ["--watch", "--watch-preserve-output", ...runnerExtraArgs, bootstrapPath]
+                  ? [
+                      "--watch",
+                      "--watch-preserve-output",
+                      ...runnerExtraArgs,
+                      bootstrapPath,
+                    ]
                   : [...runnerExtraArgs, bootstrapPath];
 
               try {
-                await execa(
-                  runner,
-                  runnerArgs,
-                  {
-                    stdio: "inherit",
-                    env: { ...process.env, NODE_ENV: "development" },
-                  },
-                );
+                await execa(runner, runnerArgs, {
+                  stdio: "inherit",
+                  env: { ...process.env, NODE_ENV: "development" },
+                });
               } catch (_e) {
                 started = false;
               }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -175,7 +175,9 @@ program
         while (true) {
           if (fs.existsSync(manifestPath)) {
             if (!started) {
-              logger.info`Server bundle detected, starting Node API...`;
+              const runnerConfig = evjsConfig?.server?.runner ?? "node";
+              const [runner, ...runnerExtraArgs] = runnerConfig.split(/\s+/);
+              logger.info`Server bundle detected, starting ${runner} API...`;
               started = true;
 
               const manifest = JSON.parse(
@@ -197,10 +199,16 @@ program
                 ].join("\n"),
               );
 
+              // node gets --watch flags; other runtimes use their own args as-is
+              const runnerArgs =
+                runner === "node"
+                  ? ["--watch", "--watch-preserve-output", ...runnerExtraArgs, bootstrapPath]
+                  : [...runnerExtraArgs, bootstrapPath];
+
               try {
                 await execa(
-                  "node",
-                  ["--watch", "--watch-preserve-output", bootstrapPath],
+                  runner,
+                  runnerArgs,
                   {
                     stdio: "inherit",
                     env: { ...process.env, NODE_ENV: "development" },

--- a/packages/runtime/tests/routing-types.test.tsx
+++ b/packages/runtime/tests/routing-types.test.tsx
@@ -18,7 +18,6 @@ import {
   createAppRootRoute,
   createRoute,
   Link,
-  Outlet,
 } from "@evjs/runtime/client";
 
 // ── Setup route tree ──
@@ -72,7 +71,7 @@ declare module "@tanstack/react-router" {
 
 // ── Type assertions: useParams ──
 
-function PostComponent() {
+function _PostComponent() {
   // ✅ Correct: postId is typed as string
   const { postId } = postRoute.useParams();
   const _check: string = postId;
@@ -84,7 +83,7 @@ function PostComponent() {
   postRoute.useParams().username;
 }
 
-function UserComponent() {
+function _UserComponent() {
   // ✅ Correct: username is typed as string
   const { username } = userRoute.useParams();
   const _check: string = username;
@@ -95,7 +94,7 @@ function UserComponent() {
 
 // ── Type assertions: useSearch ──
 
-function SearchComponent() {
+function _SearchComponent() {
   // ✅ Correct: q and page are typed
   const { q, page } = searchRoute.useSearch();
   const _q: string = q;
@@ -107,7 +106,7 @@ function SearchComponent() {
 
 // ── Type assertions: Link params ──
 
-function LinkTests() {
+function _LinkTests() {
   // ✅ Correct: Link with required params
   <Link to="/posts/$postId" params={{ postId: "123" }} />;
 

--- a/packages/runtime/tests/routing-types.test.tsx
+++ b/packages/runtime/tests/routing-types.test.tsx
@@ -71,7 +71,8 @@ declare module "@tanstack/react-router" {
 
 // ── Type assertions: useParams ──
 
-function _PostComponent() {
+// biome-ignore lint/correctness/noUnusedVariables: type-level test component
+function PostComponent() {
   // ✅ Correct: postId is typed as string
   const { postId } = postRoute.useParams();
   const _check: string = postId;
@@ -83,7 +84,8 @@ function _PostComponent() {
   postRoute.useParams().username;
 }
 
-function _UserComponent() {
+// biome-ignore lint/correctness/noUnusedVariables: type-level test component
+function UserComponent() {
   // ✅ Correct: username is typed as string
   const { username } = userRoute.useParams();
   const _check: string = username;
@@ -94,7 +96,8 @@ function _UserComponent() {
 
 // ── Type assertions: useSearch ──
 
-function _SearchComponent() {
+// biome-ignore lint/correctness/noUnusedVariables: type-level test component
+function SearchComponent() {
   // ✅ Correct: q and page are typed
   const { q, page } = searchRoute.useSearch();
   const _q: string = q;
@@ -106,7 +109,8 @@ function _SearchComponent() {
 
 // ── Type assertions: Link params ──
 
-function _LinkTests() {
+// biome-ignore lint/correctness/noUnusedVariables: type-level test component
+function LinkTests() {
   // ✅ Correct: Link with required params
   <Link to="/posts/$postId" params={{ postId: "123" }} />;
 


### PR DESCRIPTION
## Summary

- `server.runner` was defined in the config type (`ServerConfig.runner`) and documented in AGENT.md, but `ev dev` hardcoded `node` as the server runtime
- This PR reads `server.runner` from `ev.config.ts`, splits it by whitespace — first token as executable, rest as extra args prepended to the script path
- When `runner` is `"node"` (default), behavior is unchanged (`--watch` flags preserved)

### Supported examples

| `server.runner` | Executed command |
|---|---|
| `"node"` (default) | `node --watch --watch-preserve-output script.js` |
| `"utoo-runtime run"` | `utoo-runtime run script.js` |
| `"bun"` | `bun script.js` |
| `"deno run --allow-net"` | `deno run --allow-net script.js` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)