### PR TITLE
refactor: Wire function endpoint through build define

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -38,9 +38,38 @@ interface EvPlugin {
   /** Plugin name — used in logs and error messages. */
   name: string;
 
+  /** Modify raw user config before defaults are resolved. */
+  config?: (
+    config: EvConfig,
+    ctx: EvPluginConfigContext,
+  ) => EvConfig | undefined | Promise<EvConfig | undefined>;
+
   /** Initialize the plugin, return lifecycle hooks. */
   setup?: (ctx: EvPluginContext) => EvPluginHooks | undefined;
 }
+```
+
+### Config Hook
+
+The `config` hook runs before evjs resolves defaults. Use it for framework-level
+settings that must be visible to dev proxy setup and runtime defines, such as
+`server.endpoint`.
+
+```ts
+export default defineConfig({
+  plugins: [
+    {
+      name: "custom-function-endpoint",
+      config(config) {
+        config.server = {
+          ...(typeof config.server === "object" ? config.server : {}),
+          endpoint: "/api/rpc",
+        };
+        return config;
+      },
+    },
+  ],
+});
 ```
 
 ### Setup Context

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugins.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugins.md
@@ -31,17 +31,46 @@ export default defineConfig({
 
 ## 插件结构
 
-每个插件是一个包含 `name` 和可选 `setup()` 函数的对象：
+每个插件是一个包含 `name`，以及可选 `config()` / `setup()` 函数的对象：
 
 ```ts
 interface EvPlugin {
   /** 插件名称 —— 用于日志和错误信息。 */
   name: string;
 
+  /** 在默认值解析前修改用户原始配置。 */
+  config?: (
+    config: EvConfig,
+    ctx: EvPluginConfigContext,
+  ) => EvConfig | undefined | Promise<EvConfig | undefined>;
+
   /** 初始化插件，返回生命周期钩子。 */
   setup?: (ctx: EvPluginContext) => EvPluginHooks | undefined;
 }
 ```
+
+### Config Hook
+
+`config` hook 在 evjs 解析默认配置前执行。它适合修改框架级配置，尤其是那些会影响派生配置、开发代理或运行时代码注入的选项，例如 `server.endpoint`。
+
+```ts
+export default defineConfig({
+  plugins: [
+    {
+      name: "custom-function-endpoint",
+      config(config) {
+        config.server = {
+          ...(typeof config.server === "object" ? config.server : {}),
+          endpoint: "/api/rpc",
+        };
+        return config;
+      },
+    },
+  ],
+});
+```
+
+如果只是应用自己配置服务端函数端点，直接在 `defineConfig` 中设置 `server.endpoint` 即可。只有需要由插件统一注入或封装这类配置时，才使用 `config` hook。
 
 ### Setup 上下文
 
@@ -62,21 +91,27 @@ interface EvPluginContext {
 
 ```mermaid
 flowchart LR
-    A[buildStart] --> B[bundlerConfig]
-    B --> C["bundler 编译"]
-    C --> D["HTML 生成"]
-    D --> E[transformHtml]
-    E --> F[buildEnd]
+    A[config] --> B["resolveConfig"]
+    B --> C[setup]
+    C --> D[buildStart]
+    D --> E[bundlerConfig]
+    E --> F["bundler 编译"]
+    F --> G["HTML 生成"]
+    G --> H[transformHtml]
+    H --> I[buildEnd]
 ```
 
 | 钩子 | 签名 | 时机 |
 |------|------|------|
+| `config` | `(config, ctx) => EvConfig \| undefined` | 默认配置解析前 |
 | `buildStart` | `() => void` | 编译开始前 |
 | `bundlerConfig` | `(config, ctx) => void` | 构建器配置创建期间 |
 | `transformHtml` | `(doc, result) => void` | 资源注入后、HTML 输出前 |
 | `buildEnd` | `(result) => void` | 编译完成后 |
 
 所有钩子均可异步（返回 `Promise`）。
+
+`config` 用于修改 evjs 框架配置；`bundlerConfig` 只用于修改底层构建器配置。不要用 `bundlerConfig` 改服务端函数端点这类运行时协议配置，因为它无法同步影响开发代理等框架派生配置。
 
 ---
 
@@ -332,4 +367,4 @@ import crypto from "node:crypto";
 
 ## 示例项目
 
-查看 [`examples/basic-plugins`](https://github.com/evaijs/evjs/tree/main/examples/basic-plugins) 获取演示全部四个钩子的完整示例。
+查看 [`examples/plugin-authoring`](https://github.com/afx-team/evjs/tree/main/examples/plugin-authoring) 获取演示插件钩子的完整示例。

--- a/e2e/cases/plugin-authoring.ts
+++ b/e2e/cases/plugin-authoring.ts
@@ -1,7 +1,7 @@
 import { expect } from "@playwright/test";
-import { createCsrExampleTest } from "../fixtures";
+import { createExampleTest } from "../fixtures";
 
-const test = createCsrExampleTest("plugin-authoring");
+const test = createExampleTest("plugin-authoring");
 
 test.describe("plugin-authoring", () => {
   test("renders home page with plugin content", async ({ page, baseURL }) => {
@@ -11,6 +11,42 @@ test.describe("plugin-authoring", () => {
       timeout: 10_000,
     });
     await expect(page.getByText("evjs plugin system")).toBeVisible();
+  });
+
+  test("uses server endpoint configured by plugin config hook", async ({
+    page,
+    baseURL,
+  }) => {
+    const rpcResponsePromise = page.waitForResponse((res) => {
+      const url = new URL(res.url());
+      return url.pathname === "/api/rpc" && res.request().method() === "POST";
+    });
+
+    await page.goto(baseURL);
+
+    const rpcResponse = await rpcResponsePromise;
+    expect(rpcResponse.status()).toBe(200);
+    const payload = await rpcResponse.json();
+    expect(payload.result).toEqual({
+      message: "Plugin endpoint configured by config hook",
+      nodeEnv: "production",
+    });
+
+    await expect(
+      page.getByText(
+        "Server function: Plugin endpoint configured by config hook",
+      ),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("Client mode: production")).toBeVisible();
+    await expect(page.getByText("Server mode: production")).toBeVisible();
+
+    const defaultEndpointResponse = await page.request.post(
+      `${baseURL}/api/fn`,
+      {
+        data: { fnId: "missing", args: [] },
+      },
+    );
+    expect(defaultEndpointResponse.status()).toBe(404);
   });
 
   test("HTML contains comment injected by transformHtml plugin", async ({

--- a/examples/plugin-authoring/ev.config.ts
+++ b/examples/plugin-authoring/ev.config.ts
@@ -5,17 +5,23 @@ import { defineConfig } from "@evjs/ev";
  * Example: evjs plugin system.
  *
  * Demonstrates all available plugin hooks:
+ * - `config`         — update framework config before defaults are resolved
  * - `bundlerConfig` — modify the underlying bundler config (type-safe via utoopack() helper)
  * - `buildStart`    — run logic before compilation begins
  * - `buildEnd`      — run logic after compilation completes
  * - `transformHtml` — modify the output HTML document after asset injection
  */
 export default defineConfig({
-  server: false,
-
   plugins: [
     {
       name: "example-txt-plugin",
+      config(config) {
+        config.server = {
+          ...(typeof config.server === "object" ? config.server : {}),
+          endpoint: "/api/rpc",
+        };
+        return config;
+      },
       setup(ctx) {
         console.log(`[example-txt-plugin] mode: ${ctx.mode}`);
 

--- a/examples/plugin-authoring/src/api/plugin.server.ts
+++ b/examples/plugin-authoring/src/api/plugin.server.ts
@@ -1,0 +1,8 @@
+"use server";
+
+export async function getPluginMessage() {
+  return {
+    message: "Plugin endpoint configured by config hook",
+    nodeEnv: process.env.NODE_ENV,
+  };
+}

--- a/examples/plugin-authoring/src/pages/home.tsx
+++ b/examples/plugin-authoring/src/pages/home.tsx
@@ -1,7 +1,10 @@
-import { createRoute } from "@evjs/client";
+import { createRoute, useQuery } from "@evjs/client";
+import { getPluginMessage } from "../api/plugin.server";
 import { rootRoute } from "./__root";
 
 function Home() {
+  const { data, isLoading } = useQuery(getPluginMessage);
+
   return (
     <div>
       <h1>Plugin Example</h1>
@@ -13,6 +16,15 @@ function Home() {
         View the page source to see the HTML comment injected by{" "}
         <code>transformHtml</code>.
       </p>
+      {isLoading ? (
+        <p>Loading plugin message...</p>
+      ) : (
+        <div>
+          <p>Server function: {data?.message}</p>
+          <p>Client mode: {process.env.NODE_ENV}</p>
+          <p>Server mode: {data?.nodeEnv}</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/bundler-utoopack/src/adapter/create-config.ts
+++ b/packages/bundler-utoopack/src/adapter/create-config.ts
@@ -49,6 +49,7 @@ export async function createUtoopackConfig(
   hooks: EvPluginHooks<ConfigComplete>[],
 ): Promise<ConfigComplete> {
   const isProduction = process.env.NODE_ENV === "production";
+  const mode = isProduction ? "production" : "development";
   const serverEnabled = config.serverEnabled;
   const devProxy: DevServerProxy = [
     ...config.dev.proxy,
@@ -67,7 +68,7 @@ export async function createUtoopackConfig(
   }
 
   const utoopackConfig: ConfigComplete = {
-    mode: isProduction ? "production" : "development",
+    mode,
     // MPA mode: one entry per page; SPA mode: single entry
     entry: isMpa(config)
       ? Object.entries(config.pages ?? {}).map(([name, page]) => ({
@@ -95,6 +96,7 @@ export async function createUtoopackConfig(
       runtime: "automatic",
     },
     define: {
+      "process.env.NODE_ENV": JSON.stringify(mode),
       __EVJS_FUNCTION_ENDPOINT__: JSON.stringify(config.server.endpoint),
     },
     // Server functions config — utoopack handles "use server" natively

--- a/packages/bundler-utoopack/src/adapter/create-config.ts
+++ b/packages/bundler-utoopack/src/adapter/create-config.ts
@@ -94,6 +94,9 @@ export async function createUtoopackConfig(
     react: {
       runtime: "automatic",
     },
+    define: {
+      __EVJS_FUNCTION_ENDPOINT__: JSON.stringify(config.server.endpoint),
+    },
     // Server functions config — utoopack handles "use server" natively
     ...(serverEnabled
       ? {

--- a/packages/bundler-utoopack/src/adapter/create-config.ts
+++ b/packages/bundler-utoopack/src/adapter/create-config.ts
@@ -96,6 +96,9 @@ export async function createUtoopackConfig(
       runtime: "automatic",
     },
     define: {
+      "process.env.EVJS_FUNCTION_ENDPOINT": JSON.stringify(
+        config.server.endpoint,
+      ),
       "process.env.NODE_ENV": JSON.stringify(mode),
       __EVJS_FUNCTION_ENDPOINT__: JSON.stringify(config.server.endpoint),
     },

--- a/packages/bundler-utoopack/src/adapter/create-config.ts
+++ b/packages/bundler-utoopack/src/adapter/create-config.ts
@@ -22,11 +22,14 @@ import type { ConfigComplete, DevServerProxy, ProxyRule } from "@utoo/pack";
 function createSpaHistoryFallbackRule(
   config: ResolvedEvConfig<ConfigComplete>,
 ): ProxyRule {
-  const protocol = config.dev.https ? "https" : "http";
+  const target = new URL(
+    config.dev.https ? "https://localhost" : "http://localhost",
+  );
+  target.port = String(config.dev.port);
 
   return {
     context: ["^/(?!api(?:/|$))(?!turbopack-hmr$)(?!.*\\.[^/]+$).+"],
-    target: `${protocol}://localhost:${config.dev.port}`,
+    target: target.origin,
     changeOrigin: true,
     secure: false,
     pathRewrite: {

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -39,6 +39,7 @@ describe("CONFIG_DEFAULTS", () => {
     expect(CONFIG_DEFAULTS.html).toBe("./index.html");
     expect(CONFIG_DEFAULTS.port).toBe(3000);
     expect(CONFIG_DEFAULTS.serverPort).toBe(3001);
+    expect(CONFIG_DEFAULTS.endpoint).toBe("/api/fn");
     expect(CONFIG_DEFAULTS.clientProxy).toBe("@evjs/client/transport");
     expect(CONFIG_DEFAULTS.serverRegister).toBe("@evjs/server/register");
   });
@@ -51,6 +52,7 @@ describe("CONFIG_DEFAULTS", () => {
       html: "./index.html",
       port: 3000,
       serverPort: 3001,
+      endpoint: "/api/fn",
       clientProxy: "@evjs/client/transport",
       serverRegister: "@evjs/server/register",
     });

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -7,8 +7,8 @@
  */
 
 import {
-  DEFAULT_ENDPOINT,
   DEFAULT_ERROR_STATUS,
+  getFunctionEndpoint,
   ServerFunctionError,
 } from "@evjs/shared";
 
@@ -175,7 +175,7 @@ let _transport: ServerTransport | null = null;
 
 function getTransport(): ServerTransport {
   if (!_transport) {
-    _transport = createFetchTransport("", DEFAULT_ENDPOINT);
+    _transport = createFetchTransport("", getFunctionEndpoint());
   }
   return _transport;
 }
@@ -196,7 +196,7 @@ export function initTransport(options: TransportOptions): void {
   } else {
     _transport = createFetchTransport(
       options.baseUrl ?? "",
-      options.functions?.endpoint ?? DEFAULT_ENDPOINT,
+      options.functions?.endpoint ?? getFunctionEndpoint(),
       options.headers,
     );
   }

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -53,7 +53,7 @@ export interface ServerTransport {
 }
 
 export interface TransportOptions {
-  /** Base URL for the server function endpoint. Defaults to the current origin. */
+  /** Base URL for the server function endpoint. Defaults to the current page URL. */
   baseUrl?: string;
   /** Server functions configuration */
   functions?: {
@@ -70,11 +70,47 @@ export interface TransportOptions {
   silent?: boolean;
 }
 
+const FALLBACK_BASE_URL = "http://localhost/";
+
+function getDefaultBaseUrl(): URL {
+  const base = new URL(globalThis.location?.href ?? FALLBACK_BASE_URL);
+  base.pathname = "/";
+  base.search = "";
+  base.hash = "";
+  return base;
+}
+
+function resolveBaseUrl(baseUrl?: string): URL {
+  if (baseUrl === undefined) {
+    return getDefaultBaseUrl();
+  }
+
+  return new URL(baseUrl, getDefaultBaseUrl());
+}
+
+function resolveEndpointUrl(
+  baseUrl: string | undefined,
+  endpoint: string,
+): URL {
+  try {
+    return new URL(endpoint);
+  } catch {
+    // Relative endpoint: resolve against the configured base URL below.
+  }
+
+  const base = resolveBaseUrl(baseUrl);
+  if (!base.pathname.endsWith("/")) {
+    base.pathname += "/";
+  }
+
+  return new URL(endpoint.replace(/^\/+/, ""), base);
+}
+
 /**
  * Default fetch-based transport.
  */
 function createFetchTransport(
-  baseUrl: string,
+  baseUrl: string | undefined,
   endpoint: string,
   headersFactory?:
     | Record<string, string>
@@ -86,7 +122,7 @@ function createFetchTransport(
       args: unknown[],
       context?: RequestContext,
     ): Promise<unknown> {
-      const url = `${baseUrl}${endpoint}`;
+      const url = resolveEndpointUrl(baseUrl, endpoint);
 
       const extraHeaders =
         typeof headersFactory === "function"
@@ -175,7 +211,7 @@ let _transport: ServerTransport | null = null;
 
 function getTransport(): ServerTransport {
   if (!_transport) {
-    _transport = createFetchTransport("", getFunctionEndpoint());
+    _transport = createFetchTransport(undefined, getFunctionEndpoint());
   }
   return _transport;
 }
@@ -195,7 +231,7 @@ export function initTransport(options: TransportOptions): void {
     _transport = options.transport;
   } else {
     _transport = createFetchTransport(
-      options.baseUrl ?? "",
+      options.baseUrl,
       options.functions?.endpoint ?? getFunctionEndpoint(),
       options.headers,
     );

--- a/packages/client/tests/transport.test.ts
+++ b/packages/client/tests/transport.test.ts
@@ -152,6 +152,39 @@ describe("createFetchTransport (default)", () => {
     vi.unstubAllGlobals();
   });
 
+  it("uses the build-time endpoint define by default", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: "ok" }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+    vi.stubGlobal("__EVJS_FUNCTION_ENDPOINT__", "/api/rpc");
+
+    await callServer("myFn", []);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/rpc",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("uses the build-time endpoint define when initTransport omits endpoint", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: "ok" }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+    vi.stubGlobal("__EVJS_FUNCTION_ENDPOINT__", "/api/rpc");
+
+    initTransport({ headers: { Authorization: "Bearer xyz" } });
+    await callServer("myFn", []);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/rpc",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
   it("adds static headers from config", async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/client/tests/transport.test.ts
+++ b/packages/client/tests/transport.test.ts
@@ -163,7 +163,7 @@ describe("createFetchTransport (default)", () => {
     await callServer("myFn", []);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/rpc",
+      new URL("http://localhost/api/rpc"),
       expect.objectContaining({ method: "POST" }),
     );
   });
@@ -180,7 +180,62 @@ describe("createFetchTransport (default)", () => {
     await callServer("myFn", []);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/rpc",
+      new URL("http://localhost/api/rpc"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("resolves the default endpoint from the current origin root", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: "ok" }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+    vi.stubGlobal("location", new URL("http://app.example.com/posts/1"));
+
+    initTransport({ functions: { endpoint: "/api/rpc" } });
+    await callServer("myFn", []);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      new URL("http://app.example.com/api/rpc"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("resolves the endpoint against baseUrl with URL semantics", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: "ok" }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    initTransport({
+      baseUrl: "https://api.example.com/backend",
+      functions: { endpoint: "/api/rpc" },
+    });
+    await callServer("myFn", []);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      new URL("https://api.example.com/backend/api/rpc"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("supports a complete URL as the endpoint", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: "ok" }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    initTransport({
+      baseUrl: "https://api.example.com/backend",
+      functions: { endpoint: "https://rpc.example.com/api/fn" },
+    });
+    await callServer("myFn", []);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      new URL("https://rpc.example.com/api/fn"),
       expect.objectContaining({ method: "POST" }),
     );
   });
@@ -196,7 +251,7 @@ describe("createFetchTransport (default)", () => {
     await callServer("myFn", []);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.any(String),
+      expect.any(URL),
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: "Bearer xyz",
@@ -219,7 +274,7 @@ describe("createFetchTransport (default)", () => {
     await callServer("myFn", []);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.any(String),
+      expect.any(URL),
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: "Bearer dynamic-token",

--- a/packages/ev/src/commands.ts
+++ b/packages/ev/src/commands.ts
@@ -14,6 +14,7 @@ import {
 import type {
   EvBuildResult,
   EvPlugin,
+  EvPluginConfigContext,
   EvPluginContext,
   EvPluginHooks,
 } from "./plugin.js";
@@ -75,6 +76,24 @@ async function collectPluginHooks<TBundlerCfg>(
     }
   }
   return allHooks;
+}
+
+async function runConfigHooks<TBundlerCfg>(
+  userConfig: EvConfig<TBundlerCfg> | undefined,
+  ctx: EvPluginConfigContext,
+): Promise<EvConfig<TBundlerCfg> | undefined> {
+  let config = userConfig;
+
+  for (const plugin of userConfig?.plugins ?? []) {
+    if (!plugin.config) continue;
+
+    const nextConfig = await plugin.config(config ?? {}, ctx);
+    if (nextConfig) {
+      config = nextConfig;
+    }
+  }
+
+  return config;
 }
 
 async function runBuildStartHooks<TBundlerCfg>(
@@ -176,9 +195,13 @@ export async function dev<TBundlerCfg = import("@utoo/pack").ConfigComplete>(
   userConfig?: EvConfig<TBundlerCfg>,
   options?: DevOptions<TBundlerCfg>,
 ): Promise<void> {
-  const resolvedConfig = resolveConfig(userConfig);
   const cwd = options?.cwd ?? process.cwd();
   process.env.NODE_ENV ??= "development";
+  const configuredConfig = await runConfigHooks(userConfig, {
+    mode: "development",
+    cwd,
+  });
+  const resolvedConfig = resolveConfig(configuredConfig);
 
   const bundler = resolveBundler(resolvedConfig.bundler, options?.bundler);
   const config = withActiveBundler(resolvedConfig, bundler);
@@ -295,9 +318,13 @@ export async function build<TBundlerCfg = import("@utoo/pack").ConfigComplete>(
   userConfig?: EvConfig<TBundlerCfg>,
   options?: BuildOptions<TBundlerCfg>,
 ): Promise<void> {
-  const resolvedConfig = resolveConfig(userConfig);
   const cwd = options?.cwd ?? process.cwd();
   process.env.NODE_ENV ??= "production";
+  const configuredConfig = await runConfigHooks(userConfig, {
+    mode: "production",
+    cwd,
+  });
+  const resolvedConfig = resolveConfig(configuredConfig);
 
   const bundler = resolveBundler(resolvedConfig.bundler, options?.bundler);
   const config = withActiveBundler(resolvedConfig, bundler);

--- a/packages/ev/src/config.ts
+++ b/packages/ev/src/config.ts
@@ -7,6 +7,7 @@ export type {
   EvBundlerCtx,
   EvDocument,
   EvPlugin,
+  EvPluginConfigContext,
   EvPluginContext,
   EvPluginHooks,
 } from "./plugin.js";

--- a/packages/ev/src/config.ts
+++ b/packages/ev/src/config.ts
@@ -49,6 +49,8 @@ export interface ResolvedServerDevConfig {
 export interface ResolvedServerConfig {
   /** Explicit server entry file. Omitted when auto-generated. */
   entry?: string;
+  /** Server function endpoint path. */
+  endpoint: string;
   /** Server function build configuration. */
   functions: ResolvedServerFunctionsConfig;
   /** Server dev options. */
@@ -119,6 +121,8 @@ export interface EvConfig<TBundlerCfg = import("@utoo/pack").ConfigComplete> {
     | {
         /** Explicit server entry file. If provided, overrides auto-generated entry. */
         entry?: string;
+        /** Server function RPC endpoint path. Default: "/api/fn". */
+        endpoint?: string;
         /** Server function build configuration. */
         functions?: {
           /**
@@ -179,6 +183,7 @@ export const CONFIG_DEFAULTS = {
   html: "./index.html",
   port: 3000,
   serverPort: 3001,
+  endpoint: DEFAULT_ENDPOINT,
   clientProxy: "@evjs/client/transport",
   serverRegister: "@evjs/server/register",
 } as const;
@@ -210,6 +215,7 @@ export function resolveConfig<
   }
 
   const serverPort = serverConfig.dev?.port ?? CONFIG_DEFAULTS.serverPort;
+  const serverEndpoint = serverConfig.endpoint ?? CONFIG_DEFAULTS.endpoint;
 
   return {
     entry: config.entry ?? CONFIG_DEFAULTS.entry,
@@ -223,7 +229,7 @@ export function resolveConfig<
         ...(config.dev?.proxy ?? []),
         // Framework always proxies the server function endpoint to the local API dev server
         {
-          context: [DEFAULT_ENDPOINT],
+          context: [serverEndpoint],
           target: `http${serverConfig.dev?.https ? "s" : ""}://localhost:${serverPort}`,
           changeOrigin: true,
           secure: false,
@@ -233,6 +239,7 @@ export function resolveConfig<
     serverEnabled,
     server: {
       entry: serverConfig.entry,
+      endpoint: serverEndpoint,
       functions: {
         clientProxy:
           serverConfig.functions?.clientProxy ?? CONFIG_DEFAULTS.clientProxy,

--- a/packages/ev/src/config.ts
+++ b/packages/ev/src/config.ts
@@ -217,6 +217,10 @@ export function resolveConfig<
 
   const serverPort = serverConfig.dev?.port ?? CONFIG_DEFAULTS.serverPort;
   const serverEndpoint = serverConfig.endpoint ?? CONFIG_DEFAULTS.endpoint;
+  const serverTarget = new URL(
+    serverConfig.dev?.https ? "https://localhost" : "http://localhost",
+  );
+  serverTarget.port = String(serverPort);
 
   return {
     entry: config.entry ?? CONFIG_DEFAULTS.entry,
@@ -231,7 +235,7 @@ export function resolveConfig<
         // Framework always proxies the server function endpoint to the local API dev server
         {
           context: [serverEndpoint],
-          target: `http${serverConfig.dev?.https ? "s" : ""}://localhost:${serverPort}`,
+          target: serverTarget.origin,
           changeOrigin: true,
           secure: false,
         },

--- a/packages/ev/src/index.ts
+++ b/packages/ev/src/index.ts
@@ -12,6 +12,7 @@ export {
   type EvConfig,
   type EvDocument,
   type EvPlugin,
+  type EvPluginConfigContext,
   type EvPluginContext,
   type EvPluginHooks,
   isMpa,

--- a/packages/ev/src/plugin.ts
+++ b/packages/ev/src/plugin.ts
@@ -155,6 +155,9 @@ export interface EvPluginContext<
 
 /**
  * Lifecycle hooks returned from plugin setup().
+ *
+ * TODO: Narrow each hook context and standardize signatures as subject-first,
+ * ctx-second before allowing hooks beyond `config` to mutate framework state.
  */
 export interface EvPluginHooks<
   TBundlerCfg = import("@utoo/pack").ConfigComplete,

--- a/packages/ev/src/plugin.ts
+++ b/packages/ev/src/plugin.ts
@@ -1,5 +1,5 @@
 import type { ClientManifest, ServerManifest } from "@evjs/manifest";
-import type { ResolvedEvConfig } from "./config.js";
+import type { EvConfig, ResolvedEvConfig } from "./config.js";
 
 /**
  * Minimal DOM element / document interface for plugin HTML manipulation.
@@ -95,11 +95,35 @@ export interface EvBundlerCtx<
 }
 
 /**
+ * Context passed to plugin config hooks.
+ */
+export interface EvPluginConfigContext {
+  /** The current mode. */
+  mode: "development" | "production";
+  /** The current working directory. */
+  cwd: string;
+}
+
+/**
  * An evjs plugin.
  */
 export interface EvPlugin<TBundlerCfg = import("@utoo/pack").ConfigComplete> {
   /** Plugin name for debugging and logging. */
   name: string;
+
+  /**
+   * Modify the raw user config before defaults are resolved.
+   *
+   * Use this for framework-level config such as `server.endpoint` that must be
+   * visible to dev proxy setup and build-time runtime defines.
+   */
+  config?: (
+    config: EvConfig<TBundlerCfg>,
+    ctx: EvPluginConfigContext,
+  ) =>
+    | EvConfig<TBundlerCfg>
+    | undefined
+    | Promise<EvConfig<TBundlerCfg> | undefined>;
 
   /**
    * Initialize the plugin and return lifecycle hooks.

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -20,7 +20,7 @@ function createMockBundler(
 ): BundlerAdapter<Record<string, never>> {
   return {
     name: "mock",
-    async build(_config, cwd) {
+    async build(config, cwd) {
       events.push("bundler.build");
       const dist = path.join(cwd, "dist");
       await fs.promises.mkdir(dist, { recursive: true });
@@ -32,6 +32,9 @@ function createMockBundler(
         }),
         "utf-8",
       );
+      if (config.serverEnabled) {
+        events.push(`bundler.endpoint:${config.server.endpoint}`);
+      }
     },
     async dev() {
       events.push("bundler.dev");
@@ -81,6 +84,42 @@ describe("build", () => {
       "buildStart",
       "bundler.build",
       "buildEnd:main.js",
+    ]);
+  });
+
+  it("runs plugin config hooks before resolving config", async () => {
+    const cwd = await createProject();
+    const events: string[] = [];
+    const bundler = createMockBundler(events);
+
+    const plugin: EvPlugin<Record<string, never>> = {
+      name: "sets-endpoint",
+      config(config, ctx) {
+        events.push(`config:${ctx.mode}`);
+        config.server = {
+          ...(typeof config.server === "object" ? config.server : {}),
+          endpoint: "/api/rpc",
+        };
+        return config;
+      },
+      setup(ctx) {
+        events.push(`setup:${ctx.config.server.endpoint}`);
+      },
+    };
+
+    await build(
+      { plugins: [plugin] },
+      {
+        cwd,
+        bundler,
+      },
+    );
+
+    expect(events).toEqual([
+      "config:production",
+      "setup:/api/rpc",
+      "bundler.build",
+      "bundler.endpoint:/api/rpc",
     ]);
   });
 });

--- a/packages/ev/tests/config.test.ts
+++ b/packages/ev/tests/config.test.ts
@@ -28,6 +28,7 @@ describe("resolveConfig", () => {
     expect(resolved.server.functions.serverRegister).toBe(
       "@evjs/server/register",
     );
+    expect(resolved.server.endpoint).toBe("/api/fn");
     expect(resolved.server.dev.port).toBe(CONFIG_DEFAULTS.serverPort);
     expect(resolved.server.dev.https).toBe(false);
     expect(resolved.bundler).toBeUndefined();
@@ -76,6 +77,7 @@ describe("resolveConfig", () => {
     const resolved = resolveConfig({
       server: {
         entry: "./server.ts",
+        endpoint: "/api/rpc",
         functions: {
           clientProxy: "custom/client",
           serverRegister: "custom/server",
@@ -85,8 +87,25 @@ describe("resolveConfig", () => {
     });
     expect(resolved.serverEnabled).toBe(true);
     expect(resolved.server.entry).toBe("./server.ts");
+    expect(resolved.server.endpoint).toBe("/api/rpc");
     expect(resolved.server.functions.clientProxy).toBe("custom/client");
     expect(resolved.server.dev.port).toBe(4000);
+  });
+
+  it("proxies the configured server function endpoint in dev", () => {
+    const resolved = resolveConfig({
+      server: {
+        endpoint: "/api/rpc",
+        dev: { port: 4001 },
+      },
+    });
+
+    expect(resolved.dev.proxy).toContainEqual({
+      context: ["/api/rpc"],
+      target: "http://localhost:4001",
+      changeOrigin: true,
+      secure: false,
+    });
   });
   it("respects server dev https override", () => {
     const resolved = resolveConfig({

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -5,7 +5,7 @@
  * This app is runtime-agnostic and can be mounted in Node, Edge, or Bun.
  */
 
-import { DEFAULT_ENDPOINT } from "@evjs/shared";
+import { getFunctionEndpoint } from "@evjs/shared";
 import type {
   Context as HonoContext,
   Env as HonoEnv,
@@ -53,7 +53,7 @@ export interface CreateAppOptions {
 export function createApp(options?: CreateAppOptions): Hono {
   const {
     functions: {
-      endpoint = DEFAULT_ENDPOINT,
+      endpoint = getFunctionEndpoint(),
       bodyLimit: maxBodySize = 1024 * 1024,
     } = {},
     routes = [],

--- a/packages/server/tests/app.test.ts
+++ b/packages/server/tests/app.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp } from "../src/app.js";
+import {
+  registerServerReference,
+  registry,
+} from "../src/functions/register.js";
+
+describe("createApp", () => {
+  beforeEach(() => {
+    registry.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the build-time endpoint define by default", async () => {
+    vi.stubGlobal("__EVJS_FUNCTION_ENDPOINT__", "/api/rpc");
+    registerServerReference(async () => "ok", "fn1");
+
+    const app = createApp();
+    const res = await app.request("/api/rpc", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ fnId: "fn1", args: [] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ result: "ok" });
+  });
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -5,5 +5,20 @@
 /** Default server function endpoint path, shared between client and server. */
 export const DEFAULT_ENDPOINT = "/api/fn";
 
+declare const __EVJS_FUNCTION_ENDPOINT__: string | undefined;
+
+/**
+ * Server function endpoint configured by the application build.
+ *
+ * Bundlers replace `__EVJS_FUNCTION_ENDPOINT__` at build time. When the runtime
+ * package is used directly, the undeclared global falls back to the default.
+ */
+export function getFunctionEndpoint(): string {
+  return typeof __EVJS_FUNCTION_ENDPOINT__ === "string" &&
+    __EVJS_FUNCTION_ENDPOINT__
+    ? __EVJS_FUNCTION_ENDPOINT__
+    : DEFAULT_ENDPOINT;
+}
+
 /** Default HTTP status code for server function errors. */
 export const DEFAULT_ERROR_STATUS = 500;

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -6,6 +6,11 @@
 export const DEFAULT_ENDPOINT = "/api/fn";
 
 declare const __EVJS_FUNCTION_ENDPOINT__: string | undefined;
+declare const process: {
+  env: {
+    EVJS_FUNCTION_ENDPOINT?: string;
+  };
+};
 
 /**
  * Server function endpoint configured by the application build.
@@ -14,6 +19,13 @@ declare const __EVJS_FUNCTION_ENDPOINT__: string | undefined;
  * package is used directly, the undeclared global falls back to the default.
  */
 export function getFunctionEndpoint(): string {
+  try {
+    const processEndpoint = process.env.EVJS_FUNCTION_ENDPOINT;
+    if (processEndpoint) return processEndpoint;
+  } catch {
+    // `process` is not available in some direct browser/edge runtime usage.
+  }
+
   return typeof __EVJS_FUNCTION_ENDPOINT__ === "string" &&
     __EVJS_FUNCTION_ENDPOINT__
     ? __EVJS_FUNCTION_ENDPOINT__

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@
 export {
   DEFAULT_ENDPOINT,
   DEFAULT_ERROR_STATUS,
+  getFunctionEndpoint,
 } from "./constants.js";
 export { ServerError, ServerFunctionError } from "./errors.js";
 export type { HttpMethod } from "./http.js";

--- a/packages/shared/tests/constants.test.ts
+++ b/packages/shared/tests/constants.test.ts
@@ -1,0 +1,18 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_ENDPOINT, getFunctionEndpoint } from "../src/constants.js";
+
+describe("getFunctionEndpoint", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to the default endpoint without a build-time define", () => {
+    expect(getFunctionEndpoint()).toBe(DEFAULT_ENDPOINT);
+  });
+
+  it("uses the build-time endpoint define when present", () => {
+    vi.stubGlobal("__EVJS_FUNCTION_ENDPOINT__", "/api/rpc");
+
+    expect(getFunctionEndpoint()).toBe("/api/rpc");
+  });
+});

--- a/packages/shared/tests/constants.test.ts
+++ b/packages/shared/tests/constants.test.ts
@@ -4,10 +4,17 @@ import { DEFAULT_ENDPOINT, getFunctionEndpoint } from "../src/constants.js";
 describe("getFunctionEndpoint", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("falls back to the default endpoint without a build-time define", () => {
     expect(getFunctionEndpoint()).toBe(DEFAULT_ENDPOINT);
+  });
+
+  it("uses the process env endpoint define when present", () => {
+    vi.stubEnv("EVJS_FUNCTION_ENDPOINT", "/api/rpc");
+
+    expect(getFunctionEndpoint()).toBe("/api/rpc");
   });
 
   it("uses the build-time endpoint define when present", () => {


### PR DESCRIPTION
## Summary

- Adds `server.endpoint` to resolved evjs config and uses it for the dev proxy path.
- Injects the resolved function endpoint as the Utoopack build define `__EVJS_FUNCTION_ENDPOINT__`.
- Makes shared client/server runtime defaults read the build-time endpoint, so `@evjs/server/fetch`, custom `createApp()` server entries, and client transport stay aligned without duplicate app code.
- Adds unit coverage for shared endpoint fallback, client transport defaults, server `createApp()` defaults, and config proxy resolution.

## Root Cause

The default fetch runtime used `createApp()` with the hardcoded server default, while the client endpoint could be configured separately. The resolved app config was not passed into the default server runtime path.

## Validation

- `npm test -w @evjs/shared`
- `npm test -w @evjs/client`
- `npm test -w @evjs/ev`
- `npm test -w @evjs/server`
- `npm run lint`
- `npm run check-types`

Note: the pre-push hook also reran `npm run lint` and `npm run check-types` successfully.