### PR TITLE
refactor: framework runtime transport wiring

### DIFF
--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -76,15 +76,17 @@ instead of depending on each other. Internal runtime dependency versions stay
 `"*"` in source manifests for workspace development, then release automation
 rewrites them to the concrete release version before publishing.
 
-Generated-only `@evjs/client/internal/*` subpaths let framework-emitted
-route declarations, page bootstraps, server-function stubs, and RSC runtime
-entries type-check. Application code should keep importing standalone CSR,
-navigation, page, transport, and RSC APIs from `@evjs/client` and should not
-import generated-only internal helpers.
+Generated-only `@evjs/client/internal/*` and `@evjs/server/internal/*`
+subpaths let framework-emitted route declarations, page bootstraps,
+server-function stubs/registrations, and RSC runtime entries type-check.
+Application code should keep importing standalone CSR, navigation, page,
+transport, and RSC APIs from `@evjs/client`, and runtime server APIs from
+`@evjs/server`; it should not import generated-only internal helpers.
 Examples include `@evjs/client/internal/route-types` for generated SPA
 route declarations, `@evjs/client/internal/server-functions` for generated
-`"use server"` client stubs, and `@evjs/client/internal/rsc-runtime` for RSC
-page bootstraps.
+`"use server"` client stubs, `@evjs/server/internal/server-functions` for
+generated `"use server"` server registrations, and
+`@evjs/client/internal/rsc-runtime` for RSC page bootstraps.
 
 Do not reintroduce legacy split packages such as `@evjs/build-tools`,
 `@evjs/manifest`, or `@evjs/router-*`. Build helpers are exported from

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
@@ -66,13 +66,17 @@ runtime subpath；`@evjs/server` 会消费 `@evjs/client` 中的共享 runtime
 `@evjs/ev`，而不是彼此依赖。内部 runtime 依赖版本保持为 `"*"`，让发布自动化
 把所有分发包作为同一个框架版本处理。
 
-生成专用的 `@evjs/client/internal/*` subpath 用于让框架生成的路由声明、
-page bootstrap、server-function stub 和 RSC runtime entry 完成类型检查。
-应用代码仍应从 `@evjs/client` 导入 standalone CSR、导航、page、transport
-和 RSC API，不要导入这些生成专用的 internal helper。
+生成专用的 `@evjs/client/internal/*` 和 `@evjs/server/internal/*`
+subpath 用于让框架生成的路由声明、page bootstrap、server-function
+stub/registration 和 RSC runtime entry 完成类型检查。应用代码仍应从
+`@evjs/client` 导入 standalone CSR、导航、page、transport 和 RSC API，
+从 `@evjs/server` 导入 server runtime API，不要导入这些生成专用的
+internal helper。
 例如，`@evjs/client/internal/route-types` 用于生成的 SPA 路由声明，
 `@evjs/client/internal/server-functions` 用于生成的 `"use server"` 客户端
-stub，`@evjs/client/internal/rsc-runtime` 用于 RSC page bootstrap。
+stub，`@evjs/server/internal/server-functions` 用于生成的 `"use server"`
+服务端 registration，`@evjs/client/internal/rsc-runtime` 用于 RSC page
+bootstrap。
 
 不要重新引入 `@evjs/build-tools`、`@evjs/manifest` 或 `@evjs/router-*`
 这类历史拆分包。构建 helper 从 `@evjs/ev/build-tools` 导出，manifest

--- a/packages/ev/src/build-tools/types.ts
+++ b/packages/ev/src/build-tools/types.ts
@@ -25,8 +25,8 @@ export interface TransformOptions {
  * URLs and browser-facing origins live in config/manifest runtime fields.
  */
 export const SERVER_FUNCTION_TRANSFORM_RUNTIME = {
-  /** Module path for server-side function registration (no Hono dependency). */
-  serverModule: "@evjs/server/register",
+  /** Module path for generated server-side function registrations. */
+  serverModule: "@evjs/server/internal/server-functions",
   /** Module path for generated client-side server reference stubs. */
   clientModule: "@evjs/client/internal/server-functions",
   /** Server-side function registration (RSC convention). */

--- a/packages/ev/tests/package-surface.test.ts
+++ b/packages/ev/tests/package-surface.test.ts
@@ -198,15 +198,16 @@ const expectedServerSubpathExports = [
   "./app",
   "./fetch",
   "./framework",
+  "./internal/server-functions",
   "./node",
   "./react",
-  "./register",
 ] as const;
 
 const forbiddenServerSubpathExports = [
   "./context",
   "./ecma",
   "./functions",
+  "./register",
   "./middleware",
   "./routes",
 ] as const;
@@ -814,7 +815,7 @@ describe("workspace package surface", () => {
       parseEvjsImportSpecifiers(`
         import { defineConfig } from "@evjs/ev";
         import { createRoute } from "@evjs/server";
-        import "@evjs/server/register";
+        import "@evjs/server/internal/server-functions";
         export { createApp } from "@evjs/server";
         export * from "@evjs/client/internal";
         const runtime = import("@evjs/shared/manifest");
@@ -822,7 +823,7 @@ describe("workspace package surface", () => {
     ).toEqual([
       "@evjs/ev",
       "@evjs/server",
-      "@evjs/server/register",
+      "@evjs/server/internal/server-functions",
       "@evjs/server",
       "@evjs/client/internal",
       "@evjs/shared/manifest",
@@ -954,6 +955,11 @@ describe("workspace package surface", () => {
     expect(exportedSubpaths).not.toEqual(
       expect.arrayContaining([...forbiddenServerSubpathExports]),
     );
+    expect(serverPackageJson.exports?.["./internal/server-functions"]).toEqual({
+      types: "./esm/server-function-runtime.d.ts",
+      import: "./esm/server-function-runtime.js",
+      default: "./esm/server-function-runtime.js",
+    });
 
     const readme = await fs.readFile(
       path.join(repoRoot, "packages/server/README.md"),

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -46,10 +46,10 @@
       "import": "./esm/index.js",
       "default": "./esm/index.js"
     },
-    "./register": {
-      "types": "./esm/functions/register.d.ts",
-      "import": "./esm/functions/register.js",
-      "default": "./esm/functions/register.js"
+    "./internal/server-functions": {
+      "types": "./esm/server-function-runtime.d.ts",
+      "import": "./esm/server-function-runtime.js",
+      "default": "./esm/server-function-runtime.js"
     },
     "./node": {
       "types": "./esm/runtimes/node.d.ts",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,8 +5,8 @@
  * - @evjs/server/node
  * - @evjs/server/fetch
  *
- * For minimal function registration (no Hono), use:
- * - @evjs/server/register
+ * Framework-generated server function registrations use:
+ * - @evjs/server/internal/server-functions
  */
 
 export { ServerError } from "@evjs/shared";

--- a/packages/server/src/server-function-runtime.ts
+++ b/packages/server/src/server-function-runtime.ts
@@ -1,0 +1,8 @@
+/**
+ * Framework-generated server function registrations.
+ *
+ * Generated `"use server"` server modules import this focused internal subpath
+ * instead of a generic runtime registration entry.
+ */
+
+export { registerServerReference } from "./functions/register.js";


### PR DESCRIPTION
## Summary

- Separate server function transform module paths from browser-facing transport/runtime URL config.
- Move generated client stubs to `@evjs/client/internal/server-functions` and generated server registrations to `@evjs/server/internal/server-functions`.
- Reuse `transport.baseUrl` for framework runtime requests such as server functions and RSC Flight, while keeping runtime package surfaces explicit.
- Update package-surface guardrails and architecture docs for the generated-only internal subpaths.

## Validation

- `npm --workspace @evjs/ev test -- package-surface build-tools-transforms`
- `npm --workspace @evjs/server run check-types`
- `npm run lint`
- `npm run check-types`
- `git diff --check`

Note: full `npm test` locally still times out in the existing `@evjs/bundler-webpack` dev-server rollback test when run as part of the workspace; the failed test passed when rerun directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new server function runtime entry point for framework-generated server actions.
  * Updated the server package export surface to use the new internal server-functions path.

* **Documentation**
  * Clarified import guidance for public client/server APIs versus generated internal helpers.
  * Expanded examples for framework-generated routing, page startup, server function handling, and RSC runtime usage.

* **Tests**
  * Updated package-surface checks to reflect the new export path and removal of the older server registration path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->