### PR TITLE
feat(cli): support custom config path via -c/--config option

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -37,11 +37,15 @@ Uses webpack Node API directly (no temp config files):
 1. **WebpackDevServer** (port 3000) — client bundle with HMR.
 2. **Node API Server** (port 3001) — auto-starts when server bundle is emitted, uses `node --watch`.
 
+Option: `-c, --config <path>` to load a config file from a custom path.
+
 ### `ev build`
 
 Runs webpack via Node API with `NODE_ENV=production`:
 - `dist/client/` — optimized client assets with content hashes.
 - `dist/server/main.[hash].js` — server bundle (entry discovered via `dist/server/manifest.json`).
+
+Option: `-c, --config <path>` to load a config file from a custom path.
 
 ## Configuration
 
@@ -65,3 +69,12 @@ export default defineConfig({
 ```
 
 The `client.dev` and `server.dev` fields accept extra options that are merged with defaults.
+
+You can also point the CLI at any config file path:
+
+```bash
+ev dev --config ./configs/ev.dev.mjs
+ev build -c /absolute/path/to/ev.config.ts
+```
+
+Relative config paths are resolved from the current working directory.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -133,12 +133,16 @@ program
  * Uses ev.config.ts when present, otherwise falls back to zero-config defaults.
  * No webpack.config.cjs fallback — the meta-framework owns the build config.
  */
-async function resolveWebpackConfig(cwd: string) {
+async function resolveWebpackConfig(cwd: string, configPath?: string) {
   const { loadConfig } = await import("./load-config.js");
-  const evjsConfig = await loadConfig(cwd);
+  const evjsConfig = await loadConfig(cwd, configPath);
 
   const { createWebpackConfig } = await import("./create-webpack-config.js");
-  logger.info`Using ${evjsConfig ? "ev.config.ts" : "zero-config defaults"}`;
+  if (configPath) {
+    logger.info`Using config: ${path.relative(cwd, path.resolve(cwd, configPath))}`;
+  } else {
+    logger.info`Using ${evjsConfig ? "ev.config.ts" : "zero-config defaults"}`;
+  }
   const webpackConfig = createWebpackConfig(evjsConfig, cwd);
 
   return { evjsConfig, webpackConfig };
@@ -147,11 +151,15 @@ async function resolveWebpackConfig(cwd: string) {
 program
   .command("dev")
   .description("Start development server")
-  .action(async () => {
+  .option("-c, --config <path>", "Path to config file")
+  .action(async (options: { config?: string }) => {
     const cwd = process.cwd();
     process.env.NODE_ENV ??= "development";
 
-    const { evjsConfig, webpackConfig } = await resolveWebpackConfig(cwd);
+    const { evjsConfig, webpackConfig } = await resolveWebpackConfig(
+      cwd,
+      options.config,
+    );
     const serverPort =
       evjsConfig?.server?.dev?.port ?? CONFIG_DEFAULTS.serverPort;
 
@@ -235,10 +243,11 @@ program
 program
   .command("build")
   .description("Build project for production")
-  .action(async () => {
+  .option("-c, --config <path>", "Path to config file")
+  .action(async (options: { config?: string }) => {
     const cwd = process.cwd();
     process.env.NODE_ENV ??= "production";
-    const { webpackConfig } = await resolveWebpackConfig(cwd);
+    const { webpackConfig } = await resolveWebpackConfig(cwd, options.config);
 
     logger.info`Building for production...`;
     const webpack = esmRequire("webpack");

--- a/packages/cli/src/load-config.ts
+++ b/packages/cli/src/load-config.ts
@@ -1,8 +1,15 @@
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import type { EvConfig } from "./config.js";
 
 const CONFIG_FILES = ["ev.config.ts", "ev.config.js", "ev.config.mjs"];
+const TS_CONFIG_EXTENSIONS = new Set([".ts", ".mts", ".cts"]);
+
+type LoadConfigDependencies = {
+  ensureTsLoader?: () => Promise<void>;
+  importModule?: (configPath: string) => Promise<unknown>;
+};
 
 /**
  * Ensure a TypeScript loader is registered before importing `.ts` config files.
@@ -20,23 +27,60 @@ async function ensureTsLoader(): Promise<void> {
   }
 }
 
+async function importConfigModule(configPath: string): Promise<unknown> {
+  return import(pathToFileURL(configPath).href);
+}
+
+function shouldUseTsLoader(configPath: string): boolean {
+  return TS_CONFIG_EXTENSIONS.has(path.extname(configPath));
+}
+
+function resolveConfigPath(
+  cwd: string,
+  configPath?: string,
+): string | undefined {
+  if (configPath) {
+    return path.resolve(cwd, configPath);
+  }
+
+  for (const filename of CONFIG_FILES) {
+    const resolvedPath = path.resolve(cwd, filename);
+    if (fs.existsSync(resolvedPath)) {
+      return resolvedPath;
+    }
+  }
+
+  return undefined;
+}
+
 /**
  * Load evjs config from the project root.
  *
- * Looks for `ev.config.ts`, `.js`, or `.mjs` in the given directory.
+ * Looks for `ev.config.ts`, `.js`, or `.mjs` in the given directory, or loads
+ * the explicit config path when provided.
  * Returns undefined if no config file is found.
  */
-export async function loadConfig(cwd: string): Promise<EvConfig | undefined> {
-  for (const filename of CONFIG_FILES) {
-    const configPath = path.resolve(cwd, filename);
-    if (fs.existsSync(configPath)) {
-      // Register TS loader for .ts config files
-      if (filename.endsWith(".ts")) {
-        await ensureTsLoader();
-      }
-      const mod = await import(configPath);
-      return mod.default ?? mod;
-    }
+export async function loadConfig(
+  cwd: string,
+  configPath?: string,
+  deps: LoadConfigDependencies = {},
+): Promise<EvConfig | undefined> {
+  const resolvedConfigPath = resolveConfigPath(cwd, configPath);
+
+  if (!resolvedConfigPath) {
+    return undefined;
   }
-  return undefined;
+
+  if (!fs.existsSync(resolvedConfigPath)) {
+    throw new Error(`Config file not found: ${resolvedConfigPath}`);
+  }
+
+  if (shouldUseTsLoader(resolvedConfigPath)) {
+    await (deps.ensureTsLoader ?? ensureTsLoader)();
+  }
+
+  const mod = await (deps.importModule ?? importConfigModule)(
+    resolvedConfigPath,
+  );
+  return (mod as { default?: EvConfig }).default ?? (mod as EvConfig);
 }

--- a/packages/cli/tests/load-config.test.ts
+++ b/packages/cli/tests/load-config.test.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadConfig } from "../src/load-config.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "evjs-cli-load-config-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("loadConfig", () => {
+  it("loads the default config file from cwd when present", async () => {
+    const cwd = await createTempDir();
+    const configPath = path.join(cwd, "ev.config.mjs");
+
+    await fs.writeFile(
+      configPath,
+      'export default { server: { endpoint: "/from-default" } };\n',
+    );
+
+    const config = await loadConfig(cwd);
+
+    expect(config).toEqual({
+      server: { endpoint: "/from-default" },
+    });
+  });
+
+  it("loads an explicit relative config path from cwd", async () => {
+    const cwd = await createTempDir();
+    const configDir = path.join(cwd, "configs");
+    const configPath = path.join(configDir, "custom.mjs");
+
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      'export default { client: { entry: "./src/app.tsx" } };\n',
+    );
+
+    const config = await loadConfig(cwd, "./configs/custom.mjs");
+
+    expect(config).toEqual({
+      client: { entry: "./src/app.tsx" },
+    });
+  });
+
+  it("loads an explicit absolute config path", async () => {
+    const cwd = await createTempDir();
+    const configPath = path.join(cwd, "absolute-config.mjs");
+
+    await fs.writeFile(
+      configPath,
+      "export default { server: { dev: { port: 4100 } } };\n",
+    );
+
+    const config = await loadConfig(cwd, configPath);
+
+    expect(config).toEqual({
+      server: { dev: { port: 4100 } },
+    });
+  });
+
+  it("throws a clear error when the explicit config path does not exist", async () => {
+    const cwd = await createTempDir();
+
+    await expect(loadConfig(cwd, "./missing.config.mjs")).rejects.toThrow(
+      `Config file not found: ${path.join(cwd, "missing.config.mjs")}`,
+    );
+  });
+
+  it("prepares the ts loader before importing explicit ts configs", async () => {
+    const cwd = await createTempDir();
+    const configDir = path.join(cwd, "configs");
+    const ensureTsLoader = vi.fn().mockResolvedValue(undefined);
+    const importModule = vi.fn().mockResolvedValue({
+      default: { server: { endpoint: "/ts-config" } },
+    });
+
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(
+      path.join(configDir, "ev.custom.ts"),
+      "export default {};\n",
+    );
+
+    const config = await loadConfig(cwd, "./configs/ev.custom.ts", {
+      ensureTsLoader,
+      importModule,
+    });
+
+    expect(ensureTsLoader).toHaveBeenCalledTimes(1);
+    expect(importModule).toHaveBeenCalledWith(
+      path.join(cwd, "configs", "ev.custom.ts"),
+    );
+    expect(config).toEqual({
+      server: { endpoint: "/ts-config" },
+    });
+  });
+});


### PR DESCRIPTION
This PR adds support for a custom configuration file path using the `-c` or `--config` option in both `ev dev` and `ev build` commands. 

Key changes:
- Added `-c, --config <path>` option to CLI.
- Updated `loadConfig` to handle explicit paths and provide better testability.
- Added comprehensive tests for configuration loading.
- Updated documentation.

Closes #FIXME