### PR TITLE
feat(webpack): use window.assetPrefix as runtime publicPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 - **`assetPrefix` config option** — New top-level config field for deploying static assets to a CDN. Set `assetPrefix: "https://cdn.example.com/"` in `ev.config.ts` to prefix all JS/CSS asset URLs in the production build output
 - **Runtime `window.assetPrefix`** — The configured prefix is injected as a `<script>window.assetPrefix="..."</script>` tag in the `<head>` of `index.html`, enabling deployment-time rewriting and dynamic asset URL construction in React components
-- **Webpack `publicPath: "auto"`** — Production builds now use Webpack's automatic public path resolution, allowing lazily loaded chunks to correctly resolve relative to their CDN location without manual configuration
+- **Runtime `publicPath` via `window.assetPrefix`** — Webpack's chunk loader reads `window.assetPrefix` at runtime, so dynamically loaded chunks resolve against the deploy-time CDN URL without requiring a rebuild
 - **`assetPrefix` ignored in dev** — During `ev dev`, the prefix is always forced to `"/"` to preserve local HMR and dev server stability
 
 ### 📝 Documentation

--- a/docs/docs/deploy.md
+++ b/docs/docs/deploy.md
@@ -26,7 +26,7 @@ export default defineConfig({
 ```
 
 During `ev build`, this prefix will be:
-1. Applied to dynamically loaded JS chunks automatically using Webpack's `auto` publicPath strategy.
+1. Used as Webpack's runtime `publicPath` via `window.assetPrefix` — all dynamically loaded JS/CSS chunks, images, and fonts resolve against this prefix at runtime.
 2. Written into `<script>` and `<link>` tags in `dist/index.html`.
 3. Exposed as a global `window.assetPrefix` runtime variable on the client, which can be safely mutated by your deployment tools before serving `index.html`.
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deploy.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deploy.md
@@ -25,7 +25,7 @@ export default defineConfig({
 ```
 
 在 `ev build` 时，该前缀会被：
-1. 自动注入以加载异步 JS Chunk（通过 Webpack 自动机制）。
+1. 作为 Webpack 运行时 `publicPath`（通过 `window.assetPrefix`）—— 所有动态加载的 JS/CSS 分块、图片和字体都会基于该前缀进行解析。
 2. 直接写入 `dist/index.html` 的资源标签中。
 3. 作为客户端全局 `window.assetPrefix` 运行时变量暴露。你的部署服务器可以在分发 `index.html` 之前安全地动态替换它。
 

--- a/packages/bundler-webpack/src/adapter/create-config.ts
+++ b/packages/bundler-webpack/src/adapter/create-config.ts
@@ -52,11 +52,17 @@ export function createWebpackConfig(
   // Never spread config.dev directly — webpack-dev-server rejects unknown properties.
   const isHttps = config.dev.https;
 
+  // Runtime public path bootstrap — must execute before any dynamic import().
+  // Reads window.assetPrefix (injected into <head> by EvWebpackPlugin) and
+  // sets webpack's __webpack_require__.p so async chunks, asset modules, and
+  // CSS url() references resolve against the deploy-time CDN prefix.
+  const publicPathEntry = `data:text/javascript,__webpack_public_path__=window.assetPrefix||"/"`;
+
   const webpackConfig: Record<string, unknown> = {
     name: "client",
     mode: isProduction ? "production" : "development",
     devtool: isProduction ? "hidden-source-map" : "source-map",
-    entry,
+    entry: [publicPathEntry, entry],
     output: {
       path: path.resolve(cwd, serverEnabled ? "dist/client" : "dist"),
       filename: isProduction ? "[name].[contenthash:8].js" : "index.js",

--- a/packages/ev/src/config.ts
+++ b/packages/ev/src/config.ts
@@ -75,8 +75,10 @@ export interface EvConfig {
    * Use this when deploying static assets to a CDN on a different domain.
    *
    * At build time, this prefix is applied to all `<script>` and `<link>` tags
-   * in the generated HTML. A `<script>window.assetPrefix = "..."`</script>` tag
-   * is also injected so the value is available at runtime.
+   * in the generated HTML. It is also used as Webpack's runtime `publicPath`,
+   * so dynamically loaded chunks resolve against it. A
+   * `<script>window.assetPrefix = "..."</script>` tag is injected so the value
+   * is available at runtime and can be rewritten at deploy time.
    *
    * @example "https://cdn.example.com/assets/"
    * @default "/"


### PR DESCRIPTION
Prepend a data-URI bootstrap entry that sets __webpack_public_path__ from window.assetPrefix at runtime, so dynamically loaded chunks resolve against the deploy-time CDN URL without requiring a rebuild.

- Add publicPath bootstrap entry in create-config.ts
- Update assetPrefix docstring in config.ts
- Update deploy.md (EN + zh-Hans) and CHANGELOG.md