### PR TITLE
[codex] Fix release dependency versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,10 @@ jobs:
         run: npm install
 
       - name: Sync version from release tag
-        run: npm pkg set version="${GITHUB_REF_NAME#v}" -ws --include-workspace-root
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          npm pkg set version="${VERSION}" -ws --include-workspace-root
+          npm run sync-release-dependencies -- --version "${VERSION}"
 
       - name: Build Packages
         run: npm run build

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -74,9 +74,10 @@ Internal `@evjs/*` runtime dependencies are kept explicit and workspace-local.
 subpaths. `@evjs/server` consumes `@evjs/client` for shared runtime types.
 `@evjs/cli` owns the default Utoopack adapter dependency, and bundler adapters
 depend on `@evjs/ev` instead of depending on each other. Internal runtime
-dependency versions stay `"*"` so release automation treats the distributed
-packages as one framework version. `@evjs/ev` exports stay limited to framework
-and build tooling entries.
+dependency versions stay `"*"` in source manifests for workspace development,
+then release automation rewrites them to the concrete release version before
+publishing.
+`@evjs/ev` exports stay limited to framework and build tooling entries.
 
 Do not reintroduce legacy split packages:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,10 +55,10 @@
   -> @hono/node-server
 ```
 
-Internal `@evjs/*` runtime dependency versions stay `"*"`. Release automation
-treats the distributed packages as one framework version, so app-facing packages
-should move together and adapters should depend on `@evjs/ev` instead of on each
-other.
+Internal `@evjs/*` runtime dependency versions stay `"*"` in source manifests
+for workspace development. Release automation rewrites those dependencies to the
+concrete release version before publishing, so app-facing packages move together
+and adapters depend on `@evjs/ev` instead of on each other.
 
 ## Coding Rules
 

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -68,8 +68,8 @@ shared contracts but does not publish runtime subpaths. `@evjs/server`
 also consumes `@evjs/client` for shared runtime types. `@evjs/cli` owns the
 default Utoopack adapter dependency, and bundler adapters depend on `@evjs/ev`
 instead of depending on each other. Internal runtime dependency versions stay
-`"*"` so release automation treats the distributed packages as one framework
-version.
+`"*"` in source manifests for workspace development, then release automation
+rewrites them to the concrete release version before publishing.
 
 Generated-only `@evjs/client/internal/*` subpaths let framework-emitted
 route declarations, page bootstraps, server-function stubs, and RSC runtime

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dev": "turbo dev",
     "lint": "biome check .",
     "format": "biome format --write .",
+    "sync-release-dependencies": "node scripts/sync-internal-dependency-versions.mjs",
 
     "check-types": "turbo check-types && tsc -p tsconfig.test.json --noEmit",
     "prepare": "husky"

--- a/packages/ev/tests/package-surface.test.ts
+++ b/packages/ev/tests/package-surface.test.ts
@@ -1,12 +1,21 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import * as buildTools from "../src/build-tools/index.js";
+
+const execFileAsync = promisify(execFile);
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../../..",
+);
+const releaseDependencyScript = path.join(
+  repoRoot,
+  "scripts/sync-internal-dependency-versions.mjs",
 );
 
 const packageDistribution = {
@@ -267,6 +276,73 @@ describe("workspace package surface", () => {
       for (const dependencyName of internalDependencies) {
         expect(packageJson.dependencies?.[dependencyName]).toBe("*");
       }
+    }
+  });
+
+  it("rewrites internal package dependency versions before publishing", async () => {
+    const tempRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "evjs-release-deps-"),
+    );
+
+    try {
+      await fs.mkdir(path.join(tempRoot, "packages"), { recursive: true });
+
+      for (const packageName of expectedPackageNames) {
+        const packageDir = path.join(
+          tempRoot,
+          "packages",
+          packageDistribution[packageName].dir,
+        );
+        const dependencies = Object.fromEntries(
+          expectedInternalRuntimeDependencies[packageName].map(
+            (dependencyName) => [dependencyName, "*"],
+          ),
+        );
+
+        await fs.mkdir(packageDir, { recursive: true });
+        await fs.writeFile(
+          path.join(packageDir, "package.json"),
+          `${JSON.stringify(
+            {
+              name: packageName,
+              version: "1.2.3",
+              ...(Object.keys(dependencies).length > 0 ? { dependencies } : {}),
+            },
+            null,
+            2,
+          )}\n`,
+        );
+      }
+
+      await execFileAsync(process.execPath, [
+        releaseDependencyScript,
+        "--root",
+        tempRoot,
+        "--version",
+        "1.2.3",
+      ]);
+
+      for (const packageName of expectedPackageNames) {
+        const packageJson = JSON.parse(
+          await fs.readFile(
+            path.join(
+              tempRoot,
+              "packages",
+              packageDistribution[packageName].dir,
+              "package.json",
+            ),
+            "utf-8",
+          ),
+        ) as PackageJson;
+
+        for (const dependencyName of expectedInternalRuntimeDependencies[
+          packageName
+        ]) {
+          expect(packageJson.dependencies?.[dependencyName]).toBe("1.2.3");
+        }
+      }
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
     }
   });
 

--- a/scripts/sync-internal-dependency-versions.mjs
+++ b/scripts/sync-internal-dependency-versions.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const defaultRootDir = path.resolve(scriptDir, "..");
+const internalScope = "@evjs/";
+
+export async function syncInternalDependencyVersions({
+  rootDir = defaultRootDir,
+  releaseVersion,
+} = {}) {
+  const packages = await readWorkspacePackages(rootDir);
+  const packagesByName = new Map(
+    packages.map((workspacePackage) => [
+      workspacePackage.packageJson.name,
+      workspacePackage,
+    ]),
+  );
+
+  if (releaseVersion) {
+    for (const workspacePackage of packages) {
+      if (workspacePackage.packageJson.version !== releaseVersion) {
+        throw new Error(
+          `${workspacePackage.relativePath} version is ${workspacePackage.packageJson.version}; expected ${releaseVersion}`,
+        );
+      }
+    }
+  }
+
+  const changes = [];
+
+  for (const workspacePackage of packages) {
+    const dependencies = workspacePackage.packageJson.dependencies;
+    if (!dependencies) continue;
+
+    let changed = false;
+    for (const dependencyName of Object.keys(dependencies).sort()) {
+      const dependencyPackage = packagesByName.get(dependencyName);
+      if (!dependencyPackage) continue;
+
+      const expectedVersion = dependencyPackage.packageJson.version;
+      const currentVersion = dependencies[dependencyName];
+      if (currentVersion === expectedVersion) continue;
+
+      dependencies[dependencyName] = expectedVersion;
+      changed = true;
+      changes.push({
+        packageName: workspacePackage.packageJson.name,
+        dependencyName,
+        from: currentVersion,
+        to: expectedVersion,
+      });
+    }
+
+    if (changed) {
+      await writePackageJson(
+        workspacePackage.packageJsonPath,
+        workspacePackage.packageJson,
+      );
+    }
+  }
+
+  return changes;
+}
+
+async function readWorkspacePackages(rootDir) {
+  const packagesDir = path.join(rootDir, "packages");
+  const entries = await fs.readdir(packagesDir, { withFileTypes: true });
+  const packages = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const packageJsonPath = path.join(packagesDir, entry.name, "package.json");
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, "utf-8"));
+    if (
+      typeof packageJson.name !== "string" ||
+      !packageJson.name.startsWith(internalScope) ||
+      packageJson.private === true
+    ) {
+      continue;
+    }
+
+    packages.push({
+      packageJson,
+      packageJsonPath,
+      relativePath: path.relative(rootDir, packageJsonPath),
+    });
+  }
+
+  return packages.sort((left, right) =>
+    left.packageJson.name.localeCompare(right.packageJson.name),
+  );
+}
+
+async function writePackageJson(packageJsonPath, packageJson) {
+  await fs.writeFile(
+    packageJsonPath,
+    `${JSON.stringify(packageJson, null, 2)}\n`,
+  );
+}
+
+function parseArgs(args) {
+  const options = { rootDir: defaultRootDir };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--root") {
+      options.rootDir = path.resolve(readRequiredArg(args, index, arg));
+      index += 1;
+      continue;
+    }
+    if (arg === "--version") {
+      options.releaseVersion = readRequiredArg(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!options.releaseVersion) {
+    throw new Error("--version is required for release dependency syncing");
+  }
+
+  return options;
+}
+
+function readRequiredArg(args, index, flag) {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/sync-internal-dependency-versions.mjs [options]
+
+Options:
+  --root <dir>       Repository root. Defaults to this checkout.
+  --version <value>  Required release version for published @evjs workspaces.
+`);
+}
+
+async function main() {
+  const changes = await syncInternalDependencyVersions(
+    parseArgs(process.argv.slice(2)),
+  );
+
+  if (changes.length === 0) {
+    console.log(
+      "Internal @evjs dependency versions already match workspace package versions.",
+    );
+    return;
+  }
+
+  console.log("Synced internal @evjs dependency versions:");
+  for (const change of changes) {
+    console.log(
+      `- ${change.packageName}: ${change.dependencyName} ${change.from} -> ${change.to}`,
+    );
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- Add a release helper that rewrites internal `@evjs/*` dependencies to the workspace package version before publishing.
- Run the helper in the release workflow after syncing package versions from the release tag.
- Cover the release rewrite in package-surface tests and update docs to distinguish source `"*"` workspace references from published concrete versions.

## Root Cause

The release workflow used `npm pkg set version="${GITHUB_REF_NAME#v}" -ws --include-workspace-root`, which updates each package's own `version` but does not rewrite internal `@evjs/*` dependency ranges. As a result, published package manifests could keep `"*"` dependencies.

## Validation

- `npm run lint`
- `npm --workspace @evjs/ev test -- tests/package-surface.test.ts`
- `npm run check-types`
- `npm test`
- `git diff --check --cached`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release automation now syncs internal workspace dependency versions to the release tag version before publishing.
  * Added a reusable version-sync command for release workflows.

* **Documentation**
  * Clarified how workspace package versions are handled during development vs. release publishing.

* **Tests**
  * Added coverage to verify internal dependency versions are rewritten correctly during release sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->