### PR TITLE
Move build orchestration into @evjs/ev and slim @evjs/cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: npx turbo build --filter="./packages/*"
       
       - name: Build Examples and Docs
-        run: npx turbo build --filter="./examples/*" --filter="evjs-docs"
+        run: npx turbo build --filter="./examples/*" --filter="evjs-docs" --concurrency=2
 
       - name: Lint & Type Check
         run: npm run lint && npm run check-types

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ config needed.
 
 | Package | Purpose |
 |---------|---------|
-| [`@evjs/cli`](./packages/cli) | CLI binary (`ev dev`, `ev build`) |
-| [`@evjs/ev`](./packages/ev) | Config, plugin, and bundler types (`defineConfig`) |
+| [`@evjs/ev`](./packages/ev) | Framework API, config, plugins, and build orchestration (`defineConfig`, `dev`, `build`) |
+| [`@evjs/cli`](./packages/cli) | Thin CLI wrapper (`ev dev`, `ev build`) with the default bundler |
 | [`@evjs/create-app`](./packages/create-app) | Project scaffolding (`npx @evjs/create-app`) |
 | [`@evjs/shared`](./packages/shared) | Runtime shared: errors, HTTP utils, constants |
 | [`@evjs/client`](./packages/client) | Client runtime (React + TanStack) |
@@ -64,4 +64,3 @@ npm run test:e2e     # playwright
 ## 📄 License
 
 MIT © [Ant UED](https://xtech.antfin.com/)
-

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -31,9 +31,9 @@ evjs is a React fullstack framework with type-safe routing (TanStack Router), da
 ## Package Dependency Graph
 
 ```
-@evjs/cli ──► @evjs/bundler-utoopack ──► @evjs/build-tools ──► @swc/core
+@evjs/cli ──► @evjs/ev ──► @evjs/manifest
     │
-    └──► webpack (Node API)
+    └──► @evjs/bundler-utoopack ──► @evjs/build-tools ──► @swc/core
 
 @evjs/shared ──► @evjs/manifest
 

--- a/docs/docs/deploy.md
+++ b/docs/docs/deploy.md
@@ -6,7 +6,7 @@ Building and deploying an evjs application requires two parts: serving the stati
 
 ```bash
 npm run build
-# Under the hood: npx ev build
+# Under the hood: ev build
 ```
 
 This creates:

--- a/docs/docs/dev.md
+++ b/docs/docs/dev.md
@@ -82,14 +82,17 @@ The ECMA environment adapter (`@evjs/server/ecma`) only exports a `{ fetch }` ha
 `ev dev` and `ev build` can also be used programmatically:
 
 ```ts
-import { dev, build } from "@evjs/cli";
+import { dev, build } from "@evjs/ev";
+import { utoopackAdapter } from "@evjs/bundler-utoopack";
 
-// Start dev server (loads ev.config.ts and uses defaults)
-await dev({ dev: { port: 3000 } }, { cwd: "./my-app" });
+// Start dev server with an explicit bundler adapter
+await dev({ dev: { port: 3000 } }, { cwd: "./my-app", bundler: utoopackAdapter });
 
 // Run production build
-await build({ entry: "./src/main.tsx" }, { cwd: "./my-app" });
+await build({ entry: "./src/main.tsx" }, { cwd: "./my-app", bundler: utoopackAdapter });
 ```
+
+`@evjs/cli` also exports compatibility wrappers that inject the default utoopack adapter, matching the `ev dev` and `ev build` commands.
 
 ## Transport
 

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -84,8 +84,8 @@ declare module "@tanstack/react-router" {
 
 | Package | Purpose |
 |---------|---------|
-| [`@evjs/cli`](https://github.com/evaijs/evjs/tree/main/packages/cli) | CLI binary (`ev dev`, `ev build`) |
-| [`@evjs/ev`](https://github.com/evaijs/evjs/tree/main/packages/ev) | Config, plugin, and bundler types (`defineConfig`) |
+| [`@evjs/ev`](https://github.com/evaijs/evjs/tree/main/packages/ev) | Framework API, config, plugins, and build orchestration (`defineConfig`, `dev`, `build`) |
+| [`@evjs/cli`](https://github.com/evaijs/evjs/tree/main/packages/cli) | Thin CLI wrapper (`ev dev`, `ev build`) with the default bundler |
 | [`@evjs/create-app`](https://github.com/evaijs/evjs/tree/main/packages/create-app) | Project scaffolding (`npx @evjs/create-app`) |
 | [`@evjs/client`](https://github.com/evaijs/evjs/tree/main/packages/client) | Client runtime (React + TanStack) |
 | [`@evjs/server`](https://github.com/evaijs/evjs/tree/main/packages/server) | Server runtime (Hono) |
@@ -104,6 +104,7 @@ declare module "@tanstack/react-router" {
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@evjs/ev": "*",
     "@evjs/cli": "*",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/dev.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/dev.md
@@ -82,14 +82,17 @@ ECMA 适配器（`@evjs/server/ecma`）只导出一个 `{ fetch }` 处理器 —
 `ev dev` 和 `ev build` 也可以在代码中编程式调用：
 
 ```ts
-import { dev, build } from "@evjs/cli";
+import { dev, build } from "@evjs/ev";
+import { utoopackAdapter } from "@evjs/bundler-utoopack";
 
-// 启动开发服务器（加载 ev.config.ts 并应用默认值）
-await dev({ dev: { port: 3000 } }, { cwd: "./my-app" });
+// 使用显式构建器适配器启动开发服务器
+await dev({ dev: { port: 3000 } }, { cwd: "./my-app", bundler: utoopackAdapter });
 
 // 运行生产构建
-await build({ entry: "./src/main.tsx" }, { cwd: "./my-app" });
+await build({ entry: "./src/main.tsx" }, { cwd: "./my-app", bundler: utoopackAdapter });
 ```
+
+`@evjs/cli` 也导出兼容包装函数，会自动注入默认的 utoopack 适配器，与 `ev dev` 和 `ev build` 命令保持一致。
 
 ## 传输层
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quick-start.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quick-start.md
@@ -84,8 +84,8 @@ declare module "@tanstack/react-router" {
 
 | 包 | 用途 |
 |---|------|
-| [`@evjs/cli`](https://github.com/evaijs/evjs/tree/main/packages/cli) | CLI 命令行工具 (`ev dev`, `ev build`) |
-| [`@evjs/ev`](https://github.com/evaijs/evjs/tree/main/packages/ev) | 配置、插件和构建器类型 (`defineConfig`) |
+| [`@evjs/ev`](https://github.com/evaijs/evjs/tree/main/packages/ev) | 框架 API、配置、插件和构建编排 (`defineConfig`, `dev`, `build`) |
+| [`@evjs/cli`](https://github.com/evaijs/evjs/tree/main/packages/cli) | 注入默认构建器的轻量 CLI 包装 (`ev dev`, `ev build`) |
 | [`@evjs/create-app`](https://github.com/evaijs/evjs/tree/main/packages/create-app) | 项目脚手架 (`npx @evjs/create-app`) |
 | [`@evjs/client`](https://github.com/evaijs/evjs/tree/main/packages/client) | 客户端运行时（React + TanStack） |
 | [`@evjs/server`](https://github.com/evaijs/evjs/tree/main/packages/server) | 服务端运行时（Hono） |
@@ -104,6 +104,7 @@ declare module "@tanstack/react-router" {
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@evjs/ev": "*",
     "@evjs/cli": "*",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/e2e/cases/mpa.ts
+++ b/e2e/cases/mpa.ts
@@ -17,7 +17,7 @@ const test = base.extend<{ baseURL: string }, { _app: { port: number } }>({
     async ({}, use, workerInfo) => {
       const port = 31200 + workerInfo.workerIndex;
 
-      execSync("npx ev build", {
+      execSync("ev build", {
         cwd: exampleDir,
         stdio: "pipe",
       });

--- a/e2e/fixtures-ws.ts
+++ b/e2e/fixtures-ws.ts
@@ -47,7 +47,7 @@ export function createWebSocketExampleTest() {
         const webPort = await getAvailablePort();
 
         // 1. Build with utoopack
-        execSync("npx ev build", {
+        execSync("ev build", {
           cwd: exampleDir,
           stdio: "pipe",
         });

--- a/examples/api-routes/package.json
+++ b/examples/api-routes/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "npx ev dev",
-    "build": "npx ev build",
+    "dev": "ev dev",
+    "build": "ev build",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "npx ev dev",
-    "build": "npx ev build",
+    "dev": "ev dev",
+    "build": "ev build",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {

--- a/examples/complex-routing/package.json
+++ b/examples/complex-routing/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "npx ev dev",
-    "build": "npx ev build",
+    "dev": "ev dev",
+    "build": "ev build",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {

--- a/examples/custom-ws-transport/package.json
+++ b/examples/custom-ws-transport/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "npx ev dev",
-    "build": "npx ev build",
+    "dev": "ev dev",
+    "build": "ev build",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {

--- a/examples/mpa/package.json
+++ b/examples/mpa/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "npx ev dev",
-    "build": "npx ev build",
+    "dev": "ev dev",
+    "build": "ev build",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {

--- a/examples/plugin-authoring/package.json
+++ b/examples/plugin-authoring/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "npx ev dev",
-    "build": "npx ev build",
+    "dev": "ev dev",
+    "build": "ev build",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {

--- a/examples/with-sqlite/package.json
+++ b/examples/with-sqlite/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "npx ev dev",
-    "build": "npx ev build",
+    "dev": "ev dev",
+    "build": "ev build",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {

--- a/examples/with-tailwind/package.json
+++ b/examples/with-tailwind/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "npx ev dev",
-    "build": "npx ev build",
+    "dev": "ev dev",
+    "build": "ev build",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {

--- a/examples/with-trpc/package.json
+++ b/examples/with-trpc/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "npx ev dev",
-    "build": "npx ev build",
+    "dev": "ev dev",
+    "build": "ev build",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24798,8 +24798,7 @@
         "@evjs/bundler-utoopack": "*",
         "@evjs/ev": "*",
         "@logtape/logtape": "^2.0.4",
-        "commander": "^12.1.0",
-        "execa": "^9.6.1"
+        "commander": "^12.1.0"
       },
       "bin": {
         "ev": "bin/ev.js"
@@ -24852,9 +24851,12 @@
       "license": "MIT",
       "dependencies": {
         "@evjs/manifest": "*",
-        "@evjs/shared": "*"
+        "@evjs/shared": "*",
+        "@logtape/logtape": "^2.0.4",
+        "execa": "^9.6.1"
       },
       "devDependencies": {
+        "@types/node": "^22.19.15",
         "@utoo/pack": "^1.4.2",
         "typescript": "^6.0.2"
       }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @evjs/cli
 
-> CLI and configuration for the **evjs** fullstack framework.
+> Thin command-line wrapper for the **evjs** fullstack framework.
 
 ## Install
 
@@ -10,7 +10,7 @@ npm install -g @evjs/cli
 
 ## Convention over Configuration
 
-No configuration file is needed. `ev dev` and `ev build` work out of the box with sensible defaults:
+No configuration file is needed. `ev dev` and `ev build` delegate to `@evjs/ev` and inject the default utoopack adapter:
 
 - Entry: `./src/main.tsx`
 - HTML: `./index.html`
@@ -29,13 +29,13 @@ No configuration file is needed. `ev dev` and `ev build` work out of the box wit
 
 ### `ev dev`
 
-Uses bundler Node API directly (no temp config files):
+Uses the default bundler adapter directly (no temp config files):
 1. **dev server** (port 3000) — client bundle with HMR.
 2. **Node API Server** (port 3001) — auto-starts when server bundle is emitted, uses `node --watch`.
 
 ### `ev build`
 
-Runs webpack via Node API with `NODE_ENV=production`:
+Runs the production build through `@evjs/ev` with `NODE_ENV=production`:
 - `dist/client/` — optimized client assets with content hashes.
 - `dist/server/main.[hash].js` — server bundle (entry discovered via `dist/server/manifest.json`).
 
@@ -51,7 +51,6 @@ export default defineConfig({
   html: "./index.html",
   dev: { port: 3000 },
   server: {
-    endpoint: "/api/fn",
     dev: { port: 3001 },
   },
 });
@@ -80,13 +79,13 @@ my-app/
 ## Common Mistakes
 
 1. **Don't create `custom bundler config file`** — use `ev.config.ts` instead
-2. **Don't install webpack manually** — it's a dependency of `@evjs/cli`
+2. **Don't install bundler internals manually** — the default adapter is provided by `@evjs/cli`
 3. **Config file must be `ev.config.ts`** — not `evjs.config.ts`
 4. **Import `defineConfig` from `@evjs/ev`** — not from `@evjs/server`
 
 ## Bundled Dependencies
 
-Users do NOT need to install these — they're included in `@evjs/cli`:
-- `webpack`, `webpack-dev-server`
-- `html-webpack-plugin`, `swc-loader`, `@swc/core`
-- `@evjs/bundler-utoopack`, `@evjs/build-tools`
+Users do NOT need to install these — they're included through `@evjs/cli`:
+- `@evjs/bundler-utoopack`
+- `@evjs/build-tools`
+- the bundler's underlying compiler dependencies

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evjs/cli",
   "version": "0.0.0",
-  "description": "CLI and configuration layer for the evjs framework",
+  "description": "Command-line wrapper for the evjs framework",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,8 +31,7 @@
     "@evjs/bundler-utoopack": "*",
     "@evjs/ev": "*",
     "@logtape/logtape": "^2.0.4",
-    "commander": "^12.1.0",
-    "execa": "^9.6.1"
+    "commander": "^12.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.19.15",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,18 @@
-import fs from "node:fs";
-import path from "node:path";
+import { utoopackAdapter } from "@evjs/bundler-utoopack";
 import {
+  type BuildOptions,
+  type BundlerAdapter,
+  type DevOptions,
+  type EvConfig,
+  build as frameworkBuild,
+  dev as frameworkDev,
+} from "@evjs/ev";
+
+export {
+  type BuildOptions,
   type BundlerAdapter,
   CONFIG_DEFAULTS,
+  type DevOptions,
   defineConfig,
   type EvBuildResult,
   type EvBundlerCtx,
@@ -13,324 +23,26 @@ import {
   type ResolvedEvConfig,
   resolveConfig,
 } from "@evjs/ev";
-import type { ClientManifest, ServerManifest } from "@evjs/manifest";
-import { getLogger } from "@logtape/logtape";
-import { execa } from "execa";
+export { loadConfig } from "./load-config.js";
 
-export {
-  CONFIG_DEFAULTS,
-  type EvConfig,
-  type EvBuildResult,
-  type EvBundlerCtx,
-  type EvPlugin,
-  type EvPluginContext,
-  type EvPluginHooks,
-  type ResolvedEvConfig,
-  resolveConfig,
-  defineConfig,
-};
+const defaultBundler = utoopackAdapter as unknown as BundlerAdapter;
 
-const logger = getLogger(["evjs", "cli"]);
-
-export interface DevOptions {
-  cwd?: string;
-}
-
-export interface BuildOptions {
-  cwd?: string;
-}
-
-/**
- * Resolve the bundler adapter specified in the configuration.
- * Falls back to utoopack when no bundler is explicitly provided.
- */
-async function getBundlerAdapter<TBundlerCfg>(
-  config?: ResolvedEvConfig<TBundlerCfg>,
-): Promise<BundlerAdapter<TBundlerCfg>> {
-  if (config?.bundler) {
-    return config.bundler;
-  }
-  // Default: dynamically import utoopack so it's not a hard dependency
-  const { utoopackAdapter } = await import("@evjs/bundler-utoopack");
-  return utoopackAdapter as unknown as BundlerAdapter<TBundlerCfg>;
-}
-
-function withActiveBundler<TBundlerCfg>(
-  config: ResolvedEvConfig<TBundlerCfg>,
-  bundler: BundlerAdapter<TBundlerCfg>,
-): ResolvedEvConfig<TBundlerCfg> {
-  if (config.bundler === bundler) {
-    return config;
-  }
-
-  return {
-    ...config,
-    bundler,
-  };
-}
-
-/**
- * Run plugin setup() hooks and collect lifecycle hooks.
- */
-async function collectPluginHooks<TBundlerCfg>(
-  plugins: EvPlugin<TBundlerCfg>[],
-  ctx: EvPluginContext<TBundlerCfg>,
-): Promise<EvPluginHooks<TBundlerCfg>[]> {
-  const allHooks: EvPluginHooks<TBundlerCfg>[] = [];
-  for (const plugin of plugins) {
-    if (plugin.setup) {
-      const hooks = await plugin.setup(ctx);
-      if (hooks) {
-        allHooks.push(hooks);
-      }
-    }
-  }
-  return allHooks;
-}
-
-/**
- * Run all buildStart hooks sequentially.
- */
-async function runBuildStartHooks<TBundlerCfg>(
-  hooks: EvPluginHooks<TBundlerCfg>[],
-): Promise<void> {
-  for (const h of hooks) {
-    if (h.buildStart) {
-      await h.buildStart();
-    }
-  }
-}
-
-/**
- * Run all buildEnd hooks sequentially.
- */
-async function runBuildEndHooks<TBundlerCfg>(
-  hooks: EvPluginHooks<TBundlerCfg>[],
-  result: EvBuildResult,
-): Promise<void> {
-  for (const h of hooks) {
-    if (h.buildEnd) {
-      await h.buildEnd(result);
-    }
-  }
-}
-
-/**
- * Read build manifests from disk.
- */
-function readBuildResult(
-  cwd: string,
-  serverEnabled: boolean,
-  isRebuild: boolean,
-): EvBuildResult | null {
-  const clientManifestPath = serverEnabled
-    ? path.resolve(cwd, "dist/client/manifest.json")
-    : path.resolve(cwd, "dist/manifest.json");
-
-  if (!fs.existsSync(clientManifestPath)) return null;
-
-  let clientManifest: ClientManifest;
-  try {
-    clientManifest = JSON.parse(fs.readFileSync(clientManifestPath, "utf-8"));
-  } catch (err) {
-    logger.warn`Failed to parse client manifest: ${err}`;
-    return null;
-  }
-
-  let serverManifest: ServerManifest | undefined;
-  if (serverEnabled) {
-    const serverManifestPath = path.resolve(cwd, "dist/server/manifest.json");
-    if (fs.existsSync(serverManifestPath)) {
-      try {
-        serverManifest = JSON.parse(
-          fs.readFileSync(serverManifestPath, "utf-8"),
-        );
-      } catch (err) {
-        logger.warn`Failed to parse server manifest: ${err}`;
-      }
-    }
-  }
-
-  return { clientManifest, serverManifest, isRebuild };
-}
-
-/**
- * Start the development server programmatically.
- *
- * @param config - evjs configuration object (from `defineConfig`)
- * @param options - additional options like `cwd`
- */
 export async function dev(
   userConfig?: EvConfig,
   options?: DevOptions,
 ): Promise<void> {
-  const resolvedConfig = resolveConfig(userConfig);
-  const cwd = options?.cwd ?? process.cwd();
-  process.env.NODE_ENV ??= "development";
-
-  const bundler = await getBundlerAdapter(resolvedConfig);
-  const config = withActiveBundler(resolvedConfig, bundler);
-
-  // Collect plugin hooks
-  const pluginCtx: EvPluginContext = { mode: "development", cwd, config };
-  const hooks = await collectPluginHooks(config.plugins, pluginCtx);
-
-  // Run buildStart hooks
-  await runBuildStartHooks(hooks);
-
-  // Validate HTML files exist
-  if (config.pages) {
-    for (const [name, page] of Object.entries(config.pages)) {
-      if (!fs.existsSync(path.resolve(cwd, page.html))) {
-        throw new Error(
-          `[evjs] MPA page "${name}" html template not found: ${page.html}`,
-        );
-      }
-    }
-  } else if (!fs.existsSync(path.resolve(cwd, config.html))) {
-    throw new Error(`[evjs] HTML template not found: ${config.html}`);
-  }
-
-  // Track the running API server process for lifecycle management.
-  let apiProcess: ReturnType<typeof execa> | null = null;
-  let isFirstBuild = true;
-
-  const handleServerBundleReady = async () => {
-    if (!config.serverEnabled) return;
-
-    const manifestPath = path.resolve(cwd, "dist/server/manifest.json");
-    if (!fs.existsSync(manifestPath)) return;
-
-    let manifest: ServerManifest;
-    try {
-      manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
-    } catch (err) {
-      logger.warn`Failed to parse server manifest: ${err}`;
-      return;
-    }
-    if (manifest.version !== 1) {
-      logger.warn`Unexpected server manifest version: ${manifest.version}. Expected 1.`;
-      return;
-    }
-    if (!manifest.entry) return;
-
-    // Run buildEnd hooks with manifests
-    const buildResult = readBuildResult(
-      cwd,
-      config.serverEnabled,
-      !isFirstBuild,
-    );
-    if (buildResult) {
-      runBuildEndHooks(hooks, buildResult).catch((err) => {
-        logger.error`Plugin buildEnd hook failed: ${err}`;
-      });
-    }
-    isFirstBuild = false;
-
-    // Kill previous process before restarting (handles both first start and restarts)
-    if (apiProcess) {
-      logger.info`Restarting API server...`;
-      const oldProcess = apiProcess;
-      apiProcess = null;
-      oldProcess.kill();
-      try {
-        await Promise.race([
-          oldProcess.catch(() => {}),
-          new Promise((resolve) => setTimeout(resolve, 3000)),
-        ]);
-      } catch {}
-    }
-
-    const serverPort = config?.server?.dev?.port ?? CONFIG_DEFAULTS.serverPort;
-    logger.info`Server bundle detected, starting API...`;
-
-    const bootstrapPath = path.resolve(cwd, "dist/server/_dev_start.cjs");
-    try {
-      const serverBundlePath = path.resolve(cwd, "dist/server", manifest.entry);
-
-      if (!fs.existsSync(path.dirname(bootstrapPath))) {
-        fs.mkdirSync(path.dirname(bootstrapPath), { recursive: true });
-      }
-      fs.writeFileSync(
-        bootstrapPath,
-        [
-          `const handler = require(${JSON.stringify(serverBundlePath)}).default;`,
-          `const { serve } = require("@evjs/server/node");`,
-          `serve({ fetch: handler.fetch }, { port: ${serverPort}, https: ${JSON.stringify(config.server.dev.https)} });`,
-        ].join("\n"),
-      );
-
-      const runtimeArgs = [bootstrapPath];
-
-      // Don't await execa here since it's a long-running watch process
-      const child = execa("node", runtimeArgs, {
-        stdio: "inherit",
-        env: { ...process.env, NODE_ENV: "development" },
-      });
-      apiProcess = child;
-
-      child.catch(() => {
-        // Clear reference so the next compilation can restart
-        if (apiProcess === child) {
-          apiProcess = null;
-        }
-      });
-    } catch (err) {
-      logger.error`Server runtime failed: ${err}`;
-      apiProcess = null;
-    }
-  };
-
-  await bundler.dev(
-    config,
-    cwd,
-    { onServerBundleReady: handleServerBundleReady },
-    hooks,
-  );
+  await frameworkDev(userConfig, {
+    ...options,
+    bundler: options?.bundler ?? userConfig?.bundler ?? defaultBundler,
+  });
 }
 
-/**
- * Run a production build programmatically.
- *
- * @param config - evjs configuration object (from `defineConfig`)
- * @param options - additional options like `cwd`
- */
 export async function build(
   userConfig?: EvConfig,
   options?: BuildOptions,
 ): Promise<void> {
-  const resolvedConfig = resolveConfig(userConfig);
-  const cwd = options?.cwd ?? process.cwd();
-  process.env.NODE_ENV ??= "production";
-
-  const bundler = await getBundlerAdapter(resolvedConfig);
-  const config = withActiveBundler(resolvedConfig, bundler);
-
-  // Collect plugin hooks
-  const pluginCtx: EvPluginContext = { mode: "production", cwd, config };
-  const hooks = await collectPluginHooks(config.plugins, pluginCtx);
-
-  // Run buildStart hooks
-  await runBuildStartHooks(hooks);
-
-  // Validate HTML files exist
-  if (config.pages) {
-    for (const [name, page] of Object.entries(config.pages)) {
-      if (!fs.existsSync(path.resolve(cwd, page.html))) {
-        throw new Error(
-          `[evjs] MPA page "${name}" html template not found: ${page.html}`,
-        );
-      }
-    }
-  } else if (!fs.existsSync(path.resolve(cwd, config.html))) {
-    throw new Error(`[evjs] HTML template not found: ${config.html}`);
-  }
-
-  await bundler.build(config, cwd, hooks);
-
-  // Run buildEnd hooks with manifests
-  const buildResult = readBuildResult(cwd, config.serverEnabled, false);
-  if (buildResult) {
-    await runBuildEndHooks(hooks, buildResult);
-  }
+  await frameworkBuild(userConfig, {
+    ...options,
+    bundler: options?.bundler ?? userConfig?.bundler ?? defaultBundler,
+  });
 }

--- a/packages/cli/tests/programmatic.test.ts
+++ b/packages/cli/tests/programmatic.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { BundlerAdapter } from "@evjs/ev";
+import { describe, expect, it } from "vitest";
+import { build } from "../src/index.js";
+
+async function createProject() {
+  const cwd = await fs.promises.mkdtemp(path.join(os.tmpdir(), "evjs-cli-"));
+  await fs.promises.writeFile(
+    path.join(cwd, "index.html"),
+    '<div id="app"></div>',
+    "utf-8",
+  );
+  return cwd;
+}
+
+describe("programmatic API", () => {
+  it("forwards build calls through the framework API", async () => {
+    const cwd = await createProject();
+    const events: string[] = [];
+    const bundler: BundlerAdapter = {
+      name: "mock",
+      async build(_config, buildCwd) {
+        events.push(`build:${buildCwd}`);
+        const dist = path.join(buildCwd, "dist");
+        await fs.promises.mkdir(dist, { recursive: true });
+        await fs.promises.writeFile(
+          path.join(dist, "manifest.json"),
+          JSON.stringify({
+            version: 1,
+            assets: { js: [], css: [] },
+          }),
+          "utf-8",
+        );
+      },
+      async dev() {
+        events.push("dev");
+      },
+    };
+
+    await build({ server: false }, { cwd, bundler });
+
+    expect(events).toEqual([`build:${cwd}`]);
+  });
+});

--- a/packages/ev/package.json
+++ b/packages/ev/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evjs/ev",
   "version": "0.0.0",
-  "description": "Config, plugin, and bundler types for the evjs framework",
+  "description": "Framework API, configuration, and build orchestration for evjs",
   "type": "module",
   "publishConfig": {
     "access": "public"
@@ -33,9 +33,12 @@
   "author": "xusd320",
   "dependencies": {
     "@evjs/manifest": "*",
-    "@evjs/shared": "*"
+    "@evjs/shared": "*",
+    "@logtape/logtape": "^2.0.4",
+    "execa": "^9.6.1"
   },
   "devDependencies": {
+    "@types/node": "^22.19.15",
     "@utoo/pack": "^1.4.2",
     "typescript": "^6.0.2"
   },

--- a/packages/ev/src/commands.ts
+++ b/packages/ev/src/commands.ts
@@ -1,0 +1,293 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { ClientManifest, ServerManifest } from "@evjs/manifest";
+import { getLogger } from "@logtape/logtape";
+import { execa } from "execa";
+import type { BundlerAdapter } from "./bundler.js";
+import {
+  CONFIG_DEFAULTS,
+  type EvConfig,
+  type ResolvedEvConfig,
+  resolveConfig,
+} from "./config.js";
+import type {
+  EvBuildResult,
+  EvPlugin,
+  EvPluginContext,
+  EvPluginHooks,
+} from "./plugin.js";
+
+const logger = getLogger(["evjs", "ev"]);
+
+export interface DevOptions<TBundlerCfg = import("@utoo/pack").ConfigComplete> {
+  cwd?: string;
+  bundler?: BundlerAdapter<TBundlerCfg>;
+}
+
+export interface BuildOptions<
+  TBundlerCfg = import("@utoo/pack").ConfigComplete,
+> {
+  cwd?: string;
+  bundler?: BundlerAdapter<TBundlerCfg>;
+}
+
+function resolveBundler<TBundlerCfg>(
+  configBundler: BundlerAdapter<TBundlerCfg> | undefined,
+  optionBundler: BundlerAdapter<TBundlerCfg> | undefined,
+): BundlerAdapter<TBundlerCfg> {
+  const bundler = optionBundler ?? configBundler;
+  if (!bundler) {
+    throw new Error(
+      "[evjs] No bundler configured. Pass a bundler adapter in ev.config.ts or through dev/build options.",
+    );
+  }
+  return bundler;
+}
+
+function withActiveBundler<TBundlerCfg>(
+  config: ResolvedEvConfig<TBundlerCfg>,
+  bundler: BundlerAdapter<TBundlerCfg>,
+): ResolvedEvConfig<TBundlerCfg> {
+  if (config.bundler === bundler) {
+    return config;
+  }
+
+  return {
+    ...config,
+    bundler,
+  };
+}
+
+async function collectPluginHooks<TBundlerCfg>(
+  plugins: EvPlugin<TBundlerCfg>[],
+  ctx: EvPluginContext<TBundlerCfg>,
+): Promise<EvPluginHooks<TBundlerCfg>[]> {
+  const allHooks: EvPluginHooks<TBundlerCfg>[] = [];
+  for (const plugin of plugins) {
+    if (plugin.setup) {
+      const hooks = await plugin.setup(ctx);
+      if (hooks) {
+        allHooks.push(hooks);
+      }
+    }
+  }
+  return allHooks;
+}
+
+async function runBuildStartHooks<TBundlerCfg>(
+  hooks: EvPluginHooks<TBundlerCfg>[],
+): Promise<void> {
+  for (const h of hooks) {
+    if (h.buildStart) {
+      await h.buildStart();
+    }
+  }
+}
+
+async function runBuildEndHooks<TBundlerCfg>(
+  hooks: EvPluginHooks<TBundlerCfg>[],
+  result: EvBuildResult,
+): Promise<void> {
+  for (const h of hooks) {
+    if (h.buildEnd) {
+      await h.buildEnd(result);
+    }
+  }
+}
+
+function validateHtmlTemplates<TBundlerCfg>(
+  cwd: string,
+  config: ResolvedEvConfig<TBundlerCfg>,
+): void {
+  if (config.pages) {
+    for (const [name, page] of Object.entries(config.pages)) {
+      if (!fs.existsSync(path.resolve(cwd, page.html))) {
+        throw new Error(
+          `[evjs] MPA page "${name}" html template not found: ${page.html}`,
+        );
+      }
+    }
+    return;
+  }
+
+  if (!fs.existsSync(path.resolve(cwd, config.html))) {
+    throw new Error(`[evjs] HTML template not found: ${config.html}`);
+  }
+}
+
+function readBuildResult(
+  cwd: string,
+  serverEnabled: boolean,
+  isRebuild: boolean,
+): EvBuildResult | null {
+  const clientManifestPath = serverEnabled
+    ? path.resolve(cwd, "dist/client/manifest.json")
+    : path.resolve(cwd, "dist/manifest.json");
+
+  if (!fs.existsSync(clientManifestPath)) return null;
+
+  let clientManifest: ClientManifest;
+  try {
+    clientManifest = JSON.parse(fs.readFileSync(clientManifestPath, "utf-8"));
+  } catch (err) {
+    logger.warn`Failed to parse client manifest: ${err}`;
+    return null;
+  }
+
+  let serverManifest: ServerManifest | undefined;
+  if (serverEnabled) {
+    const serverManifestPath = path.resolve(cwd, "dist/server/manifest.json");
+    if (fs.existsSync(serverManifestPath)) {
+      try {
+        serverManifest = JSON.parse(
+          fs.readFileSync(serverManifestPath, "utf-8"),
+        );
+      } catch (err) {
+        logger.warn`Failed to parse server manifest: ${err}`;
+      }
+    }
+  }
+
+  return { clientManifest, serverManifest, isRebuild };
+}
+
+export async function dev<TBundlerCfg = import("@utoo/pack").ConfigComplete>(
+  userConfig?: EvConfig<TBundlerCfg>,
+  options?: DevOptions<TBundlerCfg>,
+): Promise<void> {
+  const resolvedConfig = resolveConfig(userConfig);
+  const cwd = options?.cwd ?? process.cwd();
+  process.env.NODE_ENV ??= "development";
+
+  const bundler = resolveBundler(resolvedConfig.bundler, options?.bundler);
+  const config = withActiveBundler(resolvedConfig, bundler);
+
+  const pluginCtx: EvPluginContext<TBundlerCfg> = {
+    mode: "development",
+    cwd,
+    config,
+  };
+  const hooks = await collectPluginHooks(config.plugins, pluginCtx);
+
+  await runBuildStartHooks(hooks);
+  validateHtmlTemplates(cwd, config);
+
+  let apiProcess: ReturnType<typeof execa> | null = null;
+  let isFirstBuild = true;
+
+  const handleServerBundleReady = async () => {
+    if (!config.serverEnabled) return;
+
+    const manifestPath = path.resolve(cwd, "dist/server/manifest.json");
+    if (!fs.existsSync(manifestPath)) return;
+
+    let manifest: ServerManifest;
+    try {
+      manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+    } catch (err) {
+      logger.warn`Failed to parse server manifest: ${err}`;
+      return;
+    }
+    if (manifest.version !== 1) {
+      logger.warn`Unexpected server manifest version: ${manifest.version}. Expected 1.`;
+      return;
+    }
+    if (!manifest.entry) return;
+
+    const buildResult = readBuildResult(
+      cwd,
+      config.serverEnabled,
+      !isFirstBuild,
+    );
+    if (buildResult) {
+      runBuildEndHooks(hooks, buildResult).catch((err) => {
+        logger.error`Plugin buildEnd hook failed: ${err}`;
+      });
+    }
+    isFirstBuild = false;
+
+    if (apiProcess) {
+      logger.info`Restarting API server...`;
+      const oldProcess = apiProcess;
+      apiProcess = null;
+      oldProcess.kill();
+      try {
+        await Promise.race([
+          oldProcess.catch(() => {}),
+          new Promise((resolve) => setTimeout(resolve, 3000)),
+        ]);
+      } catch {}
+    }
+
+    const serverPort = config.server.dev.port ?? CONFIG_DEFAULTS.serverPort;
+    logger.info`Server bundle detected, starting API...`;
+
+    const bootstrapPath = path.resolve(cwd, "dist/server/_dev_start.cjs");
+    try {
+      const serverBundlePath = path.resolve(cwd, "dist/server", manifest.entry);
+
+      if (!fs.existsSync(path.dirname(bootstrapPath))) {
+        fs.mkdirSync(path.dirname(bootstrapPath), { recursive: true });
+      }
+      fs.writeFileSync(
+        bootstrapPath,
+        [
+          `const handler = require(${JSON.stringify(serverBundlePath)}).default;`,
+          `const { serve } = require("@evjs/server/node");`,
+          `serve({ fetch: handler.fetch }, { port: ${serverPort}, https: ${JSON.stringify(config.server.dev.https)} });`,
+        ].join("\n"),
+      );
+
+      const child = execa("node", [bootstrapPath], {
+        stdio: "inherit",
+        env: { ...process.env, NODE_ENV: "development" },
+      });
+      apiProcess = child;
+
+      child.catch(() => {
+        if (apiProcess === child) {
+          apiProcess = null;
+        }
+      });
+    } catch (err) {
+      logger.error`Server runtime failed: ${err}`;
+      apiProcess = null;
+    }
+  };
+
+  await bundler.dev(
+    config,
+    cwd,
+    { onServerBundleReady: handleServerBundleReady },
+    hooks,
+  );
+}
+
+export async function build<TBundlerCfg = import("@utoo/pack").ConfigComplete>(
+  userConfig?: EvConfig<TBundlerCfg>,
+  options?: BuildOptions<TBundlerCfg>,
+): Promise<void> {
+  const resolvedConfig = resolveConfig(userConfig);
+  const cwd = options?.cwd ?? process.cwd();
+  process.env.NODE_ENV ??= "production";
+
+  const bundler = resolveBundler(resolvedConfig.bundler, options?.bundler);
+  const config = withActiveBundler(resolvedConfig, bundler);
+
+  const pluginCtx: EvPluginContext<TBundlerCfg> = {
+    mode: "production",
+    cwd,
+    config,
+  };
+  const hooks = await collectPluginHooks(config.plugins, pluginCtx);
+
+  await runBuildStartHooks(hooks);
+  validateHtmlTemplates(cwd, config);
+
+  await bundler.build(config, cwd, hooks);
+
+  const buildResult = readBuildResult(cwd, config.serverEnabled, false);
+  if (buildResult) {
+    await runBuildEndHooks(hooks, buildResult);
+  }
+}

--- a/packages/ev/src/commands.ts
+++ b/packages/ev/src/commands.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import type { ClientManifest, ServerManifest } from "@evjs/manifest";
 import { getLogger } from "@logtape/logtape";
 import { execa } from "execa";
@@ -18,6 +19,8 @@ import type {
 } from "./plugin.js";
 
 const logger = getLogger(["evjs", "ev"]);
+
+type ApiProcess = ReturnType<typeof execa>;
 
 export interface DevOptions<TBundlerCfg = import("@utoo/pack").ConfigComplete> {
   cwd?: string;
@@ -151,6 +154,24 @@ function readBuildResult(
   return { clientManifest, serverManifest, isRebuild };
 }
 
+async function stopApiProcess(
+  processToStop: ApiProcess,
+  timeoutMs = 3000,
+): Promise<void> {
+  processToStop.kill();
+  const exited = await Promise.race([
+    processToStop.then(() => true).catch(() => true),
+    new Promise<boolean>((resolve) =>
+      setTimeout(() => resolve(false), timeoutMs),
+    ),
+  ]);
+
+  if (!exited) {
+    processToStop.kill("SIGKILL");
+    await processToStop.catch(() => {});
+  }
+}
+
 export async function dev<TBundlerCfg = import("@utoo/pack").ConfigComplete>(
   userConfig?: EvConfig<TBundlerCfg>,
   options?: DevOptions<TBundlerCfg>,
@@ -172,10 +193,11 @@ export async function dev<TBundlerCfg = import("@utoo/pack").ConfigComplete>(
   await runBuildStartHooks(hooks);
   validateHtmlTemplates(cwd, config);
 
-  let apiProcess: ReturnType<typeof execa> | null = null;
+  let apiProcess: ApiProcess | null = null;
   let isFirstBuild = true;
+  let restartQueue: Promise<void> = Promise.resolve();
 
-  const handleServerBundleReady = async () => {
+  const restartApiServer = async () => {
     if (!config.serverEnabled) return;
 
     const manifestPath = path.resolve(cwd, "dist/server/manifest.json");
@@ -209,17 +231,15 @@ export async function dev<TBundlerCfg = import("@utoo/pack").ConfigComplete>(
     if (apiProcess) {
       logger.info`Restarting API server...`;
       const oldProcess = apiProcess;
-      apiProcess = null;
-      oldProcess.kill();
       try {
-        await Promise.race([
-          oldProcess.catch(() => {}),
-          new Promise((resolve) => setTimeout(resolve, 3000)),
-        ]);
+        await stopApiProcess(oldProcess);
       } catch {}
+      if (apiProcess === oldProcess) {
+        apiProcess = null;
+      }
     }
 
-    const serverPort = config.server.dev.port ?? CONFIG_DEFAULTS.serverPort;
+    const serverPort = config.server?.dev?.port ?? CONFIG_DEFAULTS.serverPort;
     logger.info`Server bundle detected, starting API...`;
 
     const bootstrapPath = path.resolve(cwd, "dist/server/_dev_start.cjs");
@@ -232,9 +252,12 @@ export async function dev<TBundlerCfg = import("@utoo/pack").ConfigComplete>(
       fs.writeFileSync(
         bootstrapPath,
         [
-          `const handler = require(${JSON.stringify(serverBundlePath)}).default;`,
+          `(async () => {`,
+          `const serverModule = await import(${JSON.stringify(pathToFileURL(serverBundlePath).href)});`,
+          `const handler = serverModule.default?.default ?? serverModule.default ?? serverModule;`,
           `const { serve } = require("@evjs/server/node");`,
-          `serve({ fetch: handler.fetch }, { port: ${serverPort}, https: ${JSON.stringify(config.server.dev.https)} });`,
+          `serve({ fetch: handler.fetch }, { port: ${serverPort}, https: ${JSON.stringify(config.server?.dev?.https ?? false)} });`,
+          `})().catch((err) => { console.error(err); process.exit(1); });`,
         ].join("\n"),
       );
 
@@ -253,6 +276,11 @@ export async function dev<TBundlerCfg = import("@utoo/pack").ConfigComplete>(
       logger.error`Server runtime failed: ${err}`;
       apiProcess = null;
     }
+  };
+
+  const handleServerBundleReady = async () => {
+    restartQueue = restartQueue.catch(() => {}).then(restartApiServer);
+    await restartQueue;
   };
 
   await bundler.dev(

--- a/packages/ev/src/index.ts
+++ b/packages/ev/src/index.ts
@@ -3,6 +3,7 @@
  */
 
 export type { BundlerAdapter } from "./bundler.js";
+export { type BuildOptions, build, type DevOptions, dev } from "./commands.js";
 export {
   CONFIG_DEFAULTS,
   defineConfig,

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { BundlerAdapter } from "../src/bundler.js";
+import { build, type EvPlugin } from "../src/index.js";
+
+async function createProject() {
+  const cwd = await fs.promises.mkdtemp(path.join(os.tmpdir(), "evjs-"));
+  await fs.promises.writeFile(
+    path.join(cwd, "index.html"),
+    '<div id="app"></div>',
+    "utf-8",
+  );
+  return cwd;
+}
+
+function createMockBundler(
+  events: string[],
+): BundlerAdapter<Record<string, never>> {
+  return {
+    name: "mock",
+    async build(_config, cwd) {
+      events.push("bundler.build");
+      const dist = path.join(cwd, "dist");
+      await fs.promises.mkdir(dist, { recursive: true });
+      await fs.promises.writeFile(
+        path.join(dist, "manifest.json"),
+        JSON.stringify({
+          version: 1,
+          assets: { js: ["main.js"], css: [] },
+        }),
+        "utf-8",
+      );
+    },
+    async dev() {
+      events.push("bundler.dev");
+    },
+  };
+}
+
+describe("build", () => {
+  it("requires a bundler from config or options", async () => {
+    const cwd = await createProject();
+    await expect(build({ server: false }, { cwd })).rejects.toThrow(
+      "No bundler configured",
+    );
+  });
+
+  it("runs framework orchestration around the injected bundler", async () => {
+    const cwd = await createProject();
+    const events: string[] = [];
+    const bundler = createMockBundler(events);
+
+    const plugin: EvPlugin<Record<string, never>> = {
+      name: "records-lifecycle",
+      setup(ctx) {
+        expect(ctx.config.bundler?.name).toBe("mock");
+        events.push(`setup:${ctx.mode}`);
+        return {
+          buildStart() {
+            events.push("buildStart");
+          },
+          buildEnd(result) {
+            events.push(`buildEnd:${result.clientManifest.assets.js[0]}`);
+          },
+        };
+      },
+    };
+
+    await build(
+      { server: false, plugins: [plugin] },
+      {
+        cwd,
+        bundler,
+      },
+    );
+
+    expect(events).toEqual([
+      "setup:production",
+      "buildStart",
+      "bundler.build",
+      "buildEnd:main.js",
+    ]);
+  });
+});

--- a/packages/ev/tsconfig.json
+++ b/packages/ev/tsconfig.json
@@ -11,6 +11,7 @@
     "stripInternal": true,
     "declarationMap": true,
     "sourceMap": true,
+    "types": ["node"],
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
## Summary
- Moved framework-level `dev()` and `build()` orchestration into `@evjs/ev`
- Kept `@evjs/cli` as a thin wrapper that injects the default `utoopack` adapter
- Updated package metadata, docs, and README copy to reflect the new package boundaries
- Added unit coverage for the new framework entrypoints and CLI forwarding path

## Testing
- `@evjs/ev`: typecheck, unit tests, and build passed
- `@evjs/cli`: typecheck, unit tests, and build passed
- Biome check passed on the touched source files