### PR TITLE
fix(bundler-utoopack): content-hash CSS output filenames

### DIFF
--- a/packages/bundler-utoopack/src/adapter/create-config.ts
+++ b/packages/bundler-utoopack/src/adapter/create-config.ts
@@ -145,6 +145,10 @@ export async function createUtoopackConfig(
       path: outputPaths.clientDir,
       filename: isProduction ? "[name].[contenthash:8].js" : "[name].js",
       chunkFilename: isProduction ? "[name].[contenthash:8].js" : "[name].js",
+      cssFilename: isProduction ? "[name].[contenthash:8].css" : "[name].css",
+      cssChunkFilename: isProduction
+        ? "[name].[contenthash:8].css"
+        : "[name].css",
       publicPath: toUtoopackPublicPath(plan.runtime.publicPath),
       crossOriginLoading: config.output.crossOriginLoading,
       clean: true,

--- a/packages/bundler-utoopack/tests/create-config.test.ts
+++ b/packages/bundler-utoopack/tests/create-config.test.ts
@@ -136,6 +136,40 @@ describe("createUtoopackConfig", () => {
     }
   });
 
+  it("content-hashes client CSS output filenames in production", async () => {
+    const config = createResolvedConfig();
+    const plan = createPlan(config, { mode: "production" });
+
+    const utoopackConfig = await createUtoopackConfig(
+      config,
+      plan,
+      process.cwd(),
+      [],
+    );
+
+    expect(utoopackConfig.output?.cssFilename).toBe(
+      "[name].[contenthash:8].css",
+    );
+    expect(utoopackConfig.output?.cssChunkFilename).toBe(
+      "[name].[contenthash:8].css",
+    );
+  });
+
+  it("uses stable client CSS output filenames in development", async () => {
+    const config = createResolvedConfig();
+    const plan = createPlan(config, { mode: "development" });
+
+    const utoopackConfig = await createUtoopackConfig(
+      config,
+      plan,
+      process.cwd(),
+      [],
+    );
+
+    expect(utoopackConfig.output?.cssFilename).toBe("[name].css");
+    expect(utoopackConfig.output?.cssChunkFilename).toBe("[name].css");
+  });
+
   it("sets crossorigin for dynamically loaded browser chunks", async () => {
     const config = createResolvedConfig({
       output: {


### PR DESCRIPTION
## 问题

只改 `.tsx`（不动 CSS 入口文件）时，生成的 CSS 内容变了但文件名不变 → CDN/浏览器按 URL 命中缓存、长期返回旧 CSS，造成「本地正常、线上缺样式」。

根因：`create-config.ts` 的 client `output` 没设 `cssFilename` / `cssChunkFilename`。`@utoo/pack-shared` 的 `webpackCompat` 仅在检测到 `MiniCssExtractPlugin` 时补 `cssFilename`，evjs 不是 webpack、无该插件，于是 utoo 退回内部默认 CSS 命名 `src_style_<源路径哈希>.css` —— 哈希基于**源模块路径**而非**生成内容**，内容变、URL 不变 → 缓存命中旧 CSS。

## 修复

在 client `output` 块补上与 JS 一致的内容哈希命名：

```ts
cssFilename: isProduction ? "[name].[contenthash:8].css" : "[name].css",
cssChunkFilename: isProduction ? "[name].[contenthash:8].css" : "[name].css",
```

修复后 CSS 文件名随内容变化（如 `...cba925b5.css` → `...0eecb13e.css`），CDN 自动破缓存。

## 关于 server output

**未**给 server `output` 加 CSS 字段，原因：

1. `@utoo/pack-shared` 的 `server.output` 类型在 1.4.13（当前）到 1.4.17（最新）整个 1.4.x 线都只声明 `path` / `filename` / `chunkFilename`，没有 `cssFilename` / `cssChunkFilename`（仅 client output 有）。
2. `webpackCompat` 的 CSS 归一化只作用于顶层 output，不处理 server output。
3. 语义上，CDN 缓存旧 CSS 是浏览器加载的 client 产物问题；SSR server bundle 不产出按 URL 走 CDN 的 CSS 资源。

强行加会触发 TS2353（未知属性），运行时也会被忽略。故 client-only 是类型安全且真正解决该 bug 的改法。

## 测试

新增两个用例并全部通过（`vitest run` 29/29，`tsc --noEmit` 通过，`biome check` 通过）：
- 生产模式：client `cssFilename` / `cssChunkFilename` 为 `"[name].[contenthash:8].css"`
- 开发模式：为 `"[name].css"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSS assets now use content-hashing in production builds for improved cache invalidation
  * CSS assets use stable, non-hashed names in development for easier debugging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->