### PR TITLE
refactor: fix dev server readiness and e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
 
       - name: Install Dependencies
         run: npm install

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
+          cache: npm
 
       - name: Install Dependencies
         run: npm install

--- a/e2e/cases/api-routes.ts
+++ b/e2e/cases/api-routes.ts
@@ -110,13 +110,22 @@ test.describe("api-routes", () => {
     expect(healthResponse.status()).toBe(200);
     const healthData = await healthResponse.json();
     expect(healthData.status).toBe("ok");
-    expect(healthData.uptime).toBeDefined();
+    expect(healthData.uptime).toEqual(expect.any(Number));
+    expect(healthData.timestamp).toEqual(
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+    );
 
     // Wait for the pre tag containing JSON to appear and verify its contents
     const pre = page.locator("pre").first();
     await expect(pre).toBeVisible({ timeout: 5_000 });
     const text = await pre.textContent();
-    expect(text).toContain('"status": "ok"');
+    expect(JSON.parse(text ?? "{}")).toEqual(
+      expect.objectContaining({
+        status: "ok",
+        uptime: expect.any(Number),
+        timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+      }),
+    );
   });
 
   test("calls server function", async ({ page, baseURL }) => {

--- a/e2e/cases/basic.ts
+++ b/e2e/cases/basic.ts
@@ -16,9 +16,15 @@ test.describe("basic", () => {
     const response = await responsePromise;
     expect(response.status()).toBe(200);
     const data = await response.json();
-    expect(data.result).toBeDefined();
     expect(Array.isArray(data.result)).toBe(true);
     expect(data.result.length).toBeGreaterThanOrEqual(3);
+    expect(data.result).toEqual(
+      expect.arrayContaining([
+        { id: "1", name: "Alice", email: "alice@example.com" },
+        { id: "2", name: "Bob", email: "bob@example.com" },
+        { id: "3", name: "Charlie", email: "charlie@example.com" },
+      ]),
+    );
 
     // Wait for loading to finish
     await expect(page.getByText("Loading users")).not.toBeVisible({
@@ -48,9 +54,13 @@ test.describe("basic", () => {
     const createResponse = await createResponsePromise;
     expect(createResponse.status()).toBe(200);
     const createData = await createResponse.json();
-    expect(createData.result).toBeDefined();
-    expect(createData.result.name).toBe("Dave");
-    expect(createData.result.email).toBe("dave@example.com");
+    expect(createData.result).toEqual(
+      expect.objectContaining({
+        id: expect.stringMatching(/^\d+$/),
+        name: "Dave",
+        email: "dave@example.com",
+      }),
+    );
 
     // Verify new user appears
     await expect(page.getByText("Dave")).toBeVisible({ timeout: 5_000 });

--- a/e2e/cases/complex-routing.ts
+++ b/e2e/cases/complex-routing.ts
@@ -111,9 +111,13 @@ test.describe("complex-routing", () => {
     const dashboardResponse = await dashboardPromise;
     expect(dashboardResponse.status()).toBe(200);
     const dashboardData = await dashboardResponse.json();
-    expect(dashboardData.result).toBeDefined();
-    expect(dashboardData.result.totalPosts).toBeDefined();
-    expect(dashboardData.result.totalUsers).toBeDefined();
+    expect(dashboardData.result).toEqual(
+      expect.objectContaining({
+        totalPosts: 5,
+        totalUsers: 3,
+        tags: expect.arrayContaining(["tutorial", "advanced", "routing"]),
+      }),
+    );
 
     await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible({
       timeout: 10_000,
@@ -122,9 +126,8 @@ test.describe("complex-routing", () => {
     // Stats section loaded via route loader (server function)
     await expect(page.getByRole("heading", { name: "All Tags" })).toBeVisible();
 
-    // Stat cards present (numbers rendered from server data)
-    const statCards = page.locator("div").filter({ hasText: /^\d+$/ });
-    await expect(statCards.first()).toBeVisible();
+    await expect(page.getByText("5")).toBeVisible();
+    await expect(page.getByText("3")).toBeVisible();
   });
 
   test("redirect — /old-blog redirects to /posts", async ({

--- a/e2e/cases/mpa.ts
+++ b/e2e/cases/mpa.ts
@@ -14,9 +14,7 @@ const exampleDir = path.resolve(
 const test = base.extend<{ baseURL: string }, { _app: { port: number } }>({
   _app: [
     // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture API requires object destructuring
-    async ({}, use, workerInfo) => {
-      const port = 31200 + workerInfo.workerIndex;
-
+    async ({}, use) => {
       execSync("ev build", {
         cwd: exampleDir,
         stdio: "pipe",
@@ -52,8 +50,9 @@ const test = base.extend<{ baseURL: string }, { _app: { port: number } }>({
       });
 
       await new Promise<void>((resolve) => {
-        server.listen(port, resolve);
+        server.listen(0, resolve);
       });
+      const { port } = server.address() as { port: number };
 
       await use({ port });
 
@@ -95,10 +94,21 @@ test.describe("mpa", () => {
       pages?: Record<string, unknown>;
     };
 
-    expect(manifest.pages).toBeTruthy();
-    expect(manifest.pages && Object.keys(manifest.pages).sort()).toEqual([
-      "about",
-      "home",
-    ]);
+    expect(manifest.pages).toEqual({
+      about: expect.objectContaining({
+        assets: expect.objectContaining({
+          js: expect.arrayContaining([expect.stringMatching(/about.*\.js$/)]),
+          css: expect.any(Array),
+        }),
+        routes: [],
+      }),
+      home: expect.objectContaining({
+        assets: expect.objectContaining({
+          js: expect.arrayContaining([expect.stringMatching(/home.*\.js$/)]),
+          css: expect.any(Array),
+        }),
+        routes: [],
+      }),
+    });
   });
 });

--- a/e2e/cases/scaffold.ts
+++ b/e2e/cases/scaffold.ts
@@ -1,9 +1,20 @@
 import { execSync, spawn } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
+import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
+
+async function getAvailablePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.listen(0, () => {
+      const { port } = server.address() as { port: number };
+      server.close(() => resolve(port));
+    });
+  });
+}
 
 test.describe("Scaffolding CLI E2E", () => {
   test.setTimeout(180_000);
@@ -26,7 +37,7 @@ test.describe("Scaffolding CLI E2E", () => {
 
   test("create-app should scaffold, build, and run dev server", async ({
     page: _page,
-  }, testInfo) => {
+  }) => {
     const cleanEnv = { ...process.env };
     for (const key of Object.keys(cleanEnv)) {
       if (key.startsWith("npm_")) delete cleanEnv[key];
@@ -101,9 +112,10 @@ test.describe("Scaffolding CLI E2E", () => {
       env: cleanEnv,
     });
 
-    // Force unique port to avoid EADDRINUSE
-    const devPort = 35123 + testInfo.workerIndex * 2;
-    const serverDevPort = devPort + 1;
+    // Allocate real free ports; deterministic offsets can collide with local
+    // processes or with stale servers from a previous failed run.
+    const devPort = await getAvailablePort();
+    const serverDevPort = await getAvailablePort();
     fs.writeFileSync(
       path.join(targetDir, "ev.config.ts"),
       `export default { dev: { port: ${devPort} }, server: { dev: { port: ${serverDevPort} } } };\n`,
@@ -134,38 +146,58 @@ test.describe("Scaffolding CLI E2E", () => {
         {
           cwd: targetDir,
           env: cleanEnv,
-          stdio: "inherit",
+          stdio: ["ignore", "pipe", "pipe"],
         },
       );
 
       let settled = false;
+      let closed = false;
+      let webReady = false;
+      let apiReady = false;
       const settle = (fn: () => void) => {
         if (!settled) {
           settled = true;
           fn();
         }
       };
+      const maybeResolveReady = () => {
+        if (!webReady || !apiReady) return;
+        clearTimeout(timeout);
+        devProcess.kill("SIGTERM");
+        forceKill();
+        settle(() => resolve());
+      };
 
       const timeout = setTimeout(() => {
         devProcess.kill("SIGTERM");
+        forceKill();
+        settle(() => reject(new Error("Dev server did not become ready")));
       }, 90_000);
-
-      const checkServer = async () => {
-        try {
-          const res = await fetch(`http://127.0.0.1:${devPort}/`);
-          if (res.ok) {
-            clearTimeout(timeout);
-            devProcess.kill("SIGTERM");
-            return;
+      const forceKill = () => {
+        setTimeout(() => {
+          if (!closed) {
+            devProcess.kill("SIGKILL");
           }
-        } catch {
-          // Connection refused — server not ready yet
-        }
-        if (!settled) setTimeout(checkServer, 2000);
+        }, 5_000).unref();
       };
-      checkServer();
+
+      devProcess.stdout?.on("data", (data) => {
+        const text = data.toString();
+        process.stdout.write(data);
+        if (text.includes(`http://localhost:${devPort}`)) {
+          webReady = true;
+        }
+        if (text.includes("API server ready")) {
+          apiReady = true;
+        }
+        maybeResolveReady();
+      });
+      devProcess.stderr?.on("data", (data) => {
+        process.stderr.write(data);
+      });
 
       devProcess.on("close", (code: number | null) => {
+        closed = true;
         clearTimeout(timeout);
         if (code !== 0 && code !== null && !settled) {
           settle(() =>

--- a/e2e/cases/with-sqlite.ts
+++ b/e2e/cases/with-sqlite.ts
@@ -13,9 +13,21 @@ test.describe("with-sqlite", () => {
     const response = await responsePromise;
     expect(response.status()).toBe(200);
     const data = await response.json();
-    expect(data.result).toBeDefined();
     expect(Array.isArray(data.result)).toBe(true);
     expect(data.result.length).toBeGreaterThanOrEqual(3);
+    expect(data.result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "Alice",
+          email: "alice@example.com",
+        }),
+        expect.objectContaining({ name: "Bob", email: "bob@example.com" }),
+        expect.objectContaining({
+          name: "Charlie",
+          email: "charlie@example.com",
+        }),
+      ]),
+    );
 
     await expect(page.getByText("SQLite Server Functions")).toBeVisible({
       timeout: 10_000,
@@ -73,8 +85,12 @@ test.describe("with-sqlite", () => {
     const createResponse = await createResponsePromise;
     expect(createResponse.status()).toBe(200);
     const createData = await createResponse.json();
-    expect(createData.result).toBeDefined();
-    expect(createData.result.name).toBe(uniqueName);
+    expect(createData.result).toEqual(
+      expect.objectContaining({
+        id: expect.any(Number),
+        name: uniqueName,
+      }),
+    );
 
     // Verify new user appears
     await expect(

--- a/e2e/cases/with-tailwind.ts
+++ b/e2e/cases/with-tailwind.ts
@@ -13,9 +13,7 @@ const exampleDir = path.resolve(
 const test = base.extend<{ baseURL: string }, { _app: { port: number } }>({
   _app: [
     // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture API requires object destructuring
-    async ({}, use, workerInfo) => {
-      const port = 31000 + workerInfo.workerIndex;
-
+    async ({}, use) => {
       // Expects the example to be pre-built (npm run build)
 
       // Serve the client bundle
@@ -50,8 +48,9 @@ const test = base.extend<{ baseURL: string }, { _app: { port: number } }>({
       });
 
       await new Promise<void>((resolve) => {
-        server.listen(port, resolve);
+        server.listen(0, resolve);
       });
+      const { port } = server.address() as { port: number };
       await use({ port });
       server.close();
     },

--- a/e2e/cases/with-trpc.ts
+++ b/e2e/cases/with-trpc.ts
@@ -23,8 +23,9 @@ test.describe("with-trpc", () => {
     await page.goto(baseURL);
     const trpcResponse = await trpcPromise;
     expect(trpcResponse.status()).toBe(200);
-    const trpcData = await trpcResponse.json();
-    expect(trpcData.result).toBeDefined();
+    expect(await trpcResponse.json()).toEqual(
+      expect.objectContaining({ result: expect.anything() }),
+    );
 
     // Wait for tRPC section heading
     await expect(page.getByText("1. tRPC Call")).toBeVisible({
@@ -35,6 +36,12 @@ test.describe("with-trpc", () => {
     // Use a longer timeout since tRPC bootstraps a full request pipeline.
     const preElement = page.locator("pre");
     await expect(preElement).toBeVisible({ timeout: 15_000 });
+    await expect(preElement).toContainText(
+      "Hello from tRPC! (called via Server Function proxy)",
+    );
+    expect(JSON.parse((await preElement.textContent()) ?? "{}")).toEqual({
+      message: "Hello from tRPC! (called via Server Function proxy)",
+    });
   });
 
   test("server time section renders", async ({ page, baseURL }) => {
@@ -43,12 +50,18 @@ test.describe("with-trpc", () => {
     await expect(page.getByText("2. Direct Server Function")).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByText("Server Time:")).toBeVisible();
+    await expect(page.locator("p", { hasText: "Server Time:" })).toContainText(
+      /\d{4}-\d{2}-\d{2}T/,
+    );
   });
 
-  test("refresh button is visible", async ({ page, baseURL }) => {
+  test("refresh button refetches server data", async ({ page, baseURL }) => {
     await page.goto(baseURL);
 
+    await expect(page.locator("pre")).toContainText(
+      "Hello from tRPC! (called via Server Function proxy)",
+      { timeout: 15_000 },
+    );
     const refreshPromise = page.waitForResponse(
       (res) =>
         res.url().includes("/api/fn") && res.request().method() === "POST",
@@ -57,6 +70,8 @@ test.describe("with-trpc", () => {
     await refreshButton.click();
     const refreshResponse = await refreshPromise;
     expect(refreshResponse.status()).toBe(200);
-    await expect(refreshButton).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("pre")).toContainText(
+      "Hello from tRPC! (called via Server Function proxy)",
+    );
   });
 });

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -195,15 +195,6 @@ export function createExampleTest(exampleName: string) {
         // Build with specified bundler (fullstack = server enabled)
         await buildExample(exampleDir, bundlerName, true);
 
-        // Base port depends on both worker index and a hash of the example name
-        // to avoid conflicts if multiple worker fixtures run sequentially.
-        const hash = Array.from(exampleName + bundlerName).reduce(
-          (sum, char) => sum + char.charCodeAt(0),
-          0,
-        );
-        const apiPort = 30000 + workerInfo.workerIndex * 100 + (hash % 100);
-        const webPort = apiPort + 1;
-
         // Read the server manifest to get the hashed entry filename
         const manifestPath = path.join(
           exampleDir,
@@ -226,7 +217,7 @@ export function createExampleTest(exampleName: string) {
           [
             `const handler = require(${JSON.stringify(serverEntryPath)}).default;`,
             `const { serve } = require("@hono/node-server");`,
-            `serve({ fetch: handler.fetch, port: ${apiPort} }, (info) => {`,
+            `serve({ fetch: handler.fetch, port: 0 }, (info) => {`,
             `  console.log("E2E_SERVER_READY:" + info.port);`,
             `});`,
           ].join("\n"),
@@ -238,15 +229,16 @@ export function createExampleTest(exampleName: string) {
           stdio: "pipe",
         });
 
-        await new Promise<void>((resolve, reject) => {
+        const apiPort = await new Promise<number>((resolve, reject) => {
           const timeout = setTimeout(() => {
             reject(new Error("Server did not start within 15s"));
           }, 15_000);
 
           serverProcess.stdout?.on("data", (data) => {
-            if (data.toString().includes("E2E_SERVER_READY")) {
+            const match = data.toString().match(/E2E_SERVER_READY:(\d+)/);
+            if (match) {
               clearTimeout(timeout);
-              resolve();
+              resolve(Number(match[1]));
             }
           });
 
@@ -263,8 +255,9 @@ export function createExampleTest(exampleName: string) {
         const staticServer = createStaticServer(distDir, { apiPort });
 
         await new Promise<void>((resolve) => {
-          staticServer.listen(webPort, resolve);
+          staticServer.listen(0, resolve);
         });
+        const { port: webPort } = staticServer.address() as { port: number };
 
         await use({ webPort, apiPort });
 
@@ -309,18 +302,13 @@ export function createCsrExampleTest(exampleName: string) {
         // Build with specified bundler (CSR = server disabled)
         await buildExample(exampleDir, bundlerName, false);
 
-        const hash = Array.from(exampleName + bundlerName).reduce(
-          (sum, char) => sum + char.charCodeAt(0),
-          0,
-        );
-        const webPort = 30000 + workerInfo.workerIndex * 100 + (hash % 100) + 1;
-
         const distDir = path.join(exampleDir, "dist");
         const staticServer = createStaticServer(distDir);
 
         await new Promise<void>((resolve) => {
-          staticServer.listen(webPort, resolve);
+          staticServer.listen(0, resolve);
         });
+        const { port: webPort } = staticServer.address() as { port: number };
 
         await use({ webPort, apiPort: 0 });
 

--- a/examples/with-trpc/src/api/trpc.server.ts
+++ b/examples/with-trpc/src/api/trpc.server.ts
@@ -1,30 +1,19 @@
 "use server";
-import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { appRouter } from "../trpc";
 
 /**
- * A Server Function that acts as a tRPC handler.
+ * A Server Function that dispatches into the tRPC router.
  * This demonstrates how to combine tRPC's type-safety with
  * @evjs's RPC infrastructure.
  */
-export async function trpcHandler(reqBody: unknown) {
-  // We simulate a fetch request for tRPC
-  const url = new URL("http://localhost/trpc");
+export async function trpcHandler(op: { path: string; input: unknown }) {
+  const caller = appRouter.createCaller({});
 
-  const response = await fetchRequestHandler({
-    endpoint: "/trpc",
-    req: new Request(url, {
-      method: "POST",
-      body: JSON.stringify(reqBody),
-      headers: {
-        "Content-Type": "application/json",
-      },
-    }),
-    router: appRouter,
-    createContext: () => ({}),
-  });
+  if (op.path === "hello") {
+    return caller.hello();
+  }
 
-  return await response.json();
+  throw new Error(`Unknown tRPC procedure: ${op.path}`);
 }
 
 // standard server function examples

--- a/examples/with-trpc/src/api/trpc.server.ts
+++ b/examples/with-trpc/src/api/trpc.server.ts
@@ -1,4 +1,5 @@
 "use server";
+import { callTRPCProcedure } from "@trpc/server";
 import { appRouter } from "../trpc";
 
 /**
@@ -6,14 +7,20 @@ import { appRouter } from "../trpc";
  * This demonstrates how to combine tRPC's type-safety with
  * @evjs's RPC infrastructure.
  */
-export async function trpcHandler(op: { path: string; input: unknown }) {
-  const caller = appRouter.createCaller({});
-
-  if (op.path === "hello") {
-    return caller.hello();
-  }
-
-  throw new Error(`Unknown tRPC procedure: ${op.path}`);
+export async function trpcHandler(op: {
+  path: string;
+  input: unknown;
+  type: "query" | "mutation" | "subscription";
+}) {
+  return callTRPCProcedure({
+    router: appRouter,
+    path: op.path,
+    type: op.type,
+    ctx: {},
+    getRawInput: async () => op.input,
+    signal: undefined,
+    batchIndex: 0,
+  });
 }
 
 // standard server function examples

--- a/examples/with-trpc/src/pages/home.tsx
+++ b/examples/with-trpc/src/pages/home.tsx
@@ -13,9 +13,9 @@ const serverFnLink = (): TRPCLink<AppRouter> => {
   return () => {
     return ({ op }) => {
       return observable((observer) => {
-        trpcHandler(op)
-          .then((res) => {
-            observer.next({ result: { data: res.result.data } });
+        trpcHandler({ path: op.path, input: op.input })
+          .then((data) => {
+            observer.next({ result: { data } });
             observer.complete();
           })
           .catch((err) => {

--- a/examples/with-trpc/src/pages/home.tsx
+++ b/examples/with-trpc/src/pages/home.tsx
@@ -13,7 +13,7 @@ const serverFnLink = (): TRPCLink<AppRouter> => {
   return () => {
     return ({ op }) => {
       return observable((observer) => {
-        trpcHandler({ path: op.path, input: op.input })
+        trpcHandler({ path: op.path, input: op.input, type: op.type })
           .then((data) => {
             observer.next({ result: { data } });
             observer.complete();

--- a/packages/bundler-utoopack/src/adapter/create-config.ts
+++ b/packages/bundler-utoopack/src/adapter/create-config.ts
@@ -130,6 +130,8 @@ export async function createUtoopackConfig(
     // Dev server configuration
     devServer: {
       hot: true,
+      port: config.dev.port,
+      https: config.dev.https !== false,
       proxy: devProxy,
     },
   };

--- a/packages/bundler-utoopack/src/adapter/index.ts
+++ b/packages/bundler-utoopack/src/adapter/index.ts
@@ -150,7 +150,7 @@ export const utoopackAdapter: BundlerAdapter<ConfigComplete> = {
   async dev(
     config: ResolvedEvConfig<ConfigComplete>,
     cwd: string,
-    callbacks: { onServerBundleReady: () => void },
+    callbacks: { onServerBundleReady: () => void | Promise<void> },
     hooks: EvPluginHooks<ConfigComplete>[],
   ): Promise<void> {
     const { createUtoopackConfig } = await import("./create-config.js");
@@ -181,17 +181,24 @@ export const utoopackAdapter: BundlerAdapter<ConfigComplete> = {
 
         if (hasBundle) {
           ready = true;
-          callbacks.onServerBundleReady();
-          watcher?.close();
+          try {
+            await callbacks.onServerBundleReady();
+          } catch (err) {
+            logger.error`Server bundle ready callback failed: ${err}`;
+            process.exitCode = 1;
+            setTimeout(() => process.exit(1), 0);
+          } finally {
+            watcher?.close();
+          }
         }
       };
 
       const watcher = fs.watch(outDir, (_eventType, filename) => {
-        if (filename) checkReady(filename);
+        if (filename) void checkReady(filename);
       });
 
       // Initial check in case it was written before the watcher attached
-      checkReady();
+      await checkReady();
     }
   },
 };

--- a/packages/bundler-utoopack/src/adapter/index.ts
+++ b/packages/bundler-utoopack/src/adapter/index.ts
@@ -183,12 +183,10 @@ export const utoopackAdapter: BundlerAdapter<ConfigComplete> = {
           ready = true;
           try {
             await callbacks.onServerBundleReady();
+            watcher?.close();
           } catch (err) {
             logger.error`Server bundle ready callback failed: ${err}`;
-            process.exitCode = 1;
-            setTimeout(() => process.exit(1), 0);
-          } finally {
-            watcher?.close();
+            ready = false;
           }
         }
       };

--- a/packages/bundler-utoopack/src/manifest-generator.ts
+++ b/packages/bundler-utoopack/src/manifest-generator.ts
@@ -355,9 +355,8 @@ export class UtoopackManifestGenerator {
       const exportNames = extractServerFunctionExports(source);
       if (exportNames.length === 0) continue;
 
-      const moduleId = serverModule?.moduleId ?? sourceRel;
       for (const exportName of exportNames) {
-        const id = hashServerFunction(moduleId, exportName);
+        const id = hashServerFunction(sourceRel, exportName);
         fns[id] = {
           assets: fns[id]
             ? mergeAssets(fns[id].assets, sourceAssets)

--- a/packages/bundler-utoopack/tests/create-config.test.ts
+++ b/packages/bundler-utoopack/tests/create-config.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { createUtoopackConfig } from "../src/adapter/create-config.js";
+
+describe("createUtoopackConfig", () => {
+  function createResolvedConfig(
+    overrides: Partial<Parameters<typeof createUtoopackConfig>[0]> = {},
+  ): Parameters<typeof createUtoopackConfig>[0] {
+    return {
+      entry: "./src/main.tsx",
+      html: "./index.html",
+      dev: {
+        port: 41234,
+        https: true,
+        proxy: [],
+      },
+      serverEnabled: false,
+      server: {
+        endpoint: "/api/fn",
+        functions: {
+          clientProxy: "@evjs/client/transport",
+          serverRegister: "@evjs/server/register",
+        },
+        dev: {
+          port: 3001,
+          https: false,
+        },
+      },
+      plugins: [],
+      ...overrides,
+    };
+  }
+
+  it("passes resolved dev server options and SPA fallback to Utoopack", async () => {
+    const config = createResolvedConfig();
+
+    const utoopackConfig = await createUtoopackConfig(
+      config,
+      process.cwd(),
+      [],
+    );
+
+    expect(utoopackConfig.devServer?.port).toBe(41234);
+    expect(utoopackConfig.devServer?.https).toBe(true);
+    expect(utoopackConfig.devServer?.proxy).toContainEqual(
+      expect.objectContaining({
+        context: ["^/(?!api(?:/|$))(?!turbopack-hmr$)(?!.*\\.[^/]+$).+"],
+        target: "https://localhost:41234",
+      }),
+    );
+  });
+
+  it("does not add SPA history fallback for MPA builds", async () => {
+    const config = createResolvedConfig({
+      pages: {
+        home: { entry: "./src/home.tsx", html: "./home.html" },
+        about: { entry: "./src/about.tsx", html: "./about.html" },
+      },
+    });
+
+    const utoopackConfig = await createUtoopackConfig(
+      config,
+      process.cwd(),
+      [],
+    );
+
+    expect(utoopackConfig.entry).toEqual([
+      { import: "./src/home.tsx", name: "home" },
+      { import: "./src/about.tsx", name: "about" },
+    ]);
+    expect(utoopackConfig.devServer?.proxy).toEqual([]);
+  });
+});

--- a/packages/bundler-utoopack/tests/manifest-generator.test.ts
+++ b/packages/bundler-utoopack/tests/manifest-generator.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { hashServerFunction } from "@evjs/build-tools";
+import { transformServerFile } from "@evjs/build-tools";
 import { afterEach, describe, expect, it } from "vitest";
 import { UtoopackManifestGenerator } from "../src/manifest-generator.js";
 
@@ -63,9 +63,7 @@ describe("UtoopackManifestGenerator", () => {
       }),
     );
 
-    await fs.promises.writeFile(
-      path.join(cwd, "src/api/users.server.ts"),
-      `
+    const usersSource = `
         "use server";
         export async function getUsers() {
           return [];
@@ -73,8 +71,9 @@ describe("UtoopackManifestGenerator", () => {
         export async function createUser() {
           return { id: "1" };
         }
-      `,
-    );
+      `;
+    const usersPath = path.join(cwd, "src/api/users.server.ts");
+    await fs.promises.writeFile(usersPath, usersSource);
     await fs.promises.writeFile(
       path.join(cwd, "src/api/health.routes.ts"),
       `
@@ -99,8 +98,17 @@ describe("UtoopackManifestGenerator", () => {
 
     const generator = new UtoopackManifestGenerator(cwd, true);
     await generator.build();
-    const getUsersId = hashServerFunction(usersModuleId, "getUsers");
-    const createUserId = hashServerFunction(usersModuleId, "createUser");
+    const clientTransform = await transformServerFile(usersSource, {
+      resourcePath: usersPath,
+      rootContext: cwd,
+      isServer: false,
+    });
+    const expectedFunctionIds = [
+      ...clientTransform.code.matchAll(
+        /createServerReference\("([a-f0-9]{16})"/g,
+      ),
+    ].map((match) => match[1]);
+    expect(expectedFunctionIds).toHaveLength(2);
 
     const serverManifest = JSON.parse(
       await fs.promises.readFile(
@@ -120,10 +128,14 @@ describe("UtoopackManifestGenerator", () => {
       js: ["server.js"],
       css: ["server.css"],
     });
-    expect(serverManifest.fns).toEqual({
-      [getUsersId]: { assets: { js: ["server.js"], css: [] } },
-      [createUserId]: { assets: { js: ["server.js"], css: [] } },
-    });
+    expect(Object.keys(serverManifest.fns).sort()).toEqual(
+      expectedFunctionIds.sort(),
+    );
+    for (const fnId of expectedFunctionIds) {
+      expect(serverManifest.fns[fnId]).toEqual({
+        assets: { js: ["server.js"], css: [] },
+      });
+    }
     expect(serverManifest.routes).toEqual([
       {
         path: "/api/health",

--- a/packages/ev/src/bundler.ts
+++ b/packages/ev/src/bundler.ts
@@ -27,7 +27,7 @@ export interface BundlerAdapter<
   dev(
     config: ResolvedEvConfig<TBundlerCfg>,
     cwd: string,
-    callbacks: { onServerBundleReady: () => void },
+    callbacks: { onServerBundleReady: () => void | Promise<void> },
     hooks: EvPluginHooks<TBundlerCfg>[],
   ): Promise<void>;
 }

--- a/packages/ev/src/commands.ts
+++ b/packages/ev/src/commands.ts
@@ -381,8 +381,6 @@ export async function dev<TBundlerCfg = import("@utoo/pack").ConfigComplete>(
         if (apiProcess === child) {
           apiProcess = null;
           logger.error`API server process exited unexpectedly: ${err}`;
-          process.exitCode = 1;
-          setTimeout(() => process.exit(1), 0);
         }
       });
       await waitForApiReady(child);

--- a/packages/ev/src/commands.ts
+++ b/packages/ev/src/commands.ts
@@ -22,6 +22,7 @@ import type {
 const logger = getLogger(["evjs", "ev"]);
 
 type ApiProcess = ReturnType<typeof execa>;
+const API_READY_MARKER = "__EVJS_API_READY__";
 
 export interface DevOptions<TBundlerCfg = import("@utoo/pack").ConfigComplete> {
   cwd?: string;
@@ -225,6 +226,67 @@ async function stopApiProcess(
   }
 }
 
+function forwardApiOutput(child: ApiProcess): void {
+  child.stdout?.on("data", (data) => {
+    const text = data.toString().replaceAll(API_READY_MARKER, "");
+    if (text.length > 0) {
+      process.stdout.write(text);
+    }
+  });
+  child.stderr?.on("data", (data) => {
+    process.stderr.write(data);
+  });
+}
+
+function waitForApiReady(child: ApiProcess, timeoutMs = 10_000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      child.stdout?.off("data", onStdout);
+      child.stderr?.off("data", onStderr);
+      child.off("exit", onExit);
+      fn();
+    };
+
+    const onStdout = (data: Buffer) => {
+      if (data.toString().includes(API_READY_MARKER)) {
+        settle(resolve);
+      }
+    };
+    const onStderr = (data: Buffer) => {
+      if (data.toString().includes("EADDRINUSE")) {
+        settle(() =>
+          reject(new Error("API server port is already in use (EADDRINUSE)")),
+        );
+      }
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      settle(() =>
+        reject(
+          new Error(
+            `API server exited before it was ready (code ${code ?? "null"}, signal ${signal ?? "null"})`,
+          ),
+        ),
+      );
+    };
+    const timeout = setTimeout(() => {
+      settle(() =>
+        reject(
+          new Error(`API server did not report ready within ${timeoutMs}ms`),
+        ),
+      );
+    }, timeoutMs);
+
+    child.stdout?.on("data", onStdout);
+    child.stderr?.on("data", onStderr);
+    child.once("exit", onExit);
+  });
+}
+
 export async function dev<TBundlerCfg = import("@utoo/pack").ConfigComplete>(
   userConfig?: EvConfig<TBundlerCfg>,
   options?: DevOptions<TBundlerCfg>,
@@ -252,6 +314,17 @@ export async function dev<TBundlerCfg = import("@utoo/pack").ConfigComplete>(
 
   let apiProcess: ApiProcess | null = null;
   let restartQueue: Promise<void> = Promise.resolve();
+  const expectedApiExits = new WeakSet<ApiProcess>();
+
+  const stopApiOnParentShutdown = () => {
+    if (!apiProcess) return;
+    expectedApiExits.add(apiProcess);
+    apiProcess.kill();
+    apiProcess = null;
+  };
+
+  process.once("SIGINT", stopApiOnParentShutdown);
+  process.once("SIGTERM", stopApiOnParentShutdown);
 
   const restartApiServer = async () => {
     if (!config.serverEnabled) return;
@@ -262,6 +335,7 @@ export async function dev<TBundlerCfg = import("@utoo/pack").ConfigComplete>(
     if (apiProcess) {
       logger.info`Restarting API server...`;
       const oldProcess = apiProcess;
+      expectedApiExits.add(oldProcess);
       try {
         await stopApiProcess(oldProcess);
       } catch {}
@@ -287,25 +361,36 @@ export async function dev<TBundlerCfg = import("@utoo/pack").ConfigComplete>(
           `const serverModule = await import(${JSON.stringify(pathToFileURL(serverBundlePath).href)});`,
           `const handler = serverModule.default?.default ?? serverModule.default ?? serverModule;`,
           `const { serve } = require("@evjs/server/node");`,
-          `serve({ fetch: handler.fetch }, { port: ${serverPort}, https: ${JSON.stringify(config.server?.dev?.https ?? false)} });`,
+          `const server = serve({ fetch: handler.fetch }, { port: ${serverPort}, https: ${JSON.stringify(config.server?.dev?.https ?? false)} });`,
+          `const ready = () => console.log(${JSON.stringify(API_READY_MARKER)});`,
+          `if (server.listening) ready(); else server.once("listening", ready);`,
+          `server.once("error", (err) => { console.error(err); process.exit(1); });`,
           `})().catch((err) => { console.error(err); process.exit(1); });`,
         ].join("\n"),
       );
 
       const child = execa("node", [bootstrapPath], {
-        stdio: "inherit",
+        stdio: ["inherit", "pipe", "pipe"],
         env: { ...process.env, NODE_ENV: "development" },
       });
       apiProcess = child;
+      forwardApiOutput(child);
 
-      child.catch(() => {
+      child.catch((err) => {
+        if (expectedApiExits.has(child)) return;
         if (apiProcess === child) {
           apiProcess = null;
+          logger.error`API server process exited unexpectedly: ${err}`;
+          process.exitCode = 1;
+          setTimeout(() => process.exit(1), 0);
         }
       });
+      await waitForApiReady(child);
+      logger.info`API server ready`;
     } catch (err) {
       logger.error`Server runtime failed: ${err}`;
       apiProcess = null;
+      throw err;
     }
   };
 
@@ -314,12 +399,17 @@ export async function dev<TBundlerCfg = import("@utoo/pack").ConfigComplete>(
     await restartQueue;
   };
 
-  await bundler.dev(
-    config,
-    cwd,
-    { onServerBundleReady: handleServerBundleReady },
-    hooks,
-  );
+  try {
+    await bundler.dev(
+      config,
+      cwd,
+      { onServerBundleReady: handleServerBundleReady },
+      hooks,
+    );
+  } finally {
+    process.off("SIGINT", stopApiOnParentShutdown);
+    process.off("SIGTERM", stopApiOnParentShutdown);
+  }
 }
 
 export async function build<TBundlerCfg = import("@utoo/pack").ConfigComplete>(


### PR DESCRIPTION
## Summary

This PR fixes the dev-server readiness path and strengthens coverage around the regressions found during the repo review.

## Changes

- Pass resolved `dev.port` and `dev.https` into the Utoopack dev server config.
- Make `ev dev` wait for the API child process to report readiness, propagate startup failures, and clean up the child on parent shutdown.
- Align server-function manifest IDs with the client/server transform hash inputs.
- Harden E2E fixtures by letting local HTTP servers bind to port `0` directly instead of reserving and later reusing ports.
- Strengthen E2E assertions from broad visibility/defined checks to concrete payload and manifest checks.
- Fix the `with-trpc` example bridge so the tRPC panel actually resolves instead of staying on `Loading...`.
- Add npm caching to GitHub Actions while keeping `npm install` to avoid platform-specific optional dependency lockfile issues.

## Validation

- `npm run lint`
- `npm run check-types`
- `npm test`
- `npm run test:e2e` (`37 passed`)
- Pre-push hook reran `npm run lint` and `npm run check-types` successfully.