### PR TITLE
Respect build plan distDir in utoopack outputs

### DIFF
--- a/packages/bundler-utoopack/src/adapter/create-config.ts
+++ b/packages/bundler-utoopack/src/adapter/create-config.ts
@@ -116,8 +116,8 @@ export async function createUtoopackConfig(
 ): Promise<ConfigComplete> {
   validateUtoopackPlanSupport(plan);
 
-  const isProduction = process.env.NODE_ENV === "production";
-  const mode = isProduction ? "production" : "development";
+  const mode = plan.mode;
+  const isProduction = mode === "production";
   const serverEnabled = config.serverEnabled;
   const frameworkRules = createFrameworkModuleRules(plan);
   const devProxy: DevServerProxy = [
@@ -135,7 +135,7 @@ export async function createUtoopackConfig(
     throw new Error("Failed to resolve a server entry for the server bundle.");
   }
 
-  const outputPaths = getOutputPaths(cwd, serverEnabled);
+  const outputPaths = getOutputPaths(cwd, serverEnabled, plan.distDir);
 
   const utoopackConfig: ConfigComplete = {
     mode,

--- a/packages/bundler-utoopack/src/adapter/create-config.ts
+++ b/packages/bundler-utoopack/src/adapter/create-config.ts
@@ -249,8 +249,14 @@ function createPagesEntryCondition(): {
   path: RegExp;
   query: string;
 } {
+  const normalizedAnchor = normalizeRulePath(pagesEntryAnchor);
+  const frameworkAnchorSuffix =
+    "(?:packages/bundler-utoopack|node_modules/@evjs/bundler-utoopack)/(?:src|esm)/adapter/pages-entry-anchor\\.js";
+
   return {
-    path: new RegExp(`${escapeRegExp(normalizeRulePath(pagesEntryAnchor))}$`),
+    path: new RegExp(
+      `(?:${escapeRegExp(normalizedAnchor)}|(?:^|/)${frameworkAnchorSuffix})$`,
+    ),
     query: "",
   };
 }

--- a/packages/bundler-utoopack/src/adapter/index.ts
+++ b/packages/bundler-utoopack/src/adapter/index.ts
@@ -26,9 +26,13 @@ import { getOutputPaths } from "./output-paths.js";
 
 const logger = getLogger(["evjs", "bundler-utoopack"]);
 
-async function cleanServerOutput(cwd: string, serverEnabled: boolean) {
+async function cleanServerOutput(
+  cwd: string,
+  serverEnabled: boolean,
+  distDir: string,
+) {
   if (!serverEnabled) return;
-  const outputPaths = getOutputPaths(cwd, serverEnabled);
+  const outputPaths = getOutputPaths(cwd, serverEnabled, distDir);
   await fs.promises.rm(outputPaths.serverDir, {
     recursive: true,
     force: true,
@@ -45,7 +49,7 @@ async function generateDevArtifacts(
   ) => void | Promise<void>,
   options: { isRebuild?: boolean } = {},
 ): Promise<boolean> {
-  const outputPaths = getOutputPaths(cwd, config.serverEnabled);
+  const outputPaths = getOutputPaths(cwd, config.serverEnabled, plan.distDir);
   const clientStatsPath = path.join(outputPaths.clientDir, "stats.json");
   if (!fs.existsSync(clientStatsPath)) return false;
 
@@ -71,7 +75,7 @@ export const utoopackAdapter: BundlerAdapter<ConfigComplete> = {
 
     logger.info`Building for production with utoopack...`;
 
-    await cleanServerOutput(cwd, config.serverEnabled);
+    await cleanServerOutput(cwd, config.serverEnabled, plan.distDir);
 
     const { build } = await import("@utoo/pack");
     await build({ config: utoopackConfig });
@@ -104,8 +108,7 @@ export const utoopackAdapter: BundlerAdapter<ConfigComplete> = {
       isRebuild: false,
     });
 
-    // Watch for server bundle readiness (utoopack emits server output
-    // to dist/server/ when "use server" modules are discovered)
+    // Watch for server bundle readiness when "use server" modules are emitted.
     if (!config.serverEnabled) {
       return new UtoopackDevController({
         config,
@@ -117,7 +120,11 @@ export const utoopackAdapter: BundlerAdapter<ConfigComplete> = {
       });
     }
 
-    const outDir = getOutputPaths(cwd, config.serverEnabled).serverDir;
+    const outDir = getOutputPaths(
+      cwd,
+      config.serverEnabled,
+      plan.distDir,
+    ).serverDir;
 
     if (!fs.existsSync(outDir)) {
       fs.mkdirSync(outDir, { recursive: true });

--- a/packages/bundler-utoopack/src/adapter/output-paths.ts
+++ b/packages/bundler-utoopack/src/adapter/output-paths.ts
@@ -9,8 +9,9 @@ export interface UtoopackOutputPaths {
 export function getOutputPaths(
   cwd: string,
   serverEnabled: boolean,
+  distDir = "dist",
 ): UtoopackOutputPaths {
-  const rootDir = path.resolve(cwd, "dist");
+  const rootDir = path.resolve(cwd, distDir);
   const clientDir = serverEnabled ? path.join(rootDir, "client") : rootDir;
   const serverDir = path.join(rootDir, "server");
 

--- a/packages/bundler-utoopack/src/manifest-generator.ts
+++ b/packages/bundler-utoopack/src/manifest-generator.ts
@@ -22,8 +22,14 @@ interface UtoopackStatsModule {
   chunks?: Array<string | number>;
 }
 
+type UtoopackStatsAsset = string | { name?: string };
+
 function normalizeAssetName(name: string | undefined): string | undefined {
   return name?.replace(/^\.\//, "");
+}
+
+function readStatsAssetName(asset: UtoopackStatsAsset): string | undefined {
+  return typeof asset === "string" ? asset : asset.name;
 }
 
 function emptyAssets(): AssetGroup {
@@ -71,7 +77,7 @@ function assetsFromChunks(
 }
 
 function readEntrypointAssets(stats: {
-  entrypoints?: Record<string, { assets?: Array<{ name?: string }> }>;
+  entrypoints?: Record<string, { assets?: UtoopackStatsAsset[] }>;
 }): {
   byName: Record<string, AssetGroup>;
   first: AssetGroup;
@@ -82,7 +88,7 @@ function readEntrypointAssets(stats: {
   for (const [name, entry] of Object.entries(stats.entrypoints ?? {})) {
     const assets = emptyAssets();
     for (const asset of entry.assets ?? []) {
-      const assetName = normalizeAssetName(asset.name);
+      const assetName = normalizeAssetName(readStatsAssetName(asset));
       if (assetName?.endsWith(".js")) {
         assets.js.push(assetName);
       } else if (assetName?.endsWith(".css")) {
@@ -131,7 +137,7 @@ export class UtoopackManifestGenerator {
 
   constructor(cwd: string, serverEnabled: boolean, plan: BuildPlan) {
     this.serverEnabled = serverEnabled;
-    this.outputPaths = getOutputPaths(cwd, serverEnabled);
+    this.outputPaths = getOutputPaths(cwd, serverEnabled, plan.distDir);
     this.plan = plan;
   }
 

--- a/packages/bundler-utoopack/tests/adapter.test.ts
+++ b/packages/bundler-utoopack/tests/adapter.test.ts
@@ -124,7 +124,7 @@ function createFrameworkCallbacks(options: {
       });
       await options.onBuildOutput?.(output);
 
-      const rootDir = path.join(options.cwd, "dist");
+      const rootDir = path.join(options.cwd, plan.distDir);
       const clientDir = options.config.serverEnabled
         ? path.join(rootDir, "client")
         : rootDir;
@@ -294,6 +294,39 @@ describe("utoopackAdapter dev", () => {
       ),
     ).resolves.toBeUndefined();
     await controller.close?.();
+  });
+
+  it("emits dev artifacts under the build plan distDir", async () => {
+    const cwd = await makeProject();
+    const config = resolveConfig<ConfigComplete>({
+      server: false,
+      entry: "./src/main.tsx",
+      html: "./index.html",
+    });
+    const buildContext = await createBuildContext(config, cwd, {
+      distDir: "custom-dist",
+    });
+
+    const controller = await utoopackAdapter.dev({
+      config,
+      cwd,
+      ...buildContext,
+      callbacks: createFrameworkCallbacks({
+        config,
+        cwd,
+        ...buildContext,
+      }),
+      hooks: [],
+    });
+
+    const manifestPath = path.join(cwd, "custom-dist/manifest.json");
+    const htmlPath = path.join(cwd, "custom-dist/index.html");
+
+    expect(fs.existsSync(manifestPath)).toBe(true);
+    expect(fs.existsSync(htmlPath)).toBe(true);
+    expect(fs.existsSync(path.join(cwd, "dist/manifest.json"))).toBe(false);
+    expect(controller).toBeDefined();
+    await controller?.close?.();
   });
 
   it("applies html-only plan updates without restarting Utoopack dev", async () => {
@@ -556,10 +589,14 @@ describe("utoopackAdapter dev", () => {
 async function createBuildContext(
   config: ResolvedConfig<ConfigComplete>,
   cwd: string,
+  options: { distDir?: string } = {},
 ) {
   const analysis = await createAppGraph(config, cwd);
   return {
     graph: analysis.graph,
-    plan: createBuildPlan(config, analysis.graph, { mode: "development" }),
+    plan: createBuildPlan(config, analysis.graph, {
+      mode: "development",
+      distDir: options.distDir,
+    }),
   };
 }

--- a/packages/bundler-utoopack/tests/create-config.test.ts
+++ b/packages/bundler-utoopack/tests/create-config.test.ts
@@ -231,6 +231,16 @@ describe("createUtoopackConfig", () => {
     expect(
       pagesEntryRule?.condition.path.test("/project/src/pages/index.tsx"),
     ).toBe(false);
+    expect(
+      pagesEntryRule?.condition.path.test(
+        "packages/bundler-utoopack/esm/adapter/pages-entry-anchor.js",
+      ),
+    ).toBe(true);
+    expect(
+      pagesEntryRule?.condition.path.test(
+        "/workspace/node_modules/@evjs/bundler-utoopack/esm/adapter/pages-entry-anchor.js",
+      ),
+    ).toBe(true);
     expect(utoopackConfig.module?.rules).toMatchObject({
       "**/*": [
         {

--- a/packages/bundler-utoopack/tests/create-config.test.ts
+++ b/packages/bundler-utoopack/tests/create-config.test.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import path from "node:path";
 import type { AppGraph, BuildPlan } from "@evjs/ev";
 import { createBuildPlan } from "@evjs/ev/build-tools";
 import { describe, expect, it } from "vitest";
@@ -68,6 +69,70 @@ describe("createUtoopackConfig", () => {
         target: "https://localhost:41234",
       }),
     );
+  });
+
+  it("uses the build plan distDir for client and server outputs", async () => {
+    const config = createResolvedConfig({
+      serverEnabled: true,
+      server: {
+        entry: "@evjs/server/fetch",
+        basePath: "/__evjs",
+        runtime: {
+          basePath: "/__evjs",
+          fn: "/__evjs/fn",
+          ppr: "/__evjs/ppr",
+        },
+        functionRuntime: {
+          endpoint: "/__evjs/fn",
+          clientProxy: "@evjs/client/internal",
+          serverRegister: "@evjs/server/register",
+        },
+        dev: {
+          port: 3001,
+          https: false,
+        },
+      },
+    });
+    const cwd = process.cwd();
+    const plan = createPlan(config, { distDir: "custom-dist" });
+
+    const utoopackConfig = await createUtoopackConfig(config, plan, cwd, []);
+
+    expect(utoopackConfig.output?.path).toBe(
+      path.resolve(cwd, "custom-dist/client"),
+    );
+    expect(utoopackConfig.server?.output?.path).toBe(
+      path.resolve(cwd, "custom-dist/server"),
+    );
+  });
+
+  it("uses the build plan mode instead of NODE_ENV", async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+    try {
+      const config = createResolvedConfig();
+      const plan = createPlan(config, { mode: "production" });
+
+      const utoopackConfig = await createUtoopackConfig(
+        config,
+        plan,
+        process.cwd(),
+        [],
+      );
+
+      expect(utoopackConfig.mode).toBe("production");
+      expect(utoopackConfig.output?.filename).toBe("[name].[contenthash:8].js");
+      expect(utoopackConfig.sourceMaps).toBe(false);
+      expect(utoopackConfig.define?.["process.env.NODE_ENV"]).toBe(
+        '"production"',
+      );
+    } finally {
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    }
   });
 
   it("keeps SPA history fallback away from custom framework runtime paths", async () => {
@@ -664,6 +729,7 @@ describe("createUtoopackConfig", () => {
 
 function createPlan(
   config: Parameters<typeof createUtoopackConfig>[0],
+  options: { distDir?: string; mode?: "development" | "production" } = {},
 ): BuildPlan {
   const graph: AppGraph = {
     version: 1,
@@ -702,7 +768,10 @@ function createPlan(
     remotes: {},
   };
 
-  return createBuildPlan(config, graph, { mode: "development" });
+  return createBuildPlan(config, graph, {
+    mode: options.mode ?? "development",
+    distDir: options.distDir,
+  });
 }
 
 function getProxyRuleContexts(rule: { context: string | string[] }): string[] {

--- a/packages/bundler-utoopack/tests/manifest-generator.test.ts
+++ b/packages/bundler-utoopack/tests/manifest-generator.test.ts
@@ -178,6 +178,61 @@ describe("UtoopackManifestGenerator", () => {
     ]);
   });
 
+  it("reads stats from the build plan distDir", async () => {
+    const cwd = await makeProject();
+    await fs.promises.mkdir(path.join(cwd, "custom-dist/client"), {
+      recursive: true,
+    });
+    await fs.promises.mkdir(path.join(cwd, "custom-dist/server"), {
+      recursive: true,
+    });
+    await fs.promises.writeFile(
+      path.join(cwd, "custom-dist/client/stats.json"),
+      JSON.stringify({
+        entrypoints: {
+          main: { assets: ["./main.js"] },
+        },
+      }),
+    );
+    await fs.promises.writeFile(
+      path.join(cwd, "custom-dist/server/stats.json"),
+      JSON.stringify({
+        entrypoints: {
+          server: { assets: ["./server.js"] },
+        },
+      }),
+    );
+
+    const graph: AppGraph = {
+      version: 1,
+      rootDir: cwd,
+      apps: {
+        default: {
+          id: "default",
+          entry: "./src/main.tsx",
+          html: "./index.html",
+        },
+      },
+      pages: {},
+      routes: [],
+      serverFunctions: [],
+      serverRoutes: [],
+      remotes: {},
+    };
+    const plan = createPlan(graph, true, { distDir: "custom-dist" });
+
+    const generator = new UtoopackManifestGenerator(cwd, true, plan);
+    const output = await generator.build();
+    const manifest = linkTestManifest(graph, plan, true, output);
+
+    expect(output.clientEntryAssets?.main).toEqual({
+      js: ["main.js"],
+      css: [],
+    });
+    expect(output.serverEntry).toBe("server.js");
+    expect(manifest.distDir).toBe("custom-dist");
+  });
+
   it("links page assets for MPA output", async () => {
     const cwd = await makeProject();
     await fs.promises.rm(path.join(cwd, "dist/client"), {
@@ -331,7 +386,11 @@ describe("UtoopackManifestGenerator", () => {
   });
 });
 
-function createPlan(graph: AppGraph, serverEnabled: boolean): BuildPlan {
+function createPlan(
+  graph: AppGraph,
+  serverEnabled: boolean,
+  options: { distDir?: string } = {},
+): BuildPlan {
   const pageEntries = Object.values(graph.pages).map((page) => ({
     name: page.id,
     import: page.entry ?? page.app ?? page.component ?? "",
@@ -389,7 +448,7 @@ function createPlan(graph: AppGraph, serverEnabled: boolean): BuildPlan {
     version: 1,
     buildId: "test",
     mode: "production",
-    distDir: "dist",
+    distDir: options.distDir ?? "dist",
     serverEnabled,
     entries: [
       ...appEntries,

--- a/packages/client/src/app.tsx
+++ b/packages/client/src/app.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { AnyRoute } from "@tanstack/react-router";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { createRoot } from "react-dom/client";
+import { formatErrorDetail } from "./validation.js";
 
 /**
  * Options for creating a framework-owned SPA runtime.
@@ -122,8 +123,4 @@ function resolveAppDocument(selector: string): Document {
     );
   }
   return doc;
-}
-
-function formatErrorDetail(error: unknown): string {
-  return error instanceof Error && error.message ? `: ${error.message}` : ".";
 }

--- a/packages/client/src/fetch-response.ts
+++ b/packages/client/src/fetch-response.ts
@@ -3,6 +3,7 @@ import {
   formatContentTypeHeaderValue,
   isApplicationJsonContentType,
 } from "@evjs/shared";
+import { isRecord } from "./validation.js";
 
 export interface FetchResponseObject {
   ok: boolean;
@@ -105,8 +106,4 @@ export function getFetchResponseContentType(
   if (!isRecord(headers) || typeof headers.get !== "function") return null;
   const value = headers.get("Content-Type");
   return typeof value === "string" ? value : null;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/packages/client/src/page-route.ts
+++ b/packages/client/src/page-route.ts
@@ -21,6 +21,7 @@ import { type ComponentType, createElement, type ReactNode } from "react";
 import { type App, createApp } from "./app.js";
 import { PageProvider } from "./page-context.js";
 import { isReactComponentExport } from "./react-component.js";
+import { isRecord } from "./validation.js";
 
 interface PageRouteContext {
   queryClient: QueryClient;
@@ -299,10 +300,6 @@ function assertOptionalReactComponent(value: unknown, path: string): void {
       `[evjs] createPagesApp() ${path} must be a React component.`,
     );
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function pickRouteOptions(mod: PageModule): Partial<PageModuleRouteOptions> {

--- a/packages/client/src/page.ts
+++ b/packages/client/src/page.ts
@@ -24,6 +24,7 @@ import {
   type Shell,
 } from "./shell.js";
 import { initTransportFromManifest } from "./transport.js";
+import { formatErrorDetail, isRecord } from "./validation.js";
 
 export interface PageRuntimeOptions {
   document?: Document;
@@ -76,7 +77,7 @@ async function loadManifest(
   try {
     response = await fetchImpl(manifestUrl);
   } catch (error) {
-    throw new Error(`${errorPrefix}${formatParseError(error)}`);
+    throw new Error(`${errorPrefix}${formatErrorDetail(error)}`);
   }
   assertFetchResponseObject(response, errorPrefix);
   if (!response.ok) {
@@ -128,7 +129,7 @@ function readEmbeddedManifest(document: Document): BuildOutput | undefined {
     manifest = JSON.parse(text);
   } catch (error) {
     throw new Error(
-      `[evjs] Failed to parse embedded manifest "__EVJS_MANIFEST__" as JSON${formatParseError(error)}`,
+      `[evjs] Failed to parse embedded manifest "__EVJS_MANIFEST__" as JSON${formatErrorDetail(error)}`,
     );
   }
   assertLoadedManifest(manifest, 'embedded manifest "__EVJS_MANIFEST__"');
@@ -144,7 +145,7 @@ async function parseFetchedManifest(
     manifest = await response.json();
   } catch (error) {
     throw new Error(
-      `[evjs] Failed to parse manifest "${manifestUrl}" as JSON${formatParseError(error)}`,
+      `[evjs] Failed to parse manifest "${manifestUrl}" as JSON${formatErrorDetail(error)}`,
     );
   }
   assertLoadedManifest(manifest, `manifest "${manifestUrl}"`);
@@ -186,10 +187,6 @@ function assertLoadedManifest(
     pprRendererReferences: "optional",
     rscRendererReferences: "optional",
   });
-}
-
-function formatParseError(error: unknown): string {
-  return error instanceof Error && error.message ? `: ${error.message}` : ".";
 }
 
 function assertPageRuntimeOptions(
@@ -323,10 +320,6 @@ function assertMountOption(value: unknown): void {
   }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
 function outputMount(ctx: AppContext): string {
   if (ctx.kind === "page" && "mount" in ctx.output && ctx.output.mount) {
     return ctx.output.mount;
@@ -351,7 +344,7 @@ function resolveMountPoint(
     mountPoint = document.querySelector(mount);
   } catch (error) {
     throw new Error(
-      `[evjs] startPageRuntime() mount selector "${mount}" is invalid${formatParseError(error)}`,
+      `[evjs] startPageRuntime() mount selector "${mount}" is invalid${formatErrorDetail(error)}`,
     );
   }
   return assertResolvedMountPoint(mountPoint, `mount selector "${mount}"`);

--- a/packages/client/src/query.ts
+++ b/packages/client/src/query.ts
@@ -38,6 +38,7 @@ import {
 } from "@tanstack/react-query";
 import type { ServerFunction } from "./transport.js";
 import { callServer, getServerFunction } from "./transport.js";
+import { isRecord } from "./validation.js";
 
 // biome-ignore lint/suspicious/noConfusingVoidType: TanStack uses void variables to allow mutate() without an argument.
 type NoMutationVariables = void;
@@ -271,8 +272,4 @@ function assertServerMutationOptions(
       "[evjs] useMutation() server function options must not include mutationFn. Pass the server function as the first argument instead.",
     );
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/packages/client/src/react-component.ts
+++ b/packages/client/src/react-component.ts
@@ -1,4 +1,5 @@
 import type { ComponentType, ExoticComponent } from "react";
+import { isRecord } from "./validation.js";
 
 export type ReactComponentExport<P = Record<string, unknown>> =
   | ComponentType<P>
@@ -9,8 +10,4 @@ export function isReactComponentExport<P = Record<string, unknown>>(
 ): value is ReactComponentExport<P> {
   if (typeof value === "function") return true;
   return isRecord(value) && typeof value.$$typeof === "symbol";
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/packages/client/src/react.ts
+++ b/packages/client/src/react.ts
@@ -42,6 +42,7 @@ import type {
   AppModule,
   RemoteSharedResolution,
 } from "./shell.js";
+import { formatErrorDetail, isRecord } from "./validation.js";
 
 export interface ReactPageRuntimeOptions {
   component: ReactComponentExport;
@@ -603,10 +604,6 @@ export function getRscFetchResponseContentType(
   return getFetchResponseContentType(response);
 }
 
-function formatErrorDetail(error: unknown): string {
-  return error instanceof Error && error.message ? `: ${error.message}` : ".";
-}
-
 export function mountRscDebugPayload(
   options: RscDebugPayloadMountOptions,
 ): void {
@@ -840,10 +837,6 @@ function readLocationPathname(): string {
 function readLocationSearch(): PageSearchParams {
   const search = globalThis.location?.search;
   return search ? parsePageSearch(search) : {};
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 function isStringRecord(value: unknown): value is Record<string, string> {

--- a/packages/client/src/remote-app.tsx
+++ b/packages/client/src/remote-app.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 import type { RemoteRuntimeContext } from "./react.js";
 import { assertSharedScope } from "./shell/shared.js";
 import { createShell } from "./shell.js";
+import { formatErrorDetail, isRecord } from "./validation.js";
 
 const REMOTE_APP_BUILD_ID = "remote-app";
 
@@ -784,14 +785,6 @@ function assertRemoteAppRequestTarget(
       `[evjs] RemoteApp request.remoteId "${value.remoteId}" must match configured remote "${remote}".`,
     );
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function formatErrorDetail(error: unknown): string {
-  return error instanceof Error && error.message ? `: ${error.message}` : ".";
 }
 
 function assertRemoteAppBuildIdentifier(value: unknown, path: string): string {

--- a/packages/client/src/rsc.ts
+++ b/packages/client/src/rsc.ts
@@ -20,6 +20,7 @@ import {
   getRscFetchResponseContentType,
   type RscFlightFetchOptions,
 } from "./react.js";
+import { formatErrorDetail, isRecord } from "./validation.js";
 
 export interface ReactRscModelOptions extends RscFlightFetchOptions {
   moduleBaseURL?: string;
@@ -479,14 +480,6 @@ function formatBootstrapPathnameError(
     case "query-or-hash":
       return "must not include a query string or hash.";
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function formatErrorDetail(error: unknown): string {
-  return error instanceof Error && error.message ? `: ${error.message}` : ".";
 }
 
 function createBootstrapManifest(

--- a/packages/client/src/shell/assets.ts
+++ b/packages/client/src/shell/assets.ts
@@ -24,6 +24,10 @@ import {
   formatFetchErrorResponseDetail,
   readFetchErrorResponseBody,
 } from "../fetch-response.js";
+import {
+  formatErrorDetail,
+  isRecord as isObjectRecord,
+} from "../validation.js";
 import { readRegisteredModule, resolveBrowserHref } from "./registry.js";
 import { resolveRemoteHref } from "./routing.js";
 import type { AppContext, AppModule } from "./types.js";
@@ -92,10 +96,8 @@ async function parseRemoteManifestJson(
   try {
     return (await response.json()) as unknown;
   } catch (error) {
-    const detail =
-      error instanceof Error && error.message ? `: ${error.message}` : ".";
     throw new Error(
-      `[evjs] Failed to parse remote manifest "${manifestUrl}" as JSON${detail}`,
+      `[evjs] Failed to parse remote manifest "${manifestUrl}" as JSON${formatErrorDetail(error)}`,
     );
   }
 }
@@ -620,14 +622,6 @@ function assertRemoteHrefResolvable(
 
 function isHttpRemoteUrl(url: URL): boolean {
   return url.protocol === "http:" || url.protocol === "https:";
-}
-
-function formatErrorDetail(error: unknown): string {
-  return error instanceof Error && error.message ? `: ${error.message}` : ".";
-}
-
-function isObjectRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 function throwRemoteManifestPathError(

--- a/packages/client/src/shell/drivers.ts
+++ b/packages/client/src/shell/drivers.ts
@@ -1,3 +1,4 @@
+import { formatErrorDetail, isRecord } from "../validation.js";
 import { createActivationRequestFromUrl } from "./routing.js";
 import type {
   BrowserWindowLike,
@@ -210,12 +211,4 @@ function assertBrowserWindow(
       `[evjs] createHistoryDriver() ${path}.removeEventListener must be a function.`,
     );
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function formatErrorDetail(error: unknown): string {
-  return error instanceof Error && error.message ? `: ${error.message}` : ".";
 }

--- a/packages/client/src/shell/module-registration.ts
+++ b/packages/client/src/shell/module-registration.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "../validation.js";
 import type { AppModule, ShellModuleRegistration } from "./types.js";
 
 export function assertShellModuleHref(
@@ -53,8 +54,4 @@ function assertOptionalLifecycleHook(
   if (value !== undefined && typeof value !== "function") {
     throw new Error(`${prefix} ${name} must be a function when provided.`);
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/packages/client/src/shell/registry.ts
+++ b/packages/client/src/shell/registry.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "../validation.js";
 import {
   assertAppModule,
   assertShellModuleHref,
@@ -119,10 +120,6 @@ function getRegistryKeys(href: string): string[] {
     keys.push(absoluteHref);
   }
   return keys;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 export function resolveBrowserHref(href: string): string | undefined {

--- a/packages/client/src/shell/runtime.ts
+++ b/packages/client/src/shell/runtime.ts
@@ -12,6 +12,7 @@ import {
   createRemoteReactModule,
   type RemoteReactModuleExports,
 } from "../react.js";
+import { isRecord } from "../validation.js";
 import {
   defaultLoadModule,
   defaultLoadRemoteManifest,
@@ -653,10 +654,6 @@ function assertOptionalFunction(value: unknown, name: string): void {
       `[evjs] createShell() ${name} must be a function when provided.`,
     );
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 async function initializeModule(

--- a/packages/client/src/shell/shared-scope.ts
+++ b/packages/client/src/shell/shared-scope.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "../validation.js";
 import type { SharedScope, SharedScopeEntry } from "./types.js";
 
 export function assertSharedDependencyName(
@@ -67,8 +68,4 @@ function assertOptionalSharedString(value: unknown, path: string): void {
 function assertOptionalSharedBoolean(value: unknown, path: string): void {
   if (value === undefined || typeof value === "boolean") return;
   throw new Error(`${path} must be a boolean when provided.`);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/packages/client/src/shell/targets.ts
+++ b/packages/client/src/shell/targets.ts
@@ -1,4 +1,5 @@
 import type { BuildOutput, RemoteManifest } from "@evjs/shared/manifest";
+import { isRecord } from "../validation.js";
 import { normalizeAndValidateRemoteManifest } from "./assets.js";
 import {
   findRemoteIdForPath,
@@ -111,10 +112,6 @@ function readRuntimeModuleHref(
     );
   }
   return href;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 async function resolveRemoteTarget(

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -27,6 +27,7 @@ import {
   getFetchResponseContentType,
   readFetchErrorResponseBody,
 } from "./fetch-response.js";
+import { formatErrorDetail, isRecord } from "./validation.js";
 
 /**
  * Request context passed through server calls.
@@ -128,10 +129,6 @@ function mergeHeaders(...values: (HeadersInit | undefined)[]): Headers {
     });
   }
   return headers;
-}
-
-function formatErrorDetail(error: unknown): string {
-  return error instanceof Error && error.message ? `: ${error.message}` : ".";
 }
 
 function createInvalidFetchResponseError(
@@ -761,10 +758,6 @@ function formatTransportBaseUrlError(error: UrlStringValidationError): string {
     case "invalid-url":
       return "must be a valid URL string.";
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function getManifestTransport(

--- a/packages/client/src/validation.ts
+++ b/packages/client/src/validation.ts
@@ -1,0 +1,7 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function formatErrorDetail(error: unknown): string {
+  return error instanceof Error && error.message ? `: ${error.message}` : ".";
+}

--- a/packages/ev/src/build-tools/graph/index.ts
+++ b/packages/ev/src/build-tools/graph/index.ts
@@ -52,6 +52,8 @@ import {
   deriveRouteIdFromPath,
   detectUseServer,
   hashServerFunction,
+  isInsideCwd,
+  toPosixPath,
 } from "../utils.js";
 
 export interface GraphAnalysisResult {
@@ -1640,16 +1642,4 @@ async function resolveSourcePath(
   }
 
   return undefined;
-}
-
-function isInsideCwd(cwd: string, candidate: string): boolean {
-  const relative = path.relative(cwd, candidate);
-  return (
-    relative === "" ||
-    (!relative.startsWith("..") && !path.isAbsolute(relative))
-  );
-}
-
-function toPosixPath(value: string): string {
-  return value.replaceAll(path.sep, "/").replaceAll("\\", "/");
 }

--- a/packages/ev/src/build-tools/page-module-config.ts
+++ b/packages/ev/src/build-tools/page-module-config.ts
@@ -10,7 +10,7 @@ import {
   collectModuleExportNames,
 } from "./module-exports.js";
 import {
-  getParseErrorMessage,
+  formatParseErrorMessage,
   getPropertyName,
   parseRouteModuleWithError,
 } from "./routes/shared.js";
@@ -52,7 +52,7 @@ export function analyzePageModuleConfig(
       diagnostics: [
         {
           level: "error",
-          message: `${PAGE_MODULE_METADATA_PARSE_DIAGNOSTIC_PREFIX} ${formatParseError(error)}`,
+          message: `${PAGE_MODULE_METADATA_PARSE_DIAGNOSTIC_PREFIX} ${formatParseErrorMessage(error, { firstLine: true })}`,
         },
       ],
     };
@@ -152,13 +152,6 @@ function createInvalidRenderDiagnostic(value: string): string {
     return 'Page render mode "ppr" is not supported. PPR is declared with render = "ssr" and prerender = { partial: true }.';
   }
   return `Unsupported page render mode "${value}". Expected "csr", "ssr", or "ssg".`;
-}
-
-function formatParseError(error: unknown): string {
-  return (
-    getParseErrorMessage(error).split("\n").find(Boolean)?.trim() ??
-    "Unknown parse error."
-  );
 }
 
 function getExportedValue(

--- a/packages/ev/src/build-tools/page-route-types.ts
+++ b/packages/ev/src/build-tools/page-route-types.ts
@@ -7,6 +7,7 @@ import {
   PAGE_ROUTE_CONVENTION_SUMMARY,
 } from "./page-route-conventions.js";
 import { sortPageRoutes } from "./page-route-order.js";
+import { toProjectPath } from "./utils.js";
 
 export const PAGE_ROUTE_TYPES_FILE = "evjs-route-types.d.ts";
 export const PAGE_ROUTE_TYPES_MARKER =
@@ -214,12 +215,4 @@ function pathRelative(fromDir: string, module: string): string {
   }
 
   return [...fromParts.map(() => ".."), ...moduleParts].join("/") || ".";
-}
-
-function toProjectPath(cwd: string, absolute: string): string {
-  return `./${toPosixPath(path.relative(cwd, absolute))}`;
-}
-
-function toPosixPath(value: string): string {
-  return value.replaceAll(path.sep, "/").replaceAll("\\", "/");
 }

--- a/packages/ev/src/build-tools/page-routes.ts
+++ b/packages/ev/src/build-tools/page-routes.ts
@@ -15,11 +15,16 @@ import {
 } from "./page-route-conventions.js";
 import { sortPageRoutes } from "./page-route-order.js";
 import {
-  getParseErrorMessage,
+  formatParseErrorMessage,
   hasDefaultExport,
   parseRouteModuleWithError,
 } from "./routes/shared.js";
-import { deriveRouteIdFromPath } from "./utils.js";
+import {
+  deriveRouteIdFromPath,
+  isInsideCwd,
+  toPosixPath,
+  toProjectPath,
+} from "./utils.js";
 
 export interface DiscoverPageRoutesOptions {
   dir: string;
@@ -60,11 +65,8 @@ export async function discoverPageRoutes(
     };
   }
 
-  const files = await collectSourceFiles(cwd, absoluteDir);
-  const pageLayoutDirectories = await collectPageLayoutDirectories(
-    cwd,
-    absoluteDir,
-  );
+  const { files, layoutDirectories: pageLayoutDirectories } =
+    await collectPageRouteTree(cwd, absoluteDir);
   const pageLayoutDirectoriesWithSourceFiles = new Set<string>();
   const routes: PageRouteNode[] = [];
   const routeByPath = new Map<string, string>();
@@ -389,7 +391,7 @@ async function validateDefaultExport(
     diagnostics.push({
       level: "error",
       file,
-      message: `${messages.parseError}: ${formatParseError(error)}`,
+      message: `${messages.parseError}: ${formatParseErrorMessage(error, { firstLine: true })}`,
     });
     return false;
   }
@@ -406,17 +408,19 @@ async function validateDefaultExport(
   return true;
 }
 
-function formatParseError(error: unknown): string {
-  return (
-    getParseErrorMessage(error).split("\n").find(Boolean)?.trim() ??
-    "Unknown parse error."
-  );
+interface PageRouteTree {
+  files: string[];
+  layoutDirectories: string[];
 }
 
-async function collectSourceFiles(cwd: string, dir: string): Promise<string[]> {
+async function collectPageRouteTree(
+  cwd: string,
+  dir: string,
+): Promise<PageRouteTree> {
   const files: string[] = [];
+  const layoutDirectories: string[] = [];
 
-  async function visit(current: string) {
+  async function visit(current: string, insideLayoutDirectory = false) {
     let entries: import("node:fs").Dirent[];
     try {
       entries = await fs.readdir(current, { withFileTypes: true });
@@ -429,10 +433,19 @@ async function collectSourceFiles(cwd: string, dir: string): Promise<string[]> {
       if (entry.name.startsWith(".")) continue;
       const absolute = path.join(current, entry.name);
       if (!isInsideCwd(cwd, absolute)) continue;
+
       if (entry.isDirectory()) {
-        await visit(absolute);
+        const isLayoutDirectory =
+          !insideLayoutDirectory &&
+          entry.name === "layout" &&
+          !routeSegmentsFromDir(dir, absolute).some(isIgnoredPageRouteSegment);
+        if (isLayoutDirectory) {
+          layoutDirectories.push(absolute);
+        }
+        await visit(absolute, insideLayoutDirectory || isLayoutDirectory);
         continue;
       }
+
       if (entry.isFile() && isPageRouteSourceModuleFile(entry.name)) {
         files.push(absolute);
       }
@@ -440,45 +453,14 @@ async function collectSourceFiles(cwd: string, dir: string): Promise<string[]> {
   }
 
   await visit(dir);
-  return files.sort();
+  return {
+    files: files.sort(),
+    layoutDirectories: layoutDirectories.sort(),
+  };
 }
 
-async function collectPageLayoutDirectories(
-  cwd: string,
-  dir: string,
-): Promise<string[]> {
-  const directories: string[] = [];
-
-  async function visit(current: string) {
-    let entries: import("node:fs").Dirent[];
-    try {
-      entries = await fs.readdir(current, { withFileTypes: true });
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
-      throw err;
-    }
-
-    for (const entry of entries) {
-      if (entry.name.startsWith(".")) continue;
-      const absolute = path.join(current, entry.name);
-      if (!entry.isDirectory() || !isInsideCwd(cwd, absolute)) continue;
-
-      const routeSegments = toPosixPath(path.relative(dir, absolute))
-        .split("/")
-        .filter(Boolean);
-      if (routeSegments.some(isIgnoredPageRouteSegment)) continue;
-
-      if (entry.name === "layout") {
-        directories.push(absolute);
-        continue;
-      }
-
-      await visit(absolute);
-    }
-  }
-
-  await visit(dir);
-  return directories.sort();
+function routeSegmentsFromDir(dir: string, absolute: string): string[] {
+  return toPosixPath(path.relative(dir, absolute)).split("/").filter(Boolean);
 }
 
 function getPageLayoutDirectory(
@@ -505,16 +487,8 @@ function createAmbiguousRouteShapeDiagnostic(
   ].join(" ");
 }
 
-function toProjectPath(cwd: string, file: string): string {
-  return `./${toPosixPath(path.relative(cwd, file))}`;
-}
-
 function toDiagnosticPath(projectPath: string): string {
   return projectPath.replace(/^\.\//, "");
-}
-
-function toPosixPath(value: string): string {
-  return value.replaceAll(path.sep, "/").replaceAll("\\", "/");
 }
 
 async function statIfExists(
@@ -526,12 +500,4 @@ async function statIfExists(
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
     throw err;
   }
-}
-
-function isInsideCwd(cwd: string, candidate: string): boolean {
-  const relative = path.relative(cwd, candidate);
-  return (
-    relative === "" ||
-    (!relative.startsWith("..") && !path.isAbsolute(relative))
-  );
 }

--- a/packages/ev/src/build-tools/ppr-regions.ts
+++ b/packages/ev/src/build-tools/ppr-regions.ts
@@ -18,12 +18,13 @@ import {
 } from "./module-exports.js";
 import {
   collectImportedNames,
-  getParseErrorMessage,
+  formatParseErrorMessage,
   getPropertyName,
   parseRouteModule,
   parseRouteModuleWithError,
   type RouteAst,
 } from "./routes/shared.js";
+import { toPosixPath } from "./utils.js";
 
 export interface PprRegionAnalysis {
   regions: Record<string, PprRegionConfig>;
@@ -91,7 +92,7 @@ export function extractPprRegionModuleConfig(
       diagnostics: [
         {
           level: "error",
-          message: `${PPR_REGION_METADATA_PARSE_DIAGNOSTIC_PREFIX} ${formatParseError(error)}`,
+          message: `${PPR_REGION_METADATA_PARSE_DIAGNOSTIC_PREFIX} ${formatParseErrorMessage(error, { firstLine: true })}`,
         },
       ],
     };
@@ -493,17 +494,6 @@ function derivePprRegionId(componentName: string): string {
 
 function normalizeRelativeModule(sourceRel: string, specifier: string): string {
   return `./${toPosixPath(path.normalize(path.join(path.dirname(sourceRel), specifier)))}`;
-}
-
-function formatParseError(error: unknown): string {
-  return (
-    getParseErrorMessage(error).split("\n").find(Boolean)?.trim() ??
-    "Unknown parse error."
-  );
-}
-
-function toPosixPath(value: string): string {
-  return value.split(path.sep).join("/");
 }
 
 function emptyAnalysis(): PprRegionAnalysis {

--- a/packages/ev/src/build-tools/routes/index.ts
+++ b/packages/ev/src/build-tools/routes/index.ts
@@ -3,7 +3,10 @@ import type {
   ExtractedServerRoute,
 } from "@evjs/shared/manifest";
 import { analyzeServerRoutesFromAst } from "./server.js";
-import { getParseErrorMessage, parseRouteModuleWithError } from "./shared.js";
+import {
+  formatParseErrorMessage,
+  parseRouteModuleWithError,
+} from "./shared.js";
 
 export type {
   ExtractedRoute,
@@ -42,7 +45,7 @@ export function analyzeRoutes(source: string): RouteAnalysis {
     if (mayHaveServerRoute(source)) {
       diagnostics.push({
         level: "error",
-        message: `${SERVER_ROUTE_PARSE_DIAGNOSTIC_PREFIX} ${formatParseError(error)}`,
+        message: `${SERVER_ROUTE_PARSE_DIAGNOSTIC_PREFIX} ${formatParseErrorMessage(error, { firstLine: true })}`,
       });
     }
 
@@ -65,12 +68,5 @@ function mayHaveServerRoute(source: string): boolean {
   return (
     SERVER_ROUTE_IMPORT_MARKERS.some((marker) => source.includes(marker)) &&
     source.includes("createRoute")
-  );
-}
-
-function formatParseError(error: unknown): string {
-  return (
-    getParseErrorMessage(error).split("\n").find(Boolean)?.trim() ??
-    "Unknown parse error."
   );
 }

--- a/packages/ev/src/build-tools/routes/shared.ts
+++ b/packages/ev/src/build-tools/routes/shared.ts
@@ -25,6 +25,16 @@ export function getParseErrorMessage(error: unknown): string {
   return "Unknown parse error.";
 }
 
+export function formatParseErrorMessage(
+  error: unknown,
+  options: { firstLine?: boolean } = {},
+): string {
+  const message = getParseErrorMessage(error);
+  if (!options.firstLine) return message;
+
+  return message.split("\n").find(Boolean)?.trim() ?? "Unknown parse error.";
+}
+
 export function hasDefaultExport(ast: RouteAst): boolean {
   return ast.body.some(
     (item) =>

--- a/packages/ev/src/build-tools/rsc-refs.ts
+++ b/packages/ev/src/build-tools/rsc-refs.ts
@@ -10,6 +10,7 @@ import {
   collectModuleExportNames,
   formatModuleExportName,
 } from "./module-exports.js";
+import { formatParseErrorMessage } from "./routes/shared.js";
 import {
   analyzeServerFunctionExportsFromAst,
   formatServerFunctionParseDiagnostic,
@@ -248,12 +249,7 @@ function createParseErrorAnalysis(
 }
 
 function formatRscReferenceParseDiagnostic(error: unknown): string {
-  return `${RSC_REFERENCE_PARSE_DIAGNOSTIC_PREFIX} ${formatParseError(error)}`;
-}
-
-function formatParseError(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message;
-  return "Unknown parse error.";
+  return `${RSC_REFERENCE_PARSE_DIAGNOSTIC_PREFIX} ${formatParseErrorMessage(error)}`;
 }
 
 function collectRscClientExportDiagnostics(

--- a/packages/ev/src/build-tools/server-fns.ts
+++ b/packages/ev/src/build-tools/server-fns.ts
@@ -11,6 +11,7 @@ import {
   getIdentifierExportName,
   getModuleExportName,
 } from "./module-exports.js";
+import { formatParseErrorMessage } from "./routes/shared.js";
 import { detectUseServer } from "./utils.js";
 
 type ServerFunctionAst = ReturnType<typeof parseSync>;
@@ -89,7 +90,7 @@ export function parseServerFunctionModule(source: string): {
 }
 
 export function formatServerFunctionParseDiagnostic(error: unknown): string {
-  return `${SERVER_FUNCTION_PARSE_DIAGNOSTIC_PREFIX} ${formatParseError(error)}`;
+  return `${SERVER_FUNCTION_PARSE_DIAGNOSTIC_PREFIX} ${formatParseErrorMessage(error)}`;
 }
 
 export function isServerFunctionParseDiagnostic(message: string): boolean {
@@ -108,11 +109,6 @@ function createParseErrorAnalysis(
       },
     ],
   };
-}
-
-function formatParseError(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message;
-  return "Unknown parse error.";
 }
 
 export function analyzeServerFunctionExportsFromAst(

--- a/packages/ev/src/build-tools/utils.ts
+++ b/packages/ev/src/build-tools/utils.ts
@@ -63,10 +63,24 @@ export function makeFnId(
   resourcePath: string,
   exportName: string,
 ): string {
-  const moduleId = path
-    .relative(rootContext, resourcePath)
-    .replaceAll("\\", "/");
+  const moduleId = toPosixPath(path.relative(rootContext, resourcePath));
   return hashServerFunction(moduleId, exportName);
+}
+
+export function toPosixPath(value: string): string {
+  return value.replaceAll(path.sep, "/").replaceAll("\\", "/");
+}
+
+export function toProjectPath(cwd: string, absolute: string): string {
+  return `./${toPosixPath(path.relative(cwd, absolute))}`;
+}
+
+export function isInsideCwd(cwd: string, candidate: string): boolean {
+  const relative = path.relative(cwd, candidate);
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  );
 }
 
 export type FrameworkDirective = "use client" | "use server";

--- a/packages/ev/src/commands.ts
+++ b/packages/ev/src/commands.ts
@@ -35,6 +35,7 @@ import {
   writePageRouteTypesIfChanged,
 } from "./build-tools/page-route-types.js";
 import { PAGES_APP_ENTRY_IMPORT } from "./build-tools/pages-entry.js";
+import { toProjectPath } from "./build-tools/utils.js";
 import type {
   BundlerAdapter,
   BundlerBuildFacts,
@@ -1838,14 +1839,6 @@ function createInspectPageOutput(
 
 function compareById<T extends { id: string }>(left: T, right: T): number {
   return left.id.localeCompare(right.id);
-}
-
-function toProjectPath(cwd: string, absolute: string): string {
-  return `./${toPosixPath(path.relative(cwd, absolute))}`;
-}
-
-function toPosixPath(value: string): string {
-  return value.replaceAll(path.sep, "/").replaceAll("\\", "/");
 }
 
 function normalizeDiagnosticFile(file: string): string {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -37,6 +37,7 @@ import {
 import { type DispatchError, dispatch } from "./functions/dispatch.js";
 import { textResponse } from "./responses.js";
 import type { RouteHandler } from "./routes/index.js";
+import { isRecord } from "./validation.js";
 
 export interface CreateAppOptions {
   /**
@@ -209,10 +210,6 @@ export function createApp(options?: CreateAppOptions): Hono {
   }
 
   return app;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 async function invokeRouteHandler(

--- a/packages/server/src/framework.ts
+++ b/packages/server/src/framework.ts
@@ -27,6 +27,7 @@ import type {
 import { assertFrameworkManifestShape } from "@evjs/shared/manifest";
 import { tryGetContext } from "hono/context-storage";
 import { textResponse } from "./responses.js";
+import { formatUnknownError, isRecord } from "./validation.js";
 
 export interface FrameworkServerOptions {
   manifest: BuildOutput;
@@ -352,10 +353,6 @@ function assertObject(
   if (!isRecord(value)) {
     throw new Error(`[evjs] ${source} must be an object.`);
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 export async function handleFrameworkRenderRequest(
@@ -1029,22 +1026,6 @@ function withoutResponseBody(response: Response): Response {
     statusText: response.statusText,
     headers: response.headers,
   });
-}
-
-function formatUnknownError(error: unknown): string {
-  return sanitizeDiagnosticText(
-    error instanceof Error ? error.message : String(error),
-  );
-}
-
-function sanitizeDiagnosticText(value: string): string {
-  return value
-    .replace(/file:\/\/\/[^\s"'<>)]*/g, "[redacted-file-url]")
-    .replace(
-      /(?:\/(?:Users|home|private|tmp)\/[^\s"'<>)]*)/g,
-      "[redacted-path]",
-    )
-    .replace(/[A-Za-z]:\\[^\s"'<>)]*/g, "[redacted-path]");
 }
 
 function createRendererRegistryFromManifest(

--- a/packages/server/src/functions/dispatch.ts
+++ b/packages/server/src/functions/dispatch.ts
@@ -14,6 +14,7 @@ import {
   isServerFunctionId,
   ServerError,
 } from "@evjs/shared";
+import { isRecord } from "../validation.js";
 import { registry } from "./register.js";
 
 /** Successful dispatch result. */
@@ -132,10 +133,6 @@ function getStructuredServerError(
     status: value.status,
     data: value.data,
   };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function formatThrownValue(value: unknown): string {

--- a/packages/server/src/react-renderer.ts
+++ b/packages/server/src/react-renderer.ts
@@ -22,6 +22,11 @@ import { type ComponentType, createElement } from "react";
 import { renderToString } from "react-dom/server";
 import type { RscCoordinator, RscFlightContext } from "./framework.js";
 import { textResponse } from "./responses.js";
+import {
+  formatUnknownError,
+  isRecord,
+  sanitizeDiagnosticText,
+} from "./validation.js";
 
 export interface ReactServerRenderContext {
   request: Request;
@@ -629,10 +634,6 @@ function stripPageRouteProps(
   return rest;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
-}
-
 function isStringRecord(value: unknown): value is Record<string, string> {
   return (
     isRecord(value) &&
@@ -759,22 +760,6 @@ function assetHref(manifest: BuildOutput, asset: string): string {
   if (/^(?:https?:)?\/\//.test(asset) || asset.startsWith("/")) return asset;
   const base = publicPath.endsWith("/") ? publicPath : `${publicPath}/`;
   return `${base}${asset}`;
-}
-
-function formatUnknownError(error: unknown): string {
-  return sanitizeDiagnosticText(
-    error instanceof Error ? error.message : String(error),
-  );
-}
-
-function sanitizeDiagnosticText(value: string): string {
-  return value
-    .replace(/file:\/\/\/[^\s"'<>)]*/g, "[redacted-file-url]")
-    .replace(
-      /(?:\/(?:Users|home|private|tmp)\/[^\s"'<>)]*)/g,
-      "[redacted-path]",
-    )
-    .replace(/[A-Za-z]:\\[^\s"'<>)]*/g, "[redacted-path]");
 }
 
 function emptyAssets(): AssetGroup {

--- a/packages/server/src/react.ts
+++ b/packages/server/src/react.ts
@@ -19,6 +19,7 @@ import {
   type ReactServerRenderAdapterOptions,
 } from "./react-renderer.js";
 import { textResponse } from "./responses.js";
+import { isRecord } from "./validation.js";
 
 export type {
   ReactRscDebugPayload,
@@ -170,10 +171,6 @@ function assertOptionalRscCoordinator(value: unknown, source: string): void {
   throw new Error(
     `[evjs] ${source} must be an RSC Flight function or coordinator object.`,
   );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 function createDevPageRenderGuard():

--- a/packages/server/src/validation.ts
+++ b/packages/server/src/validation.ts
@@ -1,0 +1,19 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function formatUnknownError(error: unknown): string {
+  return sanitizeDiagnosticText(
+    error instanceof Error ? error.message : String(error),
+  );
+}
+
+export function sanitizeDiagnosticText(value: string): string {
+  return value
+    .replace(/file:\/\/\/[^\s"'<>)]*/g, "[redacted-file-url]")
+    .replace(
+      /(?:\/(?:Users|home|private|tmp)\/[^\s"'<>)]*)/g,
+      "[redacted-path]",
+    )
+    .replace(/[A-Za-z]:\\[^\s"'<>)]*/g, "[redacted-path]");
+}


### PR DESCRIPTION
## Summary
- Use the build plan `distDir` for utoopack mode selection and output paths
- Keep dev artifact cleanup, manifest generation, and output discovery aligned with the planned dist directory
- Consolidate shared client validation helpers and tighten parse/error formatting reuse
- Add coverage for custom `distDir`, plan-driven production mode, and stats asset shapes

## Testing
- Added and updated unit tests for utoopack config, manifest generation, and dev artifact output paths
- Not run (not requested)