### PR TITLE
refactor(runtime): tighten generated runtime contracts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,13 +21,14 @@ src/pages + src/apis + src/middleware.ts + ev.config.ts
   -> AppGraph
   -> BuildPlan
   -> selected bundler adapter
-  -> BuildOutput / dist/server/manifest.json or dist/manifest.json
-  -> client runtime, server runtime, deployment adapters
+  -> BuildOutput / dist/client/manifest.json / dist/server/manifest.json
+  -> ClientRuntime / FrameworkRuntime contracts / deployment adapters
 ```
 
 Framework semantics are owned by `@evjs/ev` and `@evjs/shared/manifest`.
 Bundlers own module graphs, chunks, assets, dev HMR, and stats. Runtime packages
-consume `BuildOutput` rather than raw bundler stats.
+consume generated runtime contracts rather than `BuildOutput` or manifest
+artifacts.
 
 ## Package Shape
 
@@ -148,15 +149,16 @@ the bundler dev instance.
   mounts standalone CSR apps and framework-managed React pages
 
 @evjs/client/internal
-  reads BuildOutput, activates app/page modules, preloads modules, and disposes
-  lifecycles
+  reads generated ClientRuntime, activates app/page modules, preloads modules,
+  and disposes lifecycles
 
 @evjs/server
   owns server functions, standalone REST route primitives, SSR document
   rendering, PPR region rendering, and RSC Flight endpoint routing
 
 deployment adapters
-  translate BuildOutput to platform artifacts and bootstraps
+  translate BuildOutput to platform artifacts and injected FrameworkRuntime
+  bootstraps
 ```
 
 TanStack Router is available through the `@evjs/client` standalone CSR surface
@@ -167,15 +169,16 @@ and navigation helpers instead of constructing route trees directly.
 ## Manifest
 
 The framework output contract is `BuildOutput`. Builds serialize the complete
-contract to:
+private contract to:
 
 ```txt
-dist/server/manifest.json
+dist/build-output.json
 ```
 
-They also emit a browser-safe public manifest to `output.client` and a server
-bundle manifest to `output.server`. Deployment plugins and platform adapters
-should consume `BuildOutput`.
+They also emit deployment-focused client/server manifests to `output.client`
+and `output.server`, plus a generated browser `runtime.json`. Deployment
+plugins and platform adapters should consume `BuildOutput`; generated runtimes
+consume minimal `ClientRuntime` and injected `FrameworkRuntime` contracts.
 
 ## Deployment
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -179,6 +179,9 @@ They also emit deployment-focused client/server manifests to `output.client`
 and `output.server`, plus a generated browser `runtime.json`. Deployment
 plugins and platform adapters should consume `BuildOutput`; generated runtimes
 consume minimal `ClientRuntime` and injected `FrameworkRuntime` contracts.
+Routes in these artifacts are URL-to-app/page indexes. Page behavior stays
+under page records, and framework endpoint data stays under runtime/server
+projections instead of being repeated on every route.
 
 ## Deployment
 

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -2,10 +2,11 @@
 
 evjs is a React framework built around file conventions, explicit source
 declarations, a framework graph, a bundler-independent build plan, and one
-runtime manifest. The framework-owned route model is file-based: client pages
-come from `src/pages`, server file routes come from `src/apis`, and server
-middleware is split between framework request middleware in `src/middleware.ts`
-and API route middleware in `src/apis/**/middleware.ts`.
+private build output contract with generated runtime projections. The
+framework-owned route model is file-based: client pages come from `src/pages`,
+server file routes come from `src/apis`, and server middleware is split between
+framework request middleware in `src/middleware.ts` and API route middleware in
+`src/apis/**/middleware.ts`.
 
 ```txt
 src/pages + src/apis + src/middleware.ts + ev.config.ts
@@ -164,10 +165,17 @@ sequenceDiagram
 ```
 
 Builds emit the complete private `BuildOutput` handoff artifact at
-`dist/build-output.json`. The public manifest path comes from `output.client`;
-the server manifest path comes from `output.server`. Deployment adapters may
-embed equivalent runtime data into platform files, so deployed server runtimes
-do not have to read `dist/build-output.json` at startup.
+`dist/build-output.json`. The client and server manifest paths come from
+`output.client` and `output.server`; those files are deployment/tooling
+metadata. Browser bootstraps consume a generated `runtime.json` projection, and
+deployment adapters embed equivalent `FrameworkRuntime` data into platform
+server files, so deployed server runtimes do not read `dist/build-output.json`
+or manifest files at startup.
+The browser runtime projection is intentionally smaller than the public
+manifest: it keeps only the build id, transport base URL, RSC endpoint,
+app/page module targets, mount selectors, and route lookup data needed to boot
+or navigate. Asset indexes, deployment metadata, source references, and
+renderer bundle metadata stay in manifests or `BuildOutput`.
 
 TanStack Router is available through the `@evjs/client` standalone CSR surface
 for manual browser applications. In framework-managed apps, `@evjs/ev` owns
@@ -183,12 +191,13 @@ sequenceDiagram
   participant Shell as "@evjs/ev/internal/client"
   participant Runtime as "@evjs/ev/page"
   participant Server as "@evjs/ev/internal/server"
-  participant Manifest as "BuildOutput"
+  participant ClientRuntime as "ClientRuntime"
+  participant FrameworkRuntime as "FrameworkRuntime"
 
   Browser->>Runtime: page/app boot
-  Runtime->>Manifest: load embedded or /manifest.json
+  Runtime->>ClientRuntime: load embedded or /runtime.json
   Runtime->>Shell: create internal shell
-  Shell->>Manifest: resolve app/page target
+  Shell->>ClientRuntime: resolve app/page target
   Shell->>Browser: import JS/CSS module assets
   Shell->>Runtime: mount/hydrate/unmount lifecycle
 
@@ -197,16 +206,16 @@ sequenceDiagram
   Server-->>Browser: JSON result/error
 
   Browser->>Server: GET page route
-  Server->>Manifest: match route/page/renderer
+  Server->>FrameworkRuntime: match route/page/renderer
   Server-->>Browser: SSR HTML
 
   Browser->>Server: GET PPR page route
-  Server->>Manifest: match shell and region renderers
+  Server->>FrameworkRuntime: match shell and region renderers
   Server->>Server: render/cache internal regions
   Server-->>Browser: PPR HTML in the same route response
 
   Browser->>Server: GET runtime.server.rsc?page=id
-  Server->>Manifest: read RSC renderer and reference manifests
+  Server->>FrameworkRuntime: read RSC renderer and reference manifests
   Server-->>Browser: React Flight stream
 ```
 
@@ -257,7 +266,7 @@ boundaries is not implemented yet, and the current compatibility splitter only
 creates internal region renderers for the limited `Suspense` + direct
 `lazy(() => import(...))` shape. Region ids are opaque framework details.
 
-PPR page hydration is page-level `none` in the public manifest. Client
+PPR page hydration is page-level `none` in the client runtime. Client
 interactivity should be introduced through explicit client islands or
 region-level hydration metadata, not by hydrating the whole PPR shell.
 
@@ -389,9 +398,9 @@ Platform-specific adapters should derive their routing, framework endpoint, SSR,
 PPR, RSC, and asset metadata from `BuildOutput` instead of reading bundler stats.
 Build-pipeline adapters receive that object in memory; post-build tools can read
 `dist/build-output.json`.
-Full BuildOutput manifests retain source modules and server renderer references;
-public/browser manifests keep the same routing and asset shape but redact those
-server-only fields, so client-side validation treats them as optional.
+Full BuildOutput manifests retain source modules and server renderer references.
+Client/server manifests are deployment metadata; generated browser and server
+runtimes consume minimal ClientRuntime and FrameworkRuntime contracts.
 
 The deployment model is capability-driven:
 

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -176,6 +176,9 @@ manifest: it keeps only the build id, transport base URL, RSC endpoint,
 app/page module targets, mount selectors, and route lookup data needed to boot
 or navigate. Asset indexes, deployment metadata, source references, and
 renderer bundle metadata stay in manifests or `BuildOutput`.
+In `BuildOutput` and public manifests, client routes are URL-to-target indexes.
+Page rendering, hydration, and component model metadata stay under `pages`, and
+framework endpoints stay under runtime/server projections.
 
 TanStack Router is available through the `@evjs/client` standalone CSR surface
 for manual browser applications. In framework-managed apps, `@evjs/ev` owns
@@ -401,6 +404,8 @@ Build-pipeline adapters receive that object in memory; post-build tools can read
 Full BuildOutput manifests retain source modules and server renderer references.
 Client/server manifests are deployment metadata; generated browser and server
 runtimes consume minimal ClientRuntime and FrameworkRuntime contracts.
+Deployment artifacts group framework endpoint and transport data under their
+server section instead of duplicating the raw runtime object.
 
 The deployment model is capability-driven:
 

--- a/docs/docs/build.md
+++ b/docs/docs/build.md
@@ -30,7 +30,8 @@ dist/
 │   ├── index.html
 │   ├── main.[hash].js
 │   ├── [chunk].[hash].js
-│   └── manifest.json
+│   ├── manifest.json
+│   └── runtime.json
 └── server/
     ├── main.[hash].js
     └── manifest.json
@@ -58,14 +59,17 @@ dist/
 ├── index.html
 ├── main.[hash].js
 ├── [chunk].[hash].js
-└── manifest.json
+├── manifest.json
+└── runtime.json
 dist-server/
 ├── main.[hash].js
 └── manifest.json
 ```
 
-`manifest.json` files are generated for evjs runtime and deployment tooling.
-Application code should not import or edit them.
+`runtime.json` is generated browser runtime configuration with only boot,
+navigation, transport, and RSC endpoint data. `manifest.json` files and
+`build-output.json` are generated deployment/tooling metadata.
+Application code should not import or edit these files.
 
 ## Page Output
 

--- a/docs/docs/build.md
+++ b/docs/docs/build.md
@@ -68,7 +68,9 @@ dist-server/
 
 `runtime.json` is generated browser runtime configuration with only boot,
 navigation, transport, and RSC endpoint data. `manifest.json` files and
-`build-output.json` are generated deployment/tooling metadata.
+`build-output.json` are generated deployment/tooling metadata. Client route
+entries are URL-to-app/page indexes; page rendering behavior stays on page
+records, and runtime endpoints stay out of the public client manifest.
 Application code should not import or edit these files.
 
 ## Page Output

--- a/docs/docs/deploy.md
+++ b/docs/docs/deploy.md
@@ -20,6 +20,7 @@ Typical output:
 dist/
 ├── client/
 │   ├── manifest.json
+│   ├── runtime.json
 │   └── ...
 ├── server/
 │   ├── manifest.json
@@ -30,14 +31,17 @@ dist/
 Important paths:
 
 - `dist/client/`: browser assets and generated HTML.
-- `dist/client/manifest.json`: browser-safe route, asset, and runtime metadata.
+- `dist/client/manifest.json`: browser-safe route and asset metadata for
+  deployment tooling.
+- `dist/client/runtime.json`: minimal browser runtime configuration loaded by
+  generated page bootstraps when it is not embedded in HTML.
 - `dist/server/`: server bundle and server metadata when the app uses server
   functions, server file routes, SSR, PPR, or RSC.
 - `dist/build-output.json`: complete build metadata for tooling and deployment
   adapters. Application code should not import or edit it.
 
-If page HTML does not embed the manifest, the browser runtime fetches it from
-the configured manifest URL or `/manifest.json`. Serve that response as JSON
+If page HTML does not embed the runtime config, the browser runtime fetches it
+from the configured runtime URL or `/runtime.json`. Serve that response as JSON
 with `Content-Type: application/json`.
 
 ## Choose A Target

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
@@ -1,9 +1,9 @@
 # 架构
 
 evjs 是围绕文件约定、显式 source declaration、框架 graph、bundler 无关 build
-plan，以及单一 runtime manifest 构建的 React 框架。框架托管的路由模型是文件化的：
-客户端页面来自 `src/pages`，服务端文件路由来自 `src/apis`，server middleware
-分成 `src/middleware.ts` 中的 framework request middleware，以及
+plan、私有 BuildOutput 契约和生成的 runtime 投影构建的 React 框架。框架托管的路由模型
+是文件化的：客户端页面来自 `src/pages`，服务端文件路由来自 `src/apis`，server
+middleware 分成 `src/middleware.ts` 中的 framework request middleware，以及
 `src/apis/**/middleware.ts` 中的 API route middleware。
 
 ```txt
@@ -157,9 +157,14 @@ sequenceDiagram
 ```
 
 构建会在 `dist/build-output.json` 输出完整私有 `BuildOutput` handoff artifact。
-public manifest 路径来自 `output.client`，server manifest 路径来自
-`output.server`。Deployment adapter 可以把等价的 runtime 数据内嵌进平台产物，
-因此已部署的 server runtime 不必在启动时读取 `dist/build-output.json`。
+client/server manifest 路径来自 `output.client` 和 `output.server`；这些文件是部署/工具
+元信息。浏览器 bootstrap 消费生成的 `runtime.json` 投影，Deployment adapter 会把等价的
+`FrameworkRuntime` 数据内嵌进平台服务端产物，因此已部署的 server runtime 不会在启动时读取
+`dist/build-output.json` 或 manifest 文件。
+浏览器运行时投影刻意小于 public manifest：只保留启动和导航需要的 build id、
+transport base URL、RSC endpoint、app/page module target、mount selector 和 route
+lookup 数据。资源索引、部署元信息、源码引用和 renderer bundle 元信息留在 manifest 或
+`BuildOutput` 中。
 
 ## 运行时流程
 
@@ -169,12 +174,13 @@ sequenceDiagram
   participant Shell as "@evjs/ev/internal/client"
   participant Runtime as "@evjs/ev/page"
   participant Server as "@evjs/ev/internal/server"
-  participant Manifest as "BuildOutput"
+  participant ClientRuntime as "ClientRuntime"
+  participant FrameworkRuntime as "FrameworkRuntime"
 
   Browser->>Runtime: page/app boot
-  Runtime->>Manifest: load embedded or /manifest.json
+  Runtime->>ClientRuntime: load embedded or /runtime.json
   Runtime->>Shell: create internal shell
-  Shell->>Manifest: resolve app/page target
+  Shell->>ClientRuntime: resolve app/page target
   Shell->>Browser: import JS/CSS module assets
   Shell->>Runtime: mount/hydrate/unmount lifecycle
 
@@ -183,16 +189,16 @@ sequenceDiagram
   Server-->>Browser: JSON result/error
 
   Browser->>Server: GET page route
-  Server->>Manifest: match route/page/renderer
+  Server->>FrameworkRuntime: match route/page/renderer
   Server-->>Browser: SSR HTML
 
   Browser->>Server: GET PPR page route
-  Server->>Manifest: match shell and region renderers
+  Server->>FrameworkRuntime: match shell and region renderers
   Server->>Server: render/cache internal regions
   Server-->>Browser: PPR HTML in the same route response
 
   Browser->>Server: GET runtime.server.rsc?page=id
-  Server->>Manifest: read RSC renderer and reference manifests
+  Server->>FrameworkRuntime: read RSC renderer and reference manifests
   Server-->>Browser: React Flight stream
 ```
 
@@ -239,7 +245,7 @@ runtime postponed/resume 尚未实现，当前兼容 splitter 只会为受限的
 直接 `lazy(() => import(...))` 形态生成内部 region renderer。Region id 是框架
 内部 opaque 细节。
 
-PPR 页面在 public manifest 中的 page-level hydration 是 `none`。需要客户端交互时，
+PPR 页面在 client runtime 中的 page-level hydration 是 `none`。需要客户端交互时，
 应通过显式 client islands 或 region-level hydration metadata 引入，而不是 hydrate 整个
 PPR shell。
 
@@ -356,9 +362,9 @@ Deployment adapter 消费 `BuildOutput`。`@evjs/ev` 提供：
 
 平台专属 adapter 应从 `BuildOutput` 派生 routing、framework endpoint、SSR、PPR、RSC 和 asset metadata，而不是读取 bundler stats。
 构建流水线中的 adapter 会在内存里收到这个对象；构建后的工具可以读取 `dist/build-output.json`。
-完整 BuildOutput manifest 会保留源码 module 和 server renderer reference；公开/浏览器
-manifest 保持相同的 routing 与 asset 结构，但会脱敏这些 server-only 字段，因此客户端
-校验会把它们视为可选。
+完整 BuildOutput manifest 会保留源码 module 和 server renderer reference。client/server
+manifest 是部署元信息；生成的浏览器和服务端运行时消费最小化的 ClientRuntime 和
+FrameworkRuntime contract。
 
 部署模型由能力分类驱动：
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
@@ -165,6 +165,9 @@ client/server manifest 路径来自 `output.client` 和 `output.server`；这些
 transport base URL、RSC endpoint、app/page module target、mount selector 和 route
 lookup 数据。资源索引、部署元信息、源码引用和 renderer bundle 元信息留在 manifest 或
 `BuildOutput` 中。
+在 `BuildOutput` 和公开 manifest 中，client route 是 URL 到目标的索引。页面渲染、
+hydrate 和 component model 元信息留在 `pages` 下，framework endpoint 留在 runtime/server
+投影下。
 
 ## 运行时流程
 
@@ -365,6 +368,8 @@ Deployment adapter 消费 `BuildOutput`。`@evjs/ev` 提供：
 完整 BuildOutput manifest 会保留源码 module 和 server renderer reference。client/server
 manifest 是部署元信息；生成的浏览器和服务端运行时消费最小化的 ClientRuntime 和
 FrameworkRuntime contract。
+Deployment artifact 会把 framework endpoint 和 transport 数据归到 server 分组下，而不是
+重复携带原始 runtime 对象。
 
 部署模型由能力分类驱动：
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
@@ -65,7 +65,9 @@ dist-server/
 ```
 
 `runtime.json` 是只包含启动、导航、transport 和 RSC endpoint 数据的浏览器运行时配置。
-`manifest.json` 和 `build-output.json` 是部署/工具元信息。应用代码不应该导入或修改这些文件。
+`manifest.json` 和 `build-output.json` 是部署/工具元信息。client route 条目只是
+URL 到 app/page 的索引；页面渲染行为保留在 page 记录上，runtime endpoint 不进入公开
+client manifest。应用代码不应该导入或修改这些文件。
 
 ## 页面输出
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
@@ -29,7 +29,8 @@ dist/
 │   ├── index.html
 │   ├── main.[hash].js
 │   ├── [chunk].[hash].js
-│   └── manifest.json
+│   ├── manifest.json
+│   └── runtime.json
 └── server/
     ├── main.[hash].js
     └── manifest.json
@@ -56,13 +57,15 @@ dist/
 ├── index.html
 ├── main.[hash].js
 ├── [chunk].[hash].js
-└── manifest.json
+├── manifest.json
+└── runtime.json
 dist-server/
 ├── main.[hash].js
 └── manifest.json
 ```
 
-`manifest.json` 是 evjs runtime 和部署工具使用的生成文件。应用代码不应该导入或修改它们。
+`runtime.json` 是只包含启动、导航、transport 和 RSC endpoint 数据的浏览器运行时配置。
+`manifest.json` 和 `build-output.json` 是部署/工具元信息。应用代码不应该导入或修改这些文件。
 
 ## 页面输出
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deploy.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deploy.md
@@ -19,6 +19,7 @@ npm run build
 dist/
 ├── client/
 │   ├── manifest.json
+│   ├── runtime.json
 │   └── ...
 ├── server/
 │   ├── manifest.json
@@ -29,12 +30,13 @@ dist/
 重要路径：
 
 - `dist/client/`：浏览器资源和生成的 HTML。
-- `dist/client/manifest.json`：浏览器安全的路由、资源和运行时元信息。
+- `dist/client/manifest.json`：给部署工具消费的浏览器安全路由和资源元信息。
+- `dist/client/runtime.json`：生成的页面 bootstrap 在 HTML 未内嵌配置时加载的最小浏览器运行时配置。
 - `dist/server/`：应用使用服务端函数、服务端文件路由、SSR、PPR 或 RSC 时生成的服务端 bundle 和服务端元信息。
 - `dist/build-output.json`：面向工具和部署 adapter 的完整构建元信息。应用代码不应导入或修改它。
 
-如果页面 HTML 没有内嵌 manifest，浏览器 runtime 会从配置的 manifest URL 或
-`/manifest.json` 获取它。部署时应把该响应作为 JSON 返回，并设置
+如果页面 HTML 没有内嵌 runtime config，浏览器 runtime 会从配置的 runtime URL 或
+`/runtime.json` 获取它。部署时应把该响应作为 JSON 返回，并设置
 `Content-Type: application/json`。
 
 ## 选择部署目标

--- a/e2e/cases/render-modes.ts
+++ b/e2e/cases/render-modes.ts
@@ -254,6 +254,7 @@ test.describe("render-modes", () => {
   test("emits a manifest with app, page, route, and server data", async () => {
     const manifestPath = getRenderModesPublicManifestPath();
     const manifest = readRenderModesPublicManifest();
+    const buildOutput = readRenderModesBuildOutput();
 
     expect(manifest.apps.default).toEqual(
       expect.objectContaining({
@@ -371,14 +372,14 @@ test.describe("render-modes", () => {
         }),
       ]),
     );
-    expect(Object.values(manifest.server.functions)).toEqual(
+    expect(Object.values(buildOutput.server.functions)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           exportName: "getMerchantOperationsSnapshot",
         }),
       ]),
     );
-    expect(manifest.server.routes).toEqual(
+    expect(buildOutput.server.routes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           path: "/api/render-modes/health",
@@ -386,7 +387,7 @@ test.describe("render-modes", () => {
         }),
       ]),
     );
-    expect(manifest.runtime.server).toEqual(
+    expect(buildOutput.runtime.server).toEqual(
       expect.objectContaining({
         basePath: "/__evjs",
         fn: "/__evjs/fn",
@@ -394,7 +395,7 @@ test.describe("render-modes", () => {
         rsc: "/__evjs/rsc",
       }),
     );
-    expect(manifest.rsc.pages.insights).toEqual(
+    expect(buildOutput.rsc.pages.insights).toEqual(
       expect.objectContaining({
         renderer: "insights-rsc",
         routeId: "insights",
@@ -439,6 +440,15 @@ function getRenderModesPublicManifestPath(): string {
 function readRenderModesPublicManifest() {
   return JSON.parse(
     fs.readFileSync(getRenderModesPublicManifestPath(), "utf-8"),
+  );
+}
+
+function readRenderModesBuildOutput() {
+  return JSON.parse(
+    fs.readFileSync(
+      path.join(exampleDir, "dist", "build-output.json"),
+      "utf-8",
+    ),
   );
 }
 

--- a/e2e/fixtures-ws.ts
+++ b/e2e/fixtures-ws.ts
@@ -2,7 +2,9 @@ import { execSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import { createServer } from "node:net";
 import path from "node:path";
+import type { BuildOutput } from "@evjs/shared/manifest";
 import { test as base, expect } from "@playwright/test";
+import { createFrameworkRuntime } from "../packages/ev/src/framework-runtime";
 
 export { expect };
 
@@ -52,8 +54,8 @@ export function createWebSocketExampleTest() {
           stdio: "pipe",
         });
 
-        // 2. Read the server manifest for the bundle entry and the full
-        // BuildOutput for framework bootstrap.
+        // 2. Read the server manifest for the bundle entry and project the
+        // BuildOutput into the framework runtime for bootstrap.
         const serverManifestPath = path.join(
           exampleDir,
           "dist",
@@ -73,6 +75,19 @@ export function createWebSocketExampleTest() {
           exampleDir,
           "dist",
           "build-output.json",
+        );
+        const buildOutput = JSON.parse(
+          fs.readFileSync(buildOutputPath, "utf-8"),
+        ) as BuildOutput;
+        const frameworkRuntimePath = path.join(
+          exampleDir,
+          "dist",
+          "_e2e_framework_runtime.json",
+        );
+        fs.writeFileSync(
+          frameworkRuntimePath,
+          JSON.stringify(createFrameworkRuntime(buildOutput), null, 2),
+          "utf-8",
         );
         const serverEntryPath = path.join(
           exampleDir,
@@ -95,7 +110,7 @@ export function createWebSocketExampleTest() {
             ...process.env,
             SERVER_ENTRY: serverEntryPath,
             CLIENT_DIR: clientDir,
-            MANIFEST_PATH: buildOutputPath,
+            FRAMEWORK_RUNTIME_PATH: frameworkRuntimePath,
             PORT: String(webPort),
           },
         });

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -34,7 +34,7 @@ interface WorkerFixture {
   _exampleApp: { webPort: number; apiPort: number };
 }
 
-type ClientRuntimeFixture = Pick<
+type RoutingFixture = Pick<
   BuildOutput,
   "apps" | "pages" | "routes" | "runtime"
 >;
@@ -210,28 +210,26 @@ function pathMatchesPrefix(pathname: string, prefix: string): boolean {
   );
 }
 
-function getServerProxyPrefixes(runtime: ClientRuntimeFixture): string[] {
+function getServerProxyPrefixes(output: RoutingFixture): string[] {
   return compactUnique([
     "/api",
     "/__evjs",
-    runtime.runtime?.server?.basePath,
-    runtime.runtime?.server?.fn,
-    runtime.runtime?.server?.ppr,
-    runtime.runtime?.server?.rsc,
-    ...getServerRenderedPaths(runtime),
+    output.runtime?.server?.basePath,
+    output.runtime?.server?.fn,
+    output.runtime?.server?.ppr,
+    output.runtime?.server?.rsc,
+    ...getServerRenderedPaths(output),
   ]);
 }
 
-function getClientPathRewrites(
-  runtime: ClientRuntimeFixture,
-): Record<string, string> {
+function getClientPathRewrites(output: RoutingFixture): Record<string, string> {
   const rewrites = Object.fromEntries(
-    Object.entries(runtime.pages ?? {}).flatMap(([pageId, page]) =>
+    Object.entries(output.pages ?? {}).flatMap(([pageId, page]) =>
       page.path && page.render === "csr" ? [[page.path, `${pageId}.html`]] : [],
     ),
   );
 
-  for (const { path, target } of getClientRouteMatches(runtime)) {
+  for (const { path, target } of getClientRouteMatches(output)) {
     rewrites[path] ??= getClientRouteHtmlFileName(target);
   }
 
@@ -363,16 +361,9 @@ export function createExampleTest(exampleName: string) {
 
         await buildExample(exampleDir, bundlerName);
 
-        // Read the client runtime for client routing and the server manifest
+        // Read BuildOutput for fixture routing and the server manifest
         // for the bundle entry. BuildOutput stays in the fixture process and
         // is projected before the server bootstrap sees it.
-        const runtimePath = path.join(
-          exampleDir,
-          "dist",
-          "client",
-          "runtime.json",
-        );
-        const runtime = JSON.parse(fs.readFileSync(runtimePath, "utf-8"));
         const serverManifestPath = path.join(
           exampleDir,
           "dist",
@@ -455,8 +446,8 @@ export function createExampleTest(exampleName: string) {
         const distDir = path.join(exampleDir, "dist", "client");
         const staticServer = createStaticServer(distDir, {
           apiPort,
-          proxyPrefixes: getServerProxyPrefixes(runtime),
-          pathRewrites: getClientPathRewrites(runtime),
+          proxyPrefixes: getServerProxyPrefixes(buildOutput),
+          pathRewrites: getClientPathRewrites(buildOutput),
         });
 
         await new Promise<void>((resolve) => {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -19,6 +19,7 @@ import {
   getServerRenderedPaths,
 } from "@evjs/shared/manifest";
 import { test as base, expect } from "@playwright/test";
+import { createFrameworkRuntime } from "../packages/ev/src/framework-runtime";
 
 export { expect };
 
@@ -33,7 +34,7 @@ interface WorkerFixture {
   _exampleApp: { webPort: number; apiPort: number };
 }
 
-type RuntimeManifestFixture = Pick<
+type ClientRuntimeFixture = Pick<
   BuildOutput,
   "apps" | "pages" | "routes" | "runtime"
 >;
@@ -209,28 +210,28 @@ function pathMatchesPrefix(pathname: string, prefix: string): boolean {
   );
 }
 
-function getServerProxyPrefixes(manifest: RuntimeManifestFixture): string[] {
+function getServerProxyPrefixes(runtime: ClientRuntimeFixture): string[] {
   return compactUnique([
     "/api",
     "/__evjs",
-    manifest.runtime?.server?.basePath,
-    manifest.runtime?.server?.fn,
-    manifest.runtime?.server?.ppr,
-    manifest.runtime?.server?.rsc,
-    ...getServerRenderedPaths(manifest),
+    runtime.runtime?.server?.basePath,
+    runtime.runtime?.server?.fn,
+    runtime.runtime?.server?.ppr,
+    runtime.runtime?.server?.rsc,
+    ...getServerRenderedPaths(runtime),
   ]);
 }
 
 function getClientPathRewrites(
-  manifest: RuntimeManifestFixture,
+  runtime: ClientRuntimeFixture,
 ): Record<string, string> {
   const rewrites = Object.fromEntries(
-    Object.entries(manifest.pages ?? {}).flatMap(([pageId, page]) =>
+    Object.entries(runtime.pages ?? {}).flatMap(([pageId, page]) =>
       page.path && page.render === "csr" ? [[page.path, `${pageId}.html`]] : [],
     ),
   );
 
-  for (const { path, target } of getClientRouteMatches(manifest)) {
+  for (const { path, target } of getClientRouteMatches(runtime)) {
     rewrites[path] ??= getClientRouteHtmlFileName(target);
   }
 
@@ -362,17 +363,16 @@ export function createExampleTest(exampleName: string) {
 
         await buildExample(exampleDir, bundlerName);
 
-        // Read the public manifest for client routing, the server manifest for
-        // the bundle entry, and the full BuildOutput for framework bootstrap.
-        // The public manifest is browser-safe and intentionally does not
-        // expose server entry files.
-        const manifestPath = path.join(
+        // Read the client runtime for client routing and the server manifest
+        // for the bundle entry. BuildOutput stays in the fixture process and
+        // is projected before the server bootstrap sees it.
+        const runtimePath = path.join(
           exampleDir,
           "dist",
           "client",
-          "manifest.json",
+          "runtime.json",
         );
-        const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+        const runtime = JSON.parse(fs.readFileSync(runtimePath, "utf-8"));
         const serverManifestPath = path.join(
           exampleDir,
           "dist",
@@ -391,6 +391,10 @@ export function createExampleTest(exampleName: string) {
           "dist",
           "build-output.json",
         );
+        const buildOutput = JSON.parse(
+          fs.readFileSync(buildOutputPath, "utf-8"),
+        ) as BuildOutput;
+        const frameworkRuntime = createFrameworkRuntime(buildOutput);
         const serverEntryPath = path.join(
           exampleDir,
           "dist",
@@ -407,8 +411,7 @@ export function createExampleTest(exampleName: string) {
             `const fs = require("node:fs");`,
             `const path = require("node:path");`,
             `const { pathToFileURL } = require("node:url");`,
-            `const manifest = JSON.parse(fs.readFileSync(${JSON.stringify(buildOutputPath)}, "utf-8"));`,
-            `globalThis.__EVJS_MANIFEST__ = manifest;`,
+            `globalThis.__EVJS_FRAMEWORK_RUNTIME__ = ${JSON.stringify(frameworkRuntime, null, 2)};`,
             `const serverDir = path.dirname(${JSON.stringify(serverEntryPath)});`,
             `globalThis.__EVJS_SERVER_MODULE_LOADER__ = async (asset) => { const mod = await import(pathToFileURL(path.resolve(serverDir, asset)).href); const nested = mod && typeof mod.default === "object" ? mod.default : undefined; return nested && ("default" in nested || "render" in nested) ? nested : mod; };`,
             `const serverModule = await import(pathToFileURL(${JSON.stringify(serverEntryPath)}).href);`,
@@ -452,8 +455,8 @@ export function createExampleTest(exampleName: string) {
         const distDir = path.join(exampleDir, "dist", "client");
         const staticServer = createStaticServer(distDir, {
           apiPort,
-          proxyPrefixes: getServerProxyPrefixes(manifest),
-          pathRewrites: getClientPathRewrites(manifest),
+          proxyPrefixes: getServerProxyPrefixes(runtime),
+          pathRewrites: getClientPathRewrites(runtime),
         });
 
         await new Promise<void>((resolve) => {

--- a/e2e/ws-bootstrap.cjs
+++ b/e2e/ws-bootstrap.cjs
@@ -9,7 +9,7 @@
  * Environment variables:
  *   SERVER_ENTRY - path to the built server entry
  *   CLIENT_DIR   - path to the built client directory
- *   MANIFEST_PATH - path to the full BuildOutput manifest
+ *   FRAMEWORK_RUNTIME_PATH - path to the projected framework runtime JSON
  *   PORT         - port to listen on
  */
 
@@ -22,11 +22,11 @@ const { WebSocketServer } = require("ws");
 const serverEntryPath = process.env.SERVER_ENTRY;
 const distDir = process.env.CLIENT_DIR;
 const port = Number(process.env.PORT);
-const manifestPath = process.env.MANIFEST_PATH;
+const frameworkRuntimePath = process.env.FRAMEWORK_RUNTIME_PATH;
 
-if (!serverEntryPath || !distDir || !port || !manifestPath) {
+if (!serverEntryPath || !distDir || !port || !frameworkRuntimePath) {
   console.error(
-    "Missing required env: SERVER_ENTRY, CLIENT_DIR, PORT, MANIFEST_PATH",
+    "Missing required env: SERVER_ENTRY, CLIENT_DIR, PORT, FRAMEWORK_RUNTIME_PATH",
   );
   process.exit(1);
 }
@@ -35,8 +35,9 @@ if (!serverEntryPath || !distDir || !port || !manifestPath) {
 // and exports the fetch handler (app.fetch) as `default`.
 // We use the bundle's own fetch handler to ensure it shares the same
 // server function registry that registerServerReference populated.
-const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
-globalThis.__EVJS_MANIFEST__ = manifest;
+globalThis.__EVJS_FRAMEWORK_RUNTIME__ = JSON.parse(
+  fs.readFileSync(frameworkRuntimePath, "utf-8"),
+);
 const serverDir = path.dirname(serverEntryPath);
 globalThis.__EVJS_SERVER_MODULE_LOADER__ = async (asset) => {
   const mod = await import(pathToFileURL(path.resolve(serverDir, asset)).href);

--- a/packages/bundler-utoopack/tests/adapter.test.ts
+++ b/packages/bundler-utoopack/tests/adapter.test.ts
@@ -589,7 +589,6 @@ describe("utoopackAdapter dev", () => {
       module: {
         type: "entry",
         href: "main.js",
-        source: "./src/main.tsx",
       },
     });
     expect(serverManifest.entry).toBe("index.js");

--- a/packages/bundler-utoopack/tests/manifest-generator.test.ts
+++ b/packages/bundler-utoopack/tests/manifest-generator.test.ts
@@ -132,7 +132,6 @@ describe("UtoopackManifestGenerator", () => {
     expect(manifest.apps.default.module).toEqual({
       type: "entry",
       href: "main.js",
-      source: "./src/main.tsx",
     });
     expect(manifest.routes).toEqual([
       {
@@ -140,7 +139,6 @@ describe("UtoopackManifestGenerator", () => {
         path: "/",
         appId: "default",
         module: "./pages/Home.tsx",
-        render: "ssr",
       },
     ]);
     expect(manifest.server?.entry).toBe("server.js");
@@ -270,7 +268,6 @@ describe("UtoopackManifestGenerator", () => {
       module: {
         type: "entry",
         href: "home.js",
-        source: "./src/home.tsx",
       },
     });
     expect(manifest.pages.about).toMatchObject({
@@ -280,7 +277,6 @@ describe("UtoopackManifestGenerator", () => {
       module: {
         type: "entry",
         href: "about.js",
-        source: "./src/about.tsx",
       },
     });
   });

--- a/packages/bundler-webpack/tests/adapter.test.ts
+++ b/packages/bundler-webpack/tests/adapter.test.ts
@@ -574,7 +574,6 @@ describe("webpackAdapter build", () => {
         module: {
           type: "entry",
           href: "main.js",
-          source: "./src/main.ts",
         },
       });
       expect(manifest.pages.dashboard).toMatchObject({
@@ -593,8 +592,6 @@ describe("webpackAdapter build", () => {
         appId: "default",
         pageId: "dashboard",
         module: "./src/pages/Dashboard !page 中文.ts",
-        render: "ssr",
-        hydrate: "load",
       });
       expect(manifest.assets["dashboard-server"]).toEqual({
         js: ["dashboard-server.cjs"],

--- a/packages/bundler-webpack/tests/adapter.test.ts
+++ b/packages/bundler-webpack/tests/adapter.test.ts
@@ -25,6 +25,11 @@ import {
   generateHtml,
 } from "@evjs/ev/build-tools";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createClientRuntime,
+  createFrameworkRuntime,
+  type FrameworkRuntimeOutput,
+} from "../../ev/src/framework-runtime.js";
 import type { WebpackConfig } from "../src/adapter/create-config.js";
 import { __testing as webpackAdapterTesting } from "../src/adapter/index.js";
 import { webpackAdapter } from "../src/index.js";
@@ -46,7 +51,7 @@ const WEBPACK_DEV_TEST_NAMES = {
 const allocatedDevPorts = new Set<number>();
 
 type ServerRuntimeGlobals = typeof globalThis & {
-  __EVJS_MANIFEST__?: BuildOutput;
+  __EVJS_FRAMEWORK_RUNTIME__?: FrameworkRuntimeOutput;
   __EVJS_SERVER_MODULE_LOADER__?: (
     asset: string,
   ) => Promise<Record<string, unknown>>;
@@ -200,6 +205,11 @@ async function emitFrameworkArtifacts(options: {
   await fs.writeFile(
     path.join(clientDir, "manifest.json"),
     JSON.stringify(createPublicManifest(output), null, 2),
+    "utf-8",
+  );
+  await fs.writeFile(
+    path.join(clientDir, "runtime.json"),
+    JSON.stringify(createClientRuntime(output), null, 2),
     "utf-8",
   );
 
@@ -994,12 +1004,20 @@ describe("webpackAdapter dev", () => {
     try {
       const manifest = JSON.parse(
         await fs.readFile(path.join(cwd, "dist/manifest.json"), "utf-8"),
-      ) as BuildOutput;
+      ) as { pages: BuildOutput["pages"] };
+      const runtime = JSON.parse(
+        await fs.readFile(path.join(cwd, "dist/runtime.json"), "utf-8"),
+      ) as { pages: Record<string, Record<string, unknown>> };
       const html = await fetchDevText(`http://127.0.0.1:${port}/home.html`);
 
       expect(onBuildOutput).toHaveBeenCalledTimes(1);
-      expect(manifest.distDir).toBe("dist");
+      expect("distDir" in manifest).toBe(false);
       expect(manifest.pages.home.assets.js).toEqual(["home.js"]);
+      expect(runtime.pages.home).not.toHaveProperty("assets");
+      expect(runtime.pages.home).toEqual({
+        module: { type: "react-component", href: "home.js" },
+        mount: "#root",
+      });
       expect(html).toContain('data-evjs-kind="page"');
       expect(html).toContain('data-evjs-id="home"');
       expect(html).toContain('src="/home.js"');
@@ -1478,7 +1496,7 @@ async function requestServerEntry(
   );
   const serverDir = path.dirname(serverEntryPath);
   const runtimeGlobals = globalThis as ServerRuntimeGlobals;
-  runtimeGlobals.__EVJS_MANIFEST__ = manifest;
+  runtimeGlobals.__EVJS_FRAMEWORK_RUNTIME__ = createFrameworkRuntime(manifest);
   runtimeGlobals.__EVJS_SERVER_MODULE_LOADER__ = async (asset: string) => {
     const mod = await import(
       pathToFileURL(path.resolve(serverDir, asset)).href
@@ -1494,7 +1512,7 @@ async function requestServerEntry(
       serverModule.default?.default ?? serverModule.default ?? serverModule;
     return await handler.fetch(new Request(`https://example.com${pathname}`));
   } finally {
-    delete runtimeGlobals.__EVJS_MANIFEST__;
+    delete runtimeGlobals.__EVJS_FRAMEWORK_RUNTIME__;
     delete runtimeGlobals.__EVJS_SERVER_MODULE_LOADER__;
   }
 }

--- a/packages/cli/tests/plugin-hooks.test.ts
+++ b/packages/cli/tests/plugin-hooks.test.ts
@@ -103,15 +103,13 @@ function createTestBuildResult(
       version: 1 as const,
       ...(output.server.entry ? { entry: output.server.entry } : {}),
       assets: output.server.assets,
-      fns: Object.fromEntries(
+      functions: Object.fromEntries(
         Object.entries(output.server.functions).map(([id, fn]) => [
           id,
           { assets: fn.assets },
         ]),
       ),
-      ...(output.server.routes.length > 0
-        ? { routes: output.server.routes }
-        : {}),
+      routes: output.server.routes,
     },
     isRebuild,
   };

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -168,8 +168,8 @@ Standalone/manual clients can import the same query hooks directly from
 
 ### Runtime
 - Page runtime bootstrap is framework-owned and imported through `@evjs/client/internal`.
-- Page runtime loads the embedded `__EVJS_MANIFEST__` first. When it falls back
-  to `manifestUrl`, `data-evjs-manifest`, or `/manifest.json`, the response
+- Page runtime loads the embedded `__EVJS_CLIENT_RUNTIME__` first. When it falls
+  back to `runtimeUrl`, `data-evjs-runtime`, or `/runtime.json`, the response
   must be successful JSON with `Content-Type: application/json`, allowing
   optional content-type parameters.
 - `fetchRscFlight()`, `createReactRscModel()`, `mountReactRscPage()`,
@@ -182,7 +182,7 @@ Standalone/manual clients can import the same query hooks directly from
   `Content-Type: application/json` with optional parameters, `version: 1`,
   `type: "evjs.rsc"`, a build-identifier `buildId`, and well-formed asset
   lists before any diagnostic HTML is mounted.
-- Manifest shell primitives such as `createShell()`, `createPageDriver()`, and `createHistoryDriver()` are framework-owned and imported through `@evjs/client/internal`.
+- Runtime shell primitives such as `createShell()`, `createPageDriver()`, and `createHistoryDriver()` are framework-owned and imported through `@evjs/client/internal`.
 - Shell activation request URLs must be HTTP(S) URLs or pathnames starting with `/`.
 - Generated component-page bootstrap APIs are also framework-owned and imported through `@evjs/client/internal`.
 

--- a/packages/client/src/internal.ts
+++ b/packages/client/src/internal.ts
@@ -53,5 +53,5 @@ export {
   createServerReference,
   getFnId,
   getFnName,
-  initTransportFromManifest,
+  initTransportFromRuntime,
 } from "./transport-runtime.js";

--- a/packages/client/src/page.ts
+++ b/packages/client/src/page.ts
@@ -4,10 +4,6 @@ import {
   isBuildIdentifier,
 } from "@evjs/shared";
 import {
-  assertFrameworkManifestShape,
-  type BuildOutput,
-} from "@evjs/shared/manifest";
-import {
   assertFetchErrorResponseStatus,
   assertFetchResponseJson,
   assertFetchResponseJsonContentType,
@@ -16,6 +12,7 @@ import {
   formatFetchErrorResponseDetail,
   readFetchErrorResponseBody,
 } from "./fetch-response.js";
+import { assertClientRuntime, type ClientRuntime } from "./runtime-config.js";
 import {
   type AppContext,
   type AppModule,
@@ -23,16 +20,18 @@ import {
   createShell,
   type Shell,
 } from "./shell.js";
-import { initTransportFromManifest } from "./transport-runtime.js";
+import { initTransportFromRuntime } from "./transport-runtime.js";
 import { formatErrorDetail, isRecord } from "./validation.js";
 
 export interface PageRuntimeOptions {
   document?: Document;
-  manifest?: BuildOutput;
-  manifestUrl?: string;
+  runtime?: ClientRuntime;
+  runtimeUrl?: string;
   mount?: string | Element;
   loadModule?: (href: string, ctx: AppContext) => Promise<AppModule>;
 }
+
+const CLIENT_RUNTIME_SCRIPT_ID = "__EVJS_CLIENT_RUNTIME__";
 
 export async function startPageRuntime(
   options: PageRuntimeOptions = {},
@@ -41,14 +40,14 @@ export async function startPageRuntime(
   const doc = resolveRuntimeDocument(options.document);
   const request = createPageDriver({ document: doc }).current();
   assertRuntimeHtmlTarget(doc);
-  const manifest =
-    options.manifest === undefined
-      ? await loadManifest(doc, options)
-      : options.manifest;
-  assertLoadedManifest(manifest, "provided manifest");
-  initTransportFromManifest(manifest);
+  const runtime =
+    options.runtime === undefined
+      ? await loadRuntime(doc, options)
+      : options.runtime;
+  assertLoadedRuntime(runtime, "provided runtime");
+  initTransportFromRuntime(runtime);
   const shell = createShell({
-    manifest,
+    runtime,
     loadModule: options.loadModule,
     resolveMountPoint(ctx) {
       return resolveMountPoint(doc, options.mount ?? outputMount(ctx));
@@ -59,15 +58,15 @@ export async function startPageRuntime(
   return shell;
 }
 
-async function loadManifest(
+async function loadRuntime(
   document: Document,
   options: PageRuntimeOptions,
-): Promise<BuildOutput> {
-  const embedded = readEmbeddedManifest(document);
+): Promise<ClientRuntime> {
+  const embedded = readEmbeddedRuntime(document);
   if (embedded) return embedded;
 
-  const manifestUrl = resolveManifestUrl(document, options);
-  const errorPrefix = getManifestFetchErrorPrefix(manifestUrl);
+  const runtimeUrl = resolveRuntimeUrl(document, options);
+  const errorPrefix = getRuntimeFetchErrorPrefix(runtimeUrl);
   const fetchImpl = globalThis.fetch;
   if (typeof fetchImpl !== "function") {
     throw new Error(`${errorPrefix}: fetch is not available.`);
@@ -75,7 +74,7 @@ async function loadManifest(
 
   let response: unknown;
   try {
-    response = await fetchImpl(manifestUrl);
+    response = await fetchImpl(runtimeUrl);
   } catch (error) {
     throw new Error(`${errorPrefix}${formatErrorDetail(error)}`);
   }
@@ -92,98 +91,91 @@ async function loadManifest(
   }
   assertFetchResponseJson(response, errorPrefix);
   assertFetchResponseJsonContentType(response, errorPrefix);
-  return parseFetchedManifest(response, manifestUrl);
+  return parseFetchedRuntime(response, runtimeUrl);
 }
 
-function resolveManifestUrl(
+function resolveRuntimeUrl(
   document: Document,
   options: PageRuntimeOptions,
 ): string {
-  if (options.manifestUrl !== undefined) return options.manifestUrl;
+  if (options.runtimeUrl !== undefined) return options.runtimeUrl;
 
-  const attribute =
-    document.documentElement?.getAttribute("data-evjs-manifest");
-  if (attribute === null || attribute === undefined) return "/manifest.json";
-  return assertRuntimeManifestUrl(
-    attribute,
-    "data-evjs-manifest",
-    "manifest URL",
-  );
+  const attribute = document.documentElement?.getAttribute("data-evjs-runtime");
+  if (attribute === null || attribute === undefined) return "/runtime.json";
+  return assertRuntimeUrl(attribute, "data-evjs-runtime", "runtime URL");
 }
 
-function readEmbeddedManifest(document: Document): BuildOutput | undefined {
-  const script = document.getElementById("__EVJS_MANIFEST__");
+function readEmbeddedRuntime(document: Document): ClientRuntime | undefined {
+  const script = document.getElementById(CLIENT_RUNTIME_SCRIPT_ID);
   const scriptText = script?.textContent;
   if (scriptText !== null && scriptText !== undefined) {
     if (typeof scriptText !== "string") {
       throw new Error(
-        '[evjs] Embedded manifest "__EVJS_MANIFEST__" textContent must be a string when provided.',
+        `[evjs] Embedded runtime "${CLIENT_RUNTIME_SCRIPT_ID}" textContent must be a string when provided.`,
       );
     }
   }
   const text = scriptText?.trim();
   if (!text) return undefined;
 
-  let manifest: unknown;
+  let runtime: unknown;
   try {
-    manifest = JSON.parse(text);
+    runtime = JSON.parse(text);
   } catch (error) {
     throw new Error(
-      `[evjs] Failed to parse embedded manifest "__EVJS_MANIFEST__" as JSON${formatErrorDetail(error)}`,
+      `[evjs] Failed to parse embedded runtime "${CLIENT_RUNTIME_SCRIPT_ID}" as JSON${formatErrorDetail(error)}`,
     );
   }
-  assertLoadedManifest(manifest, 'embedded manifest "__EVJS_MANIFEST__"');
-  return manifest;
+  assertLoadedRuntime(
+    runtime,
+    `embedded runtime "${CLIENT_RUNTIME_SCRIPT_ID}"`,
+  );
+  return runtime;
 }
 
-async function parseFetchedManifest(
+async function parseFetchedRuntime(
   response: FetchResponseObject & { json: () => Promise<unknown> },
-  manifestUrl: string,
-): Promise<BuildOutput> {
-  let manifest: unknown;
+  runtimeUrl: string,
+): Promise<ClientRuntime> {
+  let runtime: unknown;
   try {
-    manifest = await response.json();
+    runtime = await response.json();
   } catch (error) {
     throw new Error(
-      `[evjs] Failed to parse manifest "${manifestUrl}" as JSON${formatErrorDetail(error)}`,
+      `[evjs] Failed to parse runtime "${runtimeUrl}" as JSON${formatErrorDetail(error)}`,
     );
   }
-  assertLoadedManifest(manifest, `manifest "${manifestUrl}"`);
-  return manifest;
+  assertLoadedRuntime(runtime, `runtime "${runtimeUrl}"`);
+  return runtime;
 }
 
-function getManifestFetchErrorPrefix(manifestUrl: string): string {
-  return `[evjs] Failed to load manifest "${manifestUrl}"`;
+function getRuntimeFetchErrorPrefix(runtimeUrl: string): string {
+  return `[evjs] Failed to load runtime "${runtimeUrl}"`;
 }
 
-function assertLoadedManifest(
-  manifest: unknown,
+function assertLoadedRuntime(
+  runtime: unknown,
   source: string,
-): asserts manifest is BuildOutput {
-  if (!isRecord(manifest)) {
+): asserts runtime is ClientRuntime {
+  if (!isRecord(runtime)) {
     throw new Error(`[evjs] Loaded ${source} must be a JSON object.`);
   }
-  if (manifest.version !== 1) {
+  if (runtime.version !== 1) {
     throw new Error(`[evjs] Loaded ${source} version must be 1.`);
   }
-  if (!isRecord(manifest.runtime)) {
+  if (!isRecord(runtime.runtime)) {
     throw new Error(`[evjs] Loaded ${source} runtime must be an object.`);
   }
-  if (!isRecord(manifest.pages)) {
+  if (!isRecord(runtime.pages)) {
     throw new Error(`[evjs] Loaded ${source} pages must be an object.`);
   }
-  if (!isRecord(manifest.apps)) {
+  if (!isRecord(runtime.apps)) {
     throw new Error(`[evjs] Loaded ${source} apps must be an object.`);
   }
-  if (!Array.isArray(manifest.routes)) {
+  if (!Array.isArray(runtime.routes)) {
     throw new Error(`[evjs] Loaded ${source} routes must be an array.`);
   }
-  assertFrameworkManifestShape(manifest, `Loaded ${source}`, {
-    serverFunctionModules: "optional",
-    pageRendererReferences: "optional",
-    pprRendererReferences: "optional",
-    rscRendererReferences: "optional",
-  });
+  assertClientRuntime(runtime, `Loaded ${source}`);
 }
 
 function assertPageRuntimeOptions(
@@ -192,8 +184,8 @@ function assertPageRuntimeOptions(
   if (!isRecord(options)) {
     throw new Error("[evjs] startPageRuntime() options must be an object.");
   }
-  if (options.manifestUrl !== undefined) {
-    assertRuntimeManifestUrl(options.manifestUrl, "manifestUrl", "string");
+  if (options.runtimeUrl !== undefined) {
+    assertRuntimeUrl(options.runtimeUrl, "runtimeUrl", "string");
   }
   if (options.mount !== undefined) {
     assertMountOption(options.mount);
@@ -206,7 +198,7 @@ function assertPageRuntimeOptions(
   }
 }
 
-function assertRuntimeManifestUrl(
+function assertRuntimeUrl(
   value: unknown,
   name: string,
   emptyDescription: string,

--- a/packages/client/src/react.ts
+++ b/packages/client/src/react.ts
@@ -8,12 +8,6 @@ import {
   parsePageSearch,
   type RscFlightClientPageUrlParamError,
 } from "@evjs/shared";
-import {
-  assertFrameworkManifestShape,
-  type BuildOutput,
-  type HydrationMode,
-  type RenderMode,
-} from "@evjs/shared/manifest";
 import { type ComponentType, createElement } from "react";
 import { createRoot, hydrateRoot, type Root } from "react-dom/client";
 import {
@@ -30,6 +24,12 @@ import {
   isReactComponentExport,
   type ReactComponentExport,
 } from "./react-component.js";
+import {
+  assertClientRuntime,
+  type ClientRuntime,
+  type HydrationMode,
+  type RenderMode,
+} from "./runtime-config.js";
 import type { AppContext, AppModule } from "./shell.js";
 import { formatErrorDetail, isRecord } from "./validation.js";
 
@@ -58,7 +58,7 @@ export interface ReactPageRouteContext {
 }
 
 export interface RscFlightFetchOptions {
-  manifest: BuildOutput;
+  runtime: ClientRuntime;
   pageId?: string;
   url?: string | URL;
   fetch?: typeof fetch;
@@ -76,9 +76,17 @@ export interface RscDebugPayload {
     js: string[];
     css: string[];
   };
-  clientReferences?: Record<string, unknown>;
-  serverReferences?: Record<string, unknown>;
-  pages?: NonNullable<BuildOutput["rsc"]>["pages"];
+  pages?: Record<
+    string,
+    {
+      renderer: string;
+      assets: {
+        js: string[];
+        css: string[];
+      };
+      routeId?: string;
+    }
+  >;
 }
 
 export interface RscDebugPayloadMountOptions {
@@ -298,11 +306,10 @@ export async function fetchRscFlight(
   options: RscFlightFetchOptions,
 ): Promise<Response> {
   assertRscFlightFetchOptions(options);
-  const endpoint =
-    options.manifest.rsc?.endpoint ?? options.manifest.runtime.server?.rsc;
+  const endpoint = options.runtime.runtime.server?.rsc;
   if (!endpoint) {
     throw new Error(
-      "[evjs] RSC Flight endpoint is not present in the manifest.",
+      "[evjs] RSC Flight endpoint is not present in the runtime.",
     );
   }
 
@@ -330,12 +337,7 @@ export function assertRscFlightFetchOptions(
   if (!isRecord(options)) {
     throw new Error("[evjs] fetchRscFlight() options must be an object.");
   }
-  assertFrameworkManifestShape(options.manifest, "fetchRscFlight() manifest", {
-    serverFunctionModules: "optional",
-    pageRendererReferences: "optional",
-    pprRendererReferences: "optional",
-    rscRendererReferences: "optional",
-  });
+  assertClientRuntime(options.runtime, "fetchRscFlight() runtime");
   assertOptionalRscFlightString(options.pageId, "fetchRscFlight() pageId");
   assertOptionalRscFlightUrl(options.url, "fetchRscFlight() url");
 }
@@ -423,7 +425,7 @@ function resolveRscFlightUrl(
   const explicitUrl = options.url?.toString();
   const locationHref = globalThis.location?.href;
   const currentUrl = explicitUrl ?? locationHref;
-  const transportBaseUrl = options.manifest.runtime.transport?.baseUrl;
+  const transportBaseUrl = options.runtime.runtime.transport?.baseUrl;
   const base = transportBaseUrl ?? locationHref ?? explicitUrl ?? endpoint;
   const url = new URL(endpoint, base);
   if (options.pageId) {
@@ -523,15 +525,11 @@ function readEmbeddedPageProps(): Record<string, unknown> | undefined {
 
 function pagePropsFromContext(ctx: AppContext): Record<string, unknown> {
   if (ctx.kind !== "page") return {};
-  const route = findRouteForPage(
-    ctx.manifest,
-    ctx.id,
-    readRequestPathname(ctx),
-  );
+  const route = findRouteForPage(ctx.runtime, ctx.id, readRequestPathname(ctx));
 
   return {
-    manifest: {
-      buildId: ctx.manifest.buildId,
+    runtime: {
+      buildId: ctx.runtime.buildId,
     },
     pageId: ctx.id,
     route,
@@ -539,11 +537,11 @@ function pagePropsFromContext(ctx: AppContext): Record<string, unknown> {
 }
 
 function findRouteForPage(
-  manifest: BuildOutput,
+  runtime: ClientRuntime,
   pageId: string,
   pathname: string | undefined,
 ): ReactPageRouteContext | undefined {
-  const pageRoutes = manifest.routes.filter(
+  const pageRoutes = runtime.routes.filter(
     (candidate) => candidate.pageId === pageId,
   );
   const route = pathname
@@ -679,14 +677,6 @@ function assertRscDebugPayload(
   if (value.assets !== undefined) {
     assertRscDebugAssets(value.assets, `${source}.assets`);
   }
-  assertOptionalRscDebugRecord(
-    value.clientReferences,
-    `${source}.clientReferences`,
-  );
-  assertOptionalRscDebugRecord(
-    value.serverReferences,
-    `${source}.serverReferences`,
-  );
   assertOptionalRscDebugRecord(value.pages, `${source}.pages`);
 }
 

--- a/packages/client/src/rsc-page-context.ts
+++ b/packages/client/src/rsc-page-context.ts
@@ -2,7 +2,6 @@
 
 import { AsyncLocalStorage } from "node:async_hooks";
 import { matchPageRouteParams, parsePageSearch } from "@evjs/shared";
-import type { BuildOutput } from "@evjs/shared/manifest";
 import { type ComponentType, createElement } from "react";
 import { renderToReadableStream } from "react-server-dom-webpack/server.node";
 import type { PageProps } from "./page-context.js";
@@ -15,8 +14,20 @@ import type {
 
 const storage = new AsyncLocalStorage<PageProps>();
 
+interface RscPageRuntime {
+  buildId: string;
+  routes?: Array<{
+    id: string;
+    path: string;
+    pageId?: string;
+  }>;
+  rsc?: {
+    clientReferenceManifest?: Record<string, unknown>;
+  };
+}
+
 export interface RscPageFlightRenderContext {
-  manifest: BuildOutput;
+  runtime: RscPageRuntime;
   pageId?: string;
   pageUrl?: string;
   request: Request;
@@ -30,7 +41,7 @@ export function createRscPageFlightRenderer(
   Component: ComponentType<Record<string, unknown>>,
 ): (ctx: RscPageFlightRenderContext) => Promise<Response> {
   return async function renderFlight(ctx) {
-    const clientReferenceManifest = ctx.manifest.rsc?.clientReferenceManifest;
+    const clientReferenceManifest = ctx.runtime.rsc?.clientReferenceManifest;
     if (!clientReferenceManifest) {
       return new Response(
         "[evjs] RSC client reference manifest is not available.",
@@ -109,11 +120,11 @@ export function usePageLoaderData(_path?: string): unknown {
 }
 
 function findRouteForPage(
-  manifest: BuildOutput,
+  runtime: RscPageRuntime,
   pageId: string | undefined,
 ): { id: string; path: string } | undefined {
   if (!pageId) return undefined;
-  const route = manifest.routes?.find(
+  const route = runtime.routes?.find(
     (candidate) => candidate.pageId === pageId,
   );
   return route
@@ -125,16 +136,16 @@ function findRouteForPage(
 }
 
 function createRscPageProps(ctx: RscPageFlightRenderContext): PageProps & {
-  manifest: { buildId: string };
+  runtime: { buildId: string };
   pageId?: string;
   route?: { id: string; path: string };
 } {
   return {
-    manifest: {
-      buildId: ctx.manifest.buildId,
+    runtime: {
+      buildId: ctx.runtime.buildId,
     },
     pageId: ctx.pageId,
-    route: findRouteForPage(ctx.manifest, ctx.pageId),
+    route: findRouteForPage(ctx.runtime, ctx.pageId),
     params: {},
     search: {},
     loaderData: undefined,

--- a/packages/client/src/rsc.ts
+++ b/packages/client/src/rsc.ts
@@ -7,11 +7,6 @@ import {
   type PathPatternValidationError,
   RSC_FLIGHT_CONTENT_TYPE,
 } from "@evjs/shared";
-import type {
-  AssetGroup,
-  BuildOutput,
-  PublicPathOutput,
-} from "@evjs/shared/manifest";
 import { createElement, type ReactNode, Suspense } from "react";
 import { createRoot, hydrateRoot, type Root } from "react-dom/client";
 import {
@@ -20,6 +15,7 @@ import {
   getRscFetchResponseContentType,
   type RscFlightFetchOptions,
 } from "./react.js";
+import type { ClientAssetGroup, ClientRuntime } from "./runtime-config.js";
 import { formatErrorDetail, isRecord } from "./validation.js";
 
 export interface ReactRscModelOptions extends RscFlightFetchOptions {
@@ -39,17 +35,16 @@ export interface ReactRscRuntimeBootstrap {
   pageId: string;
   endpoint: string;
   basePath?: string;
-  publicPath?: PublicPathOutput;
+  publicPath?: string;
   mount: string;
   page?: {
-    assets?: AssetGroup;
+    assets?: ClientAssetGroup;
     routeId?: string;
   };
 }
 
 const rootByMountPoint = new WeakMap<Element, Root>();
 const RSC_BOOTSTRAP_SCRIPT_ID = "__EVJS_RSC_BOOTSTRAP__";
-const RSC_BOOTSTRAP_RENDERER_ID = "evjs-rsc-bootstrap";
 let runtimeStarted = false;
 let runtimeStarting = false;
 
@@ -209,7 +204,7 @@ export async function startReactRscPageRuntime(
   const runtimeDocument = resolveRscDocument(doc);
 
   const model = await mountReactRscPage({
-    manifest: createBootstrapManifest(bootstrap),
+    runtime: createBootstrapRuntime(bootstrap),
     pageId: bootstrap.pageId,
     moduleBaseURL: publicPathModuleBaseURL(
       bootstrap.publicPath,
@@ -224,7 +219,7 @@ export async function startReactRscPageRuntime(
 }
 
 function publicPathModuleBaseURL(
-  publicPath: PublicPathOutput | undefined,
+  publicPath: string | undefined,
   document: Document,
 ): string | undefined {
   if (!publicPath || publicPath === "auto") return undefined;
@@ -471,72 +466,24 @@ function formatBootstrapPathnameError(
   }
 }
 
-function createBootstrapManifest(
+function createBootstrapRuntime(
   bootstrap: ReactRscRuntimeBootstrap,
-): BuildOutput {
-  const basePath = bootstrap.basePath ?? "/__evjs";
+): ClientRuntime {
   return {
     version: 1,
     buildId: bootstrap.buildId,
-    distDir: "dist",
-    paths: {
-      rootDir: "dist",
-      publicDir: "dist/client",
-      serverDir: "dist/server",
-    },
-    publicPath: bootstrap.publicPath ?? "auto",
     runtime: {
       server: {
-        basePath,
-        fn: joinEndpoint(basePath, "fn"),
         rsc: bootstrap.endpoint,
       },
       transport: {},
     },
-    assets: {},
     apps: {},
     pages: {
-      [bootstrap.pageId]: {
-        assets: bootstrap.page?.assets ?? { js: [], css: [] },
-        render: "ssr",
-        componentModel: "rsc",
-        rendering: {
-          component: "rsc",
-          html: "server",
-          streaming: true,
-          hydrate: "none",
-        },
-        routeId: bootstrap.page?.routeId,
-      },
+      [bootstrap.pageId]: {},
     },
     routes: [],
-    server: {
-      assets: { js: [], css: [] },
-      renderers: {
-        [RSC_BOOTSTRAP_RENDERER_ID]: {
-          kind: "rsc-page",
-          owner: { pageId: bootstrap.pageId },
-          module: "@evjs/client/rsc-bootstrap",
-          assets: bootstrap.page?.assets ?? { js: [], css: [] },
-        },
-      },
-      functions: {},
-      routes: [],
-    },
-    rsc: {
-      endpoint: bootstrap.endpoint,
-      pages: {
-        [bootstrap.pageId]: {
-          renderer: RSC_BOOTSTRAP_RENDERER_ID,
-          assets: bootstrap.page?.assets ?? { js: [], css: [] },
-        },
-      },
-    },
   };
-}
-
-function joinEndpoint(basePath: string, name: string): string {
-  return `/${basePath.split("/").concat(name).filter(Boolean).join("/")}`;
 }
 
 function scheduleRscRuntimeStart(): void {

--- a/packages/client/src/runtime-config.ts
+++ b/packages/client/src/runtime-config.ts
@@ -1,0 +1,342 @@
+import {
+  BUILD_IDENTIFIER_DESCRIPTION,
+  getPathPatternValidationError,
+  getUrlStringValidationError,
+  isBuildIdentifier,
+  normalizeRoutePathname,
+  type PathPatternValidationError,
+  pageRoutePathShapeFromPath,
+  type UrlStringValidationError,
+} from "@evjs/shared";
+import { isRecord } from "./validation.js";
+
+export type HydrationMode = "none" | "load" | "visible" | "idle";
+export type RenderMode = "csr" | "ssr" | "ssg";
+
+export interface ClientRuntime {
+  version: 1;
+  buildId: string;
+  runtime: {
+    server?: {
+      rsc?: string;
+    };
+    transport?: {
+      baseUrl?: string;
+    };
+  };
+  apps: Record<string, ClientRuntimeApp>;
+  pages: Record<string, ClientRuntimePage>;
+  routes: ClientRuntimeRoute[];
+}
+
+export interface ClientAssetGroup {
+  js: string[];
+  css: string[];
+}
+
+export interface ClientRuntimeModule {
+  type: "entry" | "lifecycle" | "react-component";
+  href?: string;
+}
+
+export interface ClientRuntimeApp {
+  mount?: string;
+  module?: ClientRuntimeModule;
+}
+
+export interface ClientRuntimePage {
+  mount?: string;
+  module?: ClientRuntimeModule;
+}
+
+export interface ClientRuntimeRoute {
+  id: string;
+  path: string;
+  appId?: string;
+  pageId?: string;
+}
+
+export function assertClientRuntime(
+  value: unknown,
+  source: string,
+): asserts value is ClientRuntime {
+  assertObject(value, source);
+  if (value.version !== 1) {
+    throw new Error(`[evjs] ${source}.version must be 1.`);
+  }
+  assertBuildIdentifier(value.buildId, `${source}.buildId`);
+  assertObject(value.runtime, `${source}.runtime`);
+  if (value.runtime.server !== undefined) {
+    assertObject(value.runtime.server, `${source}.runtime.server`);
+    assertRuntimePathname(
+      value.runtime.server.rsc,
+      `${source}.runtime.server.rsc`,
+    );
+  }
+  if (value.runtime.transport !== undefined) {
+    assertObject(value.runtime.transport, `${source}.runtime.transport`);
+    assertRuntimeTransportBaseUrl(
+      value.runtime.transport.baseUrl,
+      `${source}.runtime.transport.baseUrl`,
+    );
+  }
+  assertObject(value.apps, `${source}.apps`);
+  assertApps(value.apps, `${source}.apps`);
+  assertObject(value.pages, `${source}.pages`);
+  assertPages(value.pages, `${source}.pages`);
+  if (!Array.isArray(value.routes)) {
+    throw new Error(`[evjs] ${source}.routes must be an array.`);
+  }
+  assertRoutes(value.routes, `${source}.routes`, value.pages, value.apps);
+}
+
+function assertApps(value: Record<string, unknown>, source: string): void {
+  for (const [name, app] of Object.entries(value)) {
+    assertBuildIdentifierKey(name, source);
+    const appSource = `${source}.${name}`;
+    assertObject(app, appSource);
+    if (app.module !== undefined) {
+      assertRuntimeModule(app.module, `${appSource}.module`);
+    }
+    if (app.mount !== undefined) {
+      assertRuntimeString(app.mount, `${appSource}.mount`);
+    }
+  }
+}
+
+function assertPages(value: Record<string, unknown>, source: string): void {
+  for (const [name, page] of Object.entries(value)) {
+    assertBuildIdentifierKey(name, source);
+    const pageSource = `${source}.${name}`;
+    assertObject(page, pageSource);
+    if (page.mount !== undefined) {
+      assertRuntimeString(page.mount, `${pageSource}.mount`);
+    }
+    if (page.module !== undefined) {
+      assertRuntimeModule(page.module, `${pageSource}.module`);
+    }
+  }
+}
+
+function assertRuntimeModule(value: unknown, source: string): void {
+  assertObject(value, source);
+  if (
+    value.type !== "entry" &&
+    value.type !== "lifecycle" &&
+    value.type !== "react-component"
+  ) {
+    throw new Error(
+      `[evjs] ${source}.type must be "entry", "lifecycle", or "react-component".`,
+    );
+  }
+  if (value.href !== undefined) {
+    assertRuntimeString(value.href, `${source}.href`);
+  }
+}
+
+function assertRoutes(
+  value: unknown[],
+  source: string,
+  pages: Record<string, unknown>,
+  apps: Record<string, unknown>,
+): void {
+  const idOwners = new Map<string, string>();
+  const pathOwners = new Map<string, { path: string; source: string }>();
+  const shapeOwners = new Map<string, { path: string; source: string }>();
+
+  value.forEach((route, index) => {
+    const routeSource = `${source}[${index}]`;
+    assertObject(route, routeSource);
+    assertRuntimeString(route.id, `${routeSource}.id`);
+    assertUniqueRouteId(route.id, `${routeSource}.id`, idOwners);
+    assertRuntimePathname(route.path, `${routeSource}.path`, true);
+    const path = route.path as string;
+    assertUniqueRoutePath(path, `${routeSource}.path`, pathOwners);
+    assertUniqueRouteShape(path, `${routeSource}.path`, shapeOwners);
+    assertOptionalRecordReference(
+      route.pageId,
+      `${routeSource}.pageId`,
+      `${source.replace(/\.routes$/, "")}.pages`,
+      pages,
+    );
+    assertOptionalRecordReference(
+      route.appId,
+      `${routeSource}.appId`,
+      `${source.replace(/\.routes$/, "")}.apps`,
+      apps,
+    );
+  });
+}
+
+function assertOptionalRecordReference(
+  value: unknown,
+  source: string,
+  recordsSource: string,
+  records: Record<string, unknown>,
+): void {
+  if (value === undefined) return;
+  assertRuntimeString(value, source);
+  if (!Object.hasOwn(records, value)) {
+    throw new Error(
+      `[evjs] ${source} "${value}" does not match any ${formatRecordSource(recordsSource)} entry.`,
+    );
+  }
+}
+
+function formatRecordSource(source: string): string {
+  return source.replace(/^.*? runtime\./, "runtime.");
+}
+
+function assertObject(
+  value: unknown,
+  source: string,
+): asserts value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`[evjs] ${source} must be an object.`);
+  }
+}
+
+function assertRuntimeString(
+  value: unknown,
+  source: string,
+): asserts value is string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`[evjs] ${source} must be a non-empty string.`);
+  }
+  if (value.trim() !== value) {
+    throw new Error(
+      `[evjs] ${source} must not contain leading or trailing whitespace.`,
+    );
+  }
+}
+
+function assertBuildIdentifier(value: unknown, source: string): void {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`[evjs] ${source} must be a non-empty string.`);
+  }
+  if (!isBuildIdentifier(value)) {
+    throw new Error(
+      `[evjs] ${source} must contain only ${BUILD_IDENTIFIER_DESCRIPTION}.`,
+    );
+  }
+}
+
+function assertBuildIdentifierKey(key: string, source: string): void {
+  if (!isBuildIdentifier(key)) {
+    throw new Error(
+      `[evjs] ${source} key "${key}" must contain only ${BUILD_IDENTIFIER_DESCRIPTION}.`,
+    );
+  }
+  if (key.trim() !== key) {
+    throw new Error(
+      `[evjs] ${source} key "${key}" must not contain leading or trailing whitespace.`,
+    );
+  }
+}
+
+function assertUniqueRouteId(
+  id: string,
+  source: string,
+  idOwners: Map<string, string>,
+): void {
+  const existingSource = idOwners.get(id);
+  if (existingSource) {
+    throw new Error(
+      `[evjs] ${source} duplicates ${existingSource} "${id}". Route ids must be unique.`,
+    );
+  }
+  idOwners.set(id, source);
+}
+
+function assertUniqueRoutePath(
+  path: string,
+  source: string,
+  pathOwners: Map<string, { path: string; source: string }>,
+): void {
+  const normalizedPath = normalizeRoutePathname(path);
+  const existing = pathOwners.get(normalizedPath);
+  if (existing) {
+    throw new Error(
+      `[evjs] ${source} duplicates ${existing.source} "${existing.path}". Page route paths must be unique.`,
+    );
+  }
+  pathOwners.set(normalizedPath, { path, source });
+}
+
+function assertUniqueRouteShape(
+  path: string,
+  source: string,
+  shapeOwners: Map<string, { path: string; source: string }>,
+): void {
+  const shape = pageRoutePathShapeFromPath(path);
+  const existing = shapeOwners.get(shape);
+  if (existing) {
+    throw new Error(
+      `[evjs] ${source} has the same route shape as ${existing.source} "${existing.path}". Use one page route per URL shape.`,
+    );
+  }
+  shapeOwners.set(shape, { path, source });
+}
+
+function assertRuntimePathname(
+  value: unknown,
+  source: string,
+  required = false,
+): void {
+  if (value === undefined) {
+    if (required) {
+      throw new Error(`[evjs] ${source} must be a non-empty pathname.`);
+    }
+    return;
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`[evjs] ${source} must be a non-empty pathname.`);
+  }
+  if (value.trim() !== value) {
+    throw new Error(
+      `[evjs] ${source} must not contain leading or trailing whitespace.`,
+    );
+  }
+  const error = getPathPatternValidationError(value);
+  if (error) {
+    throw new Error(`[evjs] ${source} ${formatRuntimePathnameError(error)}`);
+  }
+}
+
+function assertRuntimeTransportBaseUrl(value: unknown, source: string): void {
+  if (value === undefined) return;
+  const error = getUrlStringValidationError(value, {
+    baseUrl: "http://evjs.local/",
+  });
+  if (error) {
+    throw new Error(
+      `[evjs] ${source} ${formatRuntimeTransportBaseUrlError(error)}`,
+    );
+  }
+}
+
+function formatRuntimeTransportBaseUrlError(
+  error: UrlStringValidationError,
+): string {
+  switch (error) {
+    case "empty":
+      return "must be a non-empty URL string.";
+    case "whitespace":
+      return "must not contain leading or trailing whitespace.";
+    case "invalid-url":
+      return "must be a valid URL string.";
+  }
+}
+
+function formatRuntimePathnameError(error: PathPatternValidationError): string {
+  switch (error) {
+    case "empty":
+      return "must be a non-empty pathname.";
+    case "missing-leading-slash":
+      return 'must start with "/".';
+    case "whitespace":
+      return "must not contain whitespace.";
+    case "query-or-hash":
+      return "must not include a query string or hash.";
+  }
+}

--- a/packages/client/src/shell/drivers.ts
+++ b/packages/client/src/shell/drivers.ts
@@ -34,7 +34,7 @@ export function createHistoryDriver(
   return {
     current() {
       return createActivationRequestFromUrl(
-        options.manifest,
+        options.runtime,
         getWindowHref(getWindow(options)),
       );
     },
@@ -42,7 +42,7 @@ export function createHistoryDriver(
       const win = getWindow(options);
       const listener = () =>
         callback(
-          createActivationRequestFromUrl(options.manifest, getWindowHref(win)),
+          createActivationRequestFromUrl(options.runtime, getWindowHref(win)),
         );
       addHistoryPopStateListener(win, listener);
       return () => removeHistoryPopStateListener(win, listener);
@@ -163,21 +163,21 @@ function assertHistoryDriverOptions(
   if (!isRecord(options)) {
     throw new Error("[evjs] createHistoryDriver() options must be an object.");
   }
-  assertHistoryDriverManifest(options.manifest);
+  assertHistoryDriverRuntime(options.runtime);
   if (options.window !== undefined) {
     assertBrowserWindow(options.window, "window");
   }
 }
 
-function assertHistoryDriverManifest(
-  manifest: unknown,
-): asserts manifest is HistoryDriverOptions["manifest"] {
-  if (!isRecord(manifest)) {
-    throw new Error("[evjs] createHistoryDriver() manifest must be an object.");
+function assertHistoryDriverRuntime(
+  runtime: unknown,
+): asserts runtime is HistoryDriverOptions["runtime"] {
+  if (!isRecord(runtime)) {
+    throw new Error("[evjs] createHistoryDriver() runtime must be an object.");
   }
-  if (!Array.isArray(manifest.routes)) {
+  if (!Array.isArray(runtime.routes)) {
     throw new Error(
-      "[evjs] createHistoryDriver() manifest.routes must be an array.",
+      "[evjs] createHistoryDriver() runtime.routes must be an array.",
     );
   }
 }

--- a/packages/client/src/shell/routing.ts
+++ b/packages/client/src/shell/routing.ts
@@ -1,14 +1,14 @@
 import { findBestPageRoute } from "@evjs/shared";
-import type { BuildOutput } from "@evjs/shared/manifest";
+import type { ClientRuntime } from "../runtime-config.js";
 import type { ActivationRequest } from "./types.js";
 
 export function createActivationRequestFromUrl(
-  manifest: BuildOutput,
+  runtime: ClientRuntime,
   url: string | URL,
 ): ActivationRequest {
   const href = url.toString();
   const pathname = getPathname(href);
-  const route = findBestPageRoute(manifest.routes, pathname);
+  const route = findBestPageRoute(runtime.routes, pathname);
 
   return {
     url: href,

--- a/packages/client/src/shell/runtime.ts
+++ b/packages/client/src/shell/runtime.ts
@@ -3,7 +3,7 @@ import {
   getHttpUrlOrAbsolutePathnameValidationError,
   isBuildIdentifier,
 } from "@evjs/shared";
-import { assertFrameworkManifestShape } from "@evjs/shared/manifest";
+import { assertClientRuntime } from "../runtime-config.js";
 import { isRecord } from "../validation.js";
 import { defaultLoadModule } from "./assets.js";
 import { assertAppModule } from "./module-registration.js";
@@ -66,7 +66,7 @@ export function createShell(options: ShellOptions): Shell {
           // Keep later transitions alive even if an earlier activation failed.
         })
         .then(() => {
-          assertActivationRequest(request, "activate()", options.manifest);
+          assertActivationRequest(request, "activate()", options.runtime);
           return activateNow(request);
         });
       activationQueue = run;
@@ -74,7 +74,7 @@ export function createShell(options: ShellOptions): Shell {
     },
     async preload(request) {
       assertNotDisposed("preload()");
-      assertActivationRequest(request, "preload()", options.manifest);
+      assertActivationRequest(request, "preload()", options.runtime);
       const target = await resolve(request);
       if (disposed) return;
       await getModule(target.href, target.ctx);
@@ -111,7 +111,7 @@ export function createShell(options: ShellOptions): Shell {
   async function resolve(
     request: ActivationRequest,
   ): Promise<ResolvedActivation> {
-    const target = await resolveTarget(options.manifest, request);
+    const target = await resolveTarget(options.runtime, request);
     const mountPoint =
       request.mountPoint ?? options.resolveMountPoint?.(target.ctx);
     if (mountPoint === undefined || mountPoint === null) {
@@ -318,7 +318,7 @@ function assertShellOptions(options: unknown): asserts options is ShellOptions {
   if (!isRecord(options)) {
     throw new Error("[evjs] createShell() options must be an object.");
   }
-  assertShellManifest(options.manifest);
+  assertShellRuntime(options.runtime);
 
   if (options.drivers !== undefined) {
     if (!Array.isArray(options.drivers)) {
@@ -336,7 +336,7 @@ function assertShellOptions(options: unknown): asserts options is ShellOptions {
 function assertActivationRequest(
   request: unknown,
   method: "activate()" | "preload()",
-  manifest: ShellOptions["manifest"],
+  runtime: ShellOptions["runtime"],
 ): asserts request is ActivationRequest {
   const prefix = `[evjs] Shell ${method} request`;
   if (!isRecord(request)) {
@@ -346,7 +346,7 @@ function assertActivationRequest(
   assertOptionalRequestString(request.appId, `${prefix}.appId`);
   assertOptionalRequestString(request.pageId, `${prefix}.pageId`);
   assertOptionalRequestBuildId(request.buildId, `${prefix}.buildId`);
-  assertRequestBuildId(request, prefix, manifest);
+  assertRequestBuildId(request, prefix, runtime);
   assertActivationTargetRequest(request, prefix);
 
   if (
@@ -426,12 +426,12 @@ function assertTrimmedRequestString(value: string, path: string): void {
 function assertRequestBuildId(
   request: ActivationRequest,
   prefix: string,
-  manifest: ShellOptions["manifest"],
+  runtime: ShellOptions["runtime"],
 ): void {
   if (request.buildId === undefined) return;
-  if (request.buildId !== manifest.buildId) {
+  if (request.buildId !== runtime.buildId) {
     throw new Error(
-      `${prefix}.buildId "${request.buildId}" does not match manifest.buildId "${manifest.buildId}".`,
+      `${prefix}.buildId "${request.buildId}" does not match runtime.buildId "${runtime.buildId}".`,
     );
   }
 }
@@ -448,41 +448,36 @@ function assertActivationTargetRequest(
   }
 }
 
-function assertShellManifest(manifest: unknown): void {
-  if (!isRecord(manifest)) {
-    throw new Error("[evjs] createShell() manifest must be an object.");
+function assertShellRuntime(runtime: unknown): void {
+  if (!isRecord(runtime)) {
+    throw new Error("[evjs] createShell() runtime must be an object.");
   }
-  if (manifest.version !== 1) {
-    throw new Error("[evjs] createShell() manifest.version must be 1.");
+  if (runtime.version !== 1) {
+    throw new Error("[evjs] createShell() runtime.version must be 1.");
   }
-  if (typeof manifest.buildId !== "string" || !manifest.buildId.trim()) {
+  if (typeof runtime.buildId !== "string" || !runtime.buildId.trim()) {
     throw new Error(
-      "[evjs] createShell() manifest.buildId must be a non-empty string.",
+      "[evjs] createShell() runtime.buildId must be a non-empty string.",
     );
   }
-  if (!isBuildIdentifier(manifest.buildId)) {
+  if (!isBuildIdentifier(runtime.buildId)) {
     throw new Error(
-      `[evjs] createShell() manifest.buildId must contain only ${BUILD_IDENTIFIER_DESCRIPTION}.`,
+      `[evjs] createShell() runtime.buildId must contain only ${BUILD_IDENTIFIER_DESCRIPTION}.`,
     );
   }
-  if (!isRecord(manifest.runtime)) {
-    throw new Error("[evjs] createShell() manifest.runtime must be an object.");
+  if (!isRecord(runtime.runtime)) {
+    throw new Error("[evjs] createShell() runtime.runtime must be an object.");
   }
-  if (!isRecord(manifest.pages)) {
-    throw new Error("[evjs] createShell() manifest.pages must be an object.");
+  if (!isRecord(runtime.pages)) {
+    throw new Error("[evjs] createShell() runtime.pages must be an object.");
   }
-  if (!isRecord(manifest.apps)) {
-    throw new Error("[evjs] createShell() manifest.apps must be an object.");
+  if (!isRecord(runtime.apps)) {
+    throw new Error("[evjs] createShell() runtime.apps must be an object.");
   }
-  if (!Array.isArray(manifest.routes)) {
-    throw new Error("[evjs] createShell() manifest.routes must be an array.");
+  if (!Array.isArray(runtime.routes)) {
+    throw new Error("[evjs] createShell() runtime.routes must be an array.");
   }
-  assertFrameworkManifestShape(manifest, "createShell() manifest", {
-    serverFunctionModules: "optional",
-    pageRendererReferences: "optional",
-    pprRendererReferences: "optional",
-    rscRendererReferences: "optional",
-  });
+  assertClientRuntime(runtime, "createShell() runtime");
 }
 
 function assertShellDriver(driver: unknown, index: number): void {

--- a/packages/client/src/shell/targets.ts
+++ b/packages/client/src/shell/targets.ts
@@ -1,17 +1,15 @@
-import type { BuildOutput } from "@evjs/shared/manifest";
+import type { ClientRuntime } from "../runtime-config.js";
 import { isRecord } from "../validation.js";
 import type { ActivationRequest, ResolvedShellTarget } from "./types.js";
 
 export async function resolveTarget(
-  manifest: BuildOutput,
+  runtime: ClientRuntime,
   request: ActivationRequest,
 ): Promise<ResolvedShellTarget> {
   if (request.pageId) {
-    const page = manifest.pages[request.pageId];
+    const page = runtime.pages[request.pageId];
     if (!page) {
-      throw new Error(
-        `[evjs] Page "${request.pageId}" is not in the manifest.`,
-      );
+      throw new Error(`[evjs] Page "${request.pageId}" is not in the runtime.`);
     }
     const href = readRuntimeModuleHref(page.module, `Page "${request.pageId}"`);
     if (!href) {
@@ -25,17 +23,17 @@ export async function resolveTarget(
       ctx: {
         id: request.pageId,
         kind: "page",
-        manifest,
+        runtime,
         output: page,
         request,
       },
     };
   }
 
-  const appId = request.appId ?? Object.keys(manifest.apps)[0];
-  const app = appId ? manifest.apps[appId] : undefined;
+  const appId = request.appId ?? Object.keys(runtime.apps)[0];
+  const app = appId ? runtime.apps[appId] : undefined;
   if (!appId || !app) {
-    throw new Error("[evjs] No app target is available in the manifest.");
+    throw new Error("[evjs] No app target is available in the runtime.");
   }
   const href = readRuntimeModuleHref(app.module, `App "${appId}"`);
   if (!href) {
@@ -49,7 +47,7 @@ export async function resolveTarget(
     ctx: {
       id: appId,
       kind: "app",
-      manifest,
+      runtime,
       output: app,
       request,
     },

--- a/packages/client/src/shell/types.ts
+++ b/packages/client/src/shell/types.ts
@@ -1,4 +1,8 @@
-import type { AppOutput, BuildOutput, PageOutput } from "@evjs/shared/manifest";
+import type {
+  ClientRuntime,
+  ClientRuntimeApp,
+  ClientRuntimePage,
+} from "../runtime-config.js";
 
 export interface AppModule {
   init?: (ctx: AppContext) => void | Promise<void>;
@@ -14,8 +18,8 @@ export type ShellModuleRegistration =
 export interface AppContext {
   id: string;
   kind: "app" | "page";
-  manifest: BuildOutput;
-  output: AppOutput | PageOutput;
+  runtime: ClientRuntime;
+  output: ClientRuntimeApp | ClientRuntimePage;
   request: ActivationRequest;
 }
 
@@ -29,7 +33,7 @@ export interface ActivationRequest {
 }
 
 export interface ShellOptions {
-  manifest: BuildOutput;
+  runtime: ClientRuntime;
   drivers?: ShellDriver[];
   loadModule?: (href: string, ctx: AppContext) => Promise<AppModule>;
   resolveMountPoint?: (ctx: AppContext) => Element | null;
@@ -63,7 +67,7 @@ export interface PageDriverOptions {
 export interface PageDriver extends ShellDriver {}
 
 export interface HistoryDriverOptions {
-  manifest: BuildOutput;
+  runtime: ClientRuntime;
   window?: BrowserWindowLike;
 }
 

--- a/packages/client/src/transport-runtime.ts
+++ b/packages/client/src/transport-runtime.ts
@@ -21,12 +21,12 @@ import {
   ServerFunctionError,
   type UrlStringValidationError,
 } from "@evjs/shared";
-import type { BuildOutput } from "@evjs/shared/manifest";
 import {
   type FetchResponseObject,
   getFetchResponseContentType,
   readFetchErrorResponseBody,
 } from "./fetch-response.js";
+import type { ClientRuntime } from "./runtime-config.js";
 import { formatErrorDetail, isRecord } from "./validation.js";
 
 /**
@@ -405,7 +405,7 @@ function readServerFunctionSuccessResult(payload: Record<string, unknown>) {
 }
 
 let _runtime: TransportRuntime | null = null;
-let _runtimeSource: "default" | "manifest" | "user" | null = null;
+let _runtimeSource: "default" | "client-runtime" | "user" | null = null;
 
 function createTransportRuntime(options: TransportOptions): TransportRuntime {
   const endpoint = options.functions?.endpoint ?? getFunctionEndpoint();
@@ -445,22 +445,22 @@ export function initTransport(options: TransportOptions = {}): void {
 }
 
 /**
- * Initialize the default HTTP transport from the framework manifest.
+ * Initialize the default HTTP transport from the generated client runtime.
  *
  * Framework-managed runtimes call this before loading user modules. Explicit
  * initTransport() calls still win, so custom adapters are not overwritten.
  */
-export function initTransportFromManifest(
-  manifest: Pick<BuildOutput, "runtime">,
+export function initTransportFromRuntime(
+  runtime: Pick<ClientRuntime, "runtime">,
 ): void {
-  const transport = getManifestTransport(manifest);
+  const transport = getClientRuntimeTransport(runtime);
   if (!transport?.baseUrl || _runtimeSource === "user") return;
 
   _runtime = createTransportRuntime({
     baseUrl: transport.baseUrl,
     silent: true,
   });
-  _runtimeSource = "manifest";
+  _runtimeSource = "client-runtime";
 }
 
 /**
@@ -793,25 +793,25 @@ function formatTransportBaseUrlError(error: UrlStringValidationError): string {
   }
 }
 
-function getManifestTransport(
-  manifest: unknown,
+function getClientRuntimeTransport(
+  runtime: unknown,
 ): { baseUrl?: string } | undefined {
-  if (!isRecord(manifest)) {
+  if (!isRecord(runtime)) {
     throw new Error(
-      "[evjs] initTransportFromManifest() manifest must be a framework manifest object.",
+      "[evjs] initTransportFromRuntime() runtime must be a client runtime object.",
     );
   }
-  if (!isRecord(manifest.runtime)) {
+  if (!isRecord(runtime.runtime)) {
     throw new Error(
-      "[evjs] initTransportFromManifest() manifest.runtime must be an object.",
+      "[evjs] initTransportFromRuntime() runtime.runtime must be an object.",
     );
   }
 
-  const transport = manifest.runtime.transport;
+  const transport = runtime.runtime.transport;
   if (transport === undefined) return undefined;
   if (!isRecord(transport)) {
     throw new Error(
-      "[evjs] initTransportFromManifest() manifest.runtime.transport must be an object.",
+      "[evjs] initTransportFromRuntime() runtime.runtime.transport must be an object.",
     );
   }
 
@@ -819,7 +819,7 @@ function getManifestTransport(
   return {
     baseUrl: assertTransportBaseUrl(
       transport.baseUrl,
-      "initTransportFromManifest() manifest.runtime.transport.baseUrl",
+      "initTransportFromRuntime() runtime.runtime.transport.baseUrl",
     ),
   };
 }

--- a/packages/client/tests/page-route.test.ts
+++ b/packages/client/tests/page-route.test.ts
@@ -36,7 +36,7 @@ describe("page route hooks", () => {
     expect("callServer" in client).toBe(false);
     expect("getFnId" in client).toBe(false);
     expect("getFnName" in client).toBe(true);
-    expect("initTransportFromManifest" in client).toBe(false);
+    expect("initTransportFromRuntime" in client).toBe(false);
   });
 
   it("exposes manual router construction APIs for standalone CSR apps", () => {

--- a/packages/client/tests/page-runtime.test.ts
+++ b/packages/client/tests/page-runtime.test.ts
@@ -1,6 +1,6 @@
-import type { BuildOutput } from "@evjs/shared/manifest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { startPageRuntime } from "../src/internal";
+import type { ClientRuntime } from "../src/runtime-config.js";
 import {
   __resetForTesting,
   callServer,
@@ -13,12 +13,12 @@ afterEach(() => {
 });
 
 describe("startPageRuntime", () => {
-  it("boots the shell from framework HTML attributes and an embedded manifest", async () => {
+  it("boots the shell from framework HTML attributes and an embedded runtime", async () => {
     const events: string[] = [];
     const mountPoint = {} as Element;
-    const manifest = createManifest();
+    const runtime = createRuntime();
     const document = createDocument({
-      manifest,
+      runtime,
       mountPoint,
       attributes: {
         "data-evjs-kind": "page",
@@ -46,7 +46,7 @@ describe("startPageRuntime", () => {
     expect(events).toEqual(["load:/home.js", "hydrate:page:home:true"]);
   });
 
-  it("fetches the manifest when it is not embedded", async () => {
+  it("fetches the runtime when it is not embedded", async () => {
     const events: string[] = [];
     const mountPoint = {} as Element;
     const document = createDocument({
@@ -54,12 +54,12 @@ describe("startPageRuntime", () => {
       attributes: {
         "data-evjs-kind": "page",
         "data-evjs-id": "home",
-        "data-evjs-manifest": "/assets/manifest.json",
+        "data-evjs-runtime": "/assets/runtime.json",
       },
     });
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => Response.json(createManifest())),
+      vi.fn(async () => Response.json(createRuntime())),
     );
 
     await startPageRuntime({
@@ -74,11 +74,11 @@ describe("startPageRuntime", () => {
       },
     });
 
-    expect(fetch).toHaveBeenCalledWith("/assets/manifest.json");
+    expect(fetch).toHaveBeenCalledWith("/assets/runtime.json");
     expect(events).toEqual(["load:/home.js", "mount"]);
   });
 
-  it("rejects invalid framework HTML target attributes before manifest loading", async () => {
+  it("rejects invalid framework HTML target attributes before runtime loading", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
@@ -156,9 +156,9 @@ describe("startPageRuntime", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("reports malformed embedded manifests with an evjs error", async () => {
+  it("reports malformed embedded runtimes with an evjs error", async () => {
     const document = createDocument({
-      embeddedManifestText: "{",
+      embeddedRuntimeText: "{",
       mountPoint: {} as Element,
       attributes: {
         "data-evjs-kind": "page",
@@ -167,13 +167,13 @@ describe("startPageRuntime", () => {
     });
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Failed to parse embedded manifest "__EVJS_MANIFEST__" as JSON',
+      '[evjs] Failed to parse embedded runtime "__EVJS_CLIENT_RUNTIME__" as JSON',
     );
   });
 
-  it("reports invalid embedded manifest script text with an evjs error", async () => {
+  it("reports invalid embedded runtime script text with an evjs error", async () => {
     const document = createDocument({
-      embeddedManifestText: 42,
+      embeddedRuntimeText: 42,
       mountPoint: {} as Element,
       attributes: {
         "data-evjs-kind": "page",
@@ -182,17 +182,17 @@ describe("startPageRuntime", () => {
     });
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Embedded manifest "__EVJS_MANIFEST__" textContent must be a string when provided.',
+      '[evjs] Embedded runtime "__EVJS_CLIENT_RUNTIME__" textContent must be a string when provided.',
     );
   });
 
-  it("reports malformed fetched manifests with an evjs error", async () => {
+  it("reports malformed fetched runtimes with an evjs error", async () => {
     const document = createDocument({
       mountPoint: {} as Element,
       attributes: {
         "data-evjs-kind": "page",
         "data-evjs-id": "home",
-        "data-evjs-manifest": "/assets/manifest.json",
+        "data-evjs-runtime": "/assets/runtime.json",
       },
     });
     vi.stubGlobal(
@@ -207,11 +207,11 @@ describe("startPageRuntime", () => {
     );
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Failed to parse manifest "/assets/manifest.json" as JSON',
+      '[evjs] Failed to parse runtime "/assets/runtime.json" as JSON',
     );
   });
 
-  it("rejects invalid manifest URL attributes before fetching", async () => {
+  it("rejects invalid runtime URL attributes before fetching", async () => {
     await expect(
       startPageRuntime({
         document: createDocument({
@@ -219,12 +219,12 @@ describe("startPageRuntime", () => {
           attributes: {
             "data-evjs-kind": "page",
             "data-evjs-id": "home",
-            "data-evjs-manifest": "",
+            "data-evjs-runtime": "",
           },
         }),
       }),
     ).rejects.toThrow(
-      "[evjs] startPageRuntime() data-evjs-manifest must be a non-empty manifest URL.",
+      "[evjs] startPageRuntime() data-evjs-runtime must be a non-empty runtime URL.",
     );
 
     await expect(
@@ -234,12 +234,12 @@ describe("startPageRuntime", () => {
           attributes: {
             "data-evjs-kind": "page",
             "data-evjs-id": "home",
-            "data-evjs-manifest": " /assets/manifest.json ",
+            "data-evjs-runtime": " /assets/runtime.json ",
           },
         }),
       }),
     ).rejects.toThrow(
-      "[evjs] startPageRuntime() data-evjs-manifest must not include leading or trailing whitespace.",
+      "[evjs] startPageRuntime() data-evjs-runtime must not include leading or trailing whitespace.",
     );
 
     await expect(
@@ -249,22 +249,22 @@ describe("startPageRuntime", () => {
           attributes: {
             "data-evjs-kind": "page",
             "data-evjs-id": "home",
-            "data-evjs-manifest": "javascript:alert(1)",
+            "data-evjs-runtime": "javascript:alert(1)",
           },
         }),
       }),
     ).rejects.toThrow(
-      "[evjs] startPageRuntime() data-evjs-manifest must be an http(s) URL or path.",
+      "[evjs] startPageRuntime() data-evjs-runtime must be an http(s) URL or path.",
     );
   });
 
-  it("reports failed manifest fetches with an evjs error", async () => {
+  it("reports failed runtime fetches with an evjs error", async () => {
     const document = createDocument({
       mountPoint: {} as Element,
       attributes: {
         "data-evjs-kind": "page",
         "data-evjs-id": "home",
-        "data-evjs-manifest": "/assets/manifest.json",
+        "data-evjs-runtime": "/assets/runtime.json",
       },
     });
     vi.stubGlobal(
@@ -275,33 +275,33 @@ describe("startPageRuntime", () => {
     );
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Failed to load manifest "/assets/manifest.json": network offline',
+      '[evjs] Failed to load runtime "/assets/runtime.json": network offline',
     );
   });
 
-  it("reports missing fetch support for manifest loading", async () => {
+  it("reports missing fetch support for runtime loading", async () => {
     const document = createDocument({
       mountPoint: {} as Element,
       attributes: {
         "data-evjs-kind": "page",
         "data-evjs-id": "home",
-        "data-evjs-manifest": "/assets/manifest.json",
+        "data-evjs-runtime": "/assets/runtime.json",
       },
     });
     vi.stubGlobal("fetch", undefined);
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Failed to load manifest "/assets/manifest.json": fetch is not available.',
+      '[evjs] Failed to load runtime "/assets/runtime.json": fetch is not available.',
     );
   });
 
-  it("reports invalid manifest fetch response objects with an evjs error", async () => {
+  it("reports invalid runtime fetch response objects with an evjs error", async () => {
     const document = createDocument({
       mountPoint: {} as Element,
       attributes: {
         "data-evjs-kind": "page",
         "data-evjs-id": "home",
-        "data-evjs-manifest": "/assets/manifest.json",
+        "data-evjs-runtime": "/assets/runtime.json",
       },
     });
 
@@ -311,19 +311,19 @@ describe("startPageRuntime", () => {
     );
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Failed to load manifest "/assets/manifest.json": fetch returned an invalid Response object.',
+      '[evjs] Failed to load runtime "/assets/runtime.json": fetch returned an invalid Response object.',
     );
 
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => ({
         ok: "yes",
-        json: async () => createManifest(),
+        json: async () => createRuntime(),
       })),
     );
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Failed to load manifest "/assets/manifest.json": fetch response.ok must be a boolean.',
+      '[evjs] Failed to load runtime "/assets/runtime.json": fetch response.ok must be a boolean.',
     );
 
     vi.stubGlobal(
@@ -335,7 +335,7 @@ describe("startPageRuntime", () => {
     );
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Failed to load manifest "/assets/manifest.json": fetch response.status must be a number when ok is false.',
+      '[evjs] Failed to load runtime "/assets/runtime.json": fetch response.status must be a number when ok is false.',
     );
 
     vi.stubGlobal(
@@ -347,7 +347,7 @@ describe("startPageRuntime", () => {
     );
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Failed to load manifest "/assets/manifest.json": fetch response.statusText must be a string when ok is false.',
+      '[evjs] Failed to load runtime "/assets/runtime.json": fetch response.statusText must be a string when ok is false.',
     );
 
     vi.stubGlobal(
@@ -358,7 +358,7 @@ describe("startPageRuntime", () => {
     );
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Failed to load manifest "/assets/manifest.json": fetch response.json must be a function.',
+      '[evjs] Failed to load runtime "/assets/runtime.json": fetch response.json must be a function.',
     );
 
     vi.stubGlobal(
@@ -366,12 +366,12 @@ describe("startPageRuntime", () => {
       vi.fn(async () => ({
         ok: true,
         headers: new Headers({ "Content-Type": "text/application/json" }),
-        json: async () => createManifest(),
+        json: async () => createRuntime(),
       })),
     );
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Failed to load manifest "/assets/manifest.json": fetch response Content-Type must be "application/json"; received "text/application/json".',
+      '[evjs] Failed to load runtime "/assets/runtime.json": fetch response Content-Type must be "application/json"; received "text/application/json".',
     );
 
     vi.stubGlobal(
@@ -379,22 +379,22 @@ describe("startPageRuntime", () => {
       vi.fn(async () => ({
         ok: true,
         headers: new Headers(),
-        json: async () => createManifest(),
+        json: async () => createRuntime(),
       })),
     );
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Failed to load manifest "/assets/manifest.json": fetch response Content-Type must be "application/json"; received missing Content-Type.',
+      '[evjs] Failed to load runtime "/assets/runtime.json": fetch response Content-Type must be "application/json"; received missing Content-Type.',
     );
   });
 
-  it("reports failed manifest HTTP responses without requiring a JSON parser", async () => {
+  it("reports failed runtime HTTP responses without requiring a JSON parser", async () => {
     const document = createDocument({
       mountPoint: {} as Element,
       attributes: {
         "data-evjs-kind": "page",
         "data-evjs-id": "home",
-        "data-evjs-manifest": "/assets/manifest.json",
+        "data-evjs-runtime": "/assets/runtime.json",
       },
     });
 
@@ -408,14 +408,14 @@ describe("startPageRuntime", () => {
     );
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Failed to load manifest "/assets/manifest.json": 503 Service Unavailable',
+      '[evjs] Failed to load runtime "/assets/runtime.json": 503 Service Unavailable',
     );
 
     vi.stubGlobal(
       "fetch",
       vi.fn(
         async () =>
-          new Response("deployment manifest missing", {
+          new Response("deployment runtime missing", {
             status: 503,
             statusText: "Service Unavailable",
           }),
@@ -423,7 +423,7 @@ describe("startPageRuntime", () => {
     );
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Failed to load manifest "/assets/manifest.json": 503 Service Unavailable: deployment manifest missing',
+      '[evjs] Failed to load runtime "/assets/runtime.json": 503 Service Unavailable: deployment runtime missing',
     );
 
     vi.stubGlobal(
@@ -438,13 +438,13 @@ describe("startPageRuntime", () => {
     );
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Failed to load manifest "/assets/manifest.json": 502 Bad Gateway',
+      '[evjs] Failed to load runtime "/assets/runtime.json": 502 Bad Gateway',
     );
   });
 
-  it("reports invalid loaded manifest shapes with an evjs error", async () => {
+  it("reports invalid loaded runtime shapes with an evjs error", async () => {
     const document = createDocument({
-      embeddedManifestText: "[]",
+      embeddedRuntimeText: "[]",
       mountPoint: {} as Element,
       attributes: {
         "data-evjs-kind": "page",
@@ -453,14 +453,14 @@ describe("startPageRuntime", () => {
     });
 
     await expect(startPageRuntime({ document })).rejects.toThrow(
-      '[evjs] Loaded embedded manifest "__EVJS_MANIFEST__" must be a JSON object.',
+      '[evjs] Loaded embedded runtime "__EVJS_CLIENT_RUNTIME__" must be a JSON object.',
     );
 
     await expect(
       startPageRuntime({
         document: createDocument({
-          embeddedManifestText: JSON.stringify({
-            ...createManifest(),
+          embeddedRuntimeText: JSON.stringify({
+            ...createRuntime(),
             version: 2,
           }),
           mountPoint: {} as Element,
@@ -471,14 +471,14 @@ describe("startPageRuntime", () => {
         }),
       }),
     ).rejects.toThrow(
-      '[evjs] Loaded embedded manifest "__EVJS_MANIFEST__" version must be 1.',
+      '[evjs] Loaded embedded runtime "__EVJS_CLIENT_RUNTIME__" version must be 1.',
     );
 
     await expect(
       startPageRuntime({
         document: createDocument({
-          embeddedManifestText: JSON.stringify({
-            ...createManifest(),
+          embeddedRuntimeText: JSON.stringify({
+            ...createRuntime(),
             pages: [],
           }),
           mountPoint: {} as Element,
@@ -489,11 +489,11 @@ describe("startPageRuntime", () => {
         }),
       }),
     ).rejects.toThrow(
-      '[evjs] Loaded embedded manifest "__EVJS_MANIFEST__" pages must be an object.',
+      '[evjs] Loaded embedded runtime "__EVJS_CLIENT_RUNTIME__" pages must be an object.',
     );
   });
 
-  it("reports invalid explicit manifest options with an evjs error", async () => {
+  it("reports invalid explicit runtime options with an evjs error", async () => {
     const document = createDocument({
       mountPoint: {} as Element,
       attributes: {
@@ -503,145 +503,97 @@ describe("startPageRuntime", () => {
     });
 
     await expect(
-      startPageRuntime({ document, manifest: null as never }),
-    ).rejects.toThrow("[evjs] Loaded provided manifest must be a JSON object.");
+      startPageRuntime({ document, runtime: null as never }),
+    ).rejects.toThrow("[evjs] Loaded provided runtime must be a JSON object.");
 
     await expect(
       startPageRuntime({
         document,
-        manifest: {
-          ...createManifest(),
+        runtime: {
+          ...createRuntime(),
           buildId: "build.1",
         } as never,
       }),
     ).rejects.toThrow(
-      "[evjs] Loaded provided manifest.buildId must contain only letters, numbers, underscores, or hyphens.",
+      "[evjs] Loaded provided runtime.buildId must contain only letters, numbers, underscores, or hyphens.",
     );
 
     await expect(
       startPageRuntime({
         document,
-        manifest: {
-          ...createManifest(),
-          publicPath: { mode: "asset" },
-        } as never,
-      }),
-    ).rejects.toThrow(
-      "[evjs] Loaded provided manifest.publicPath must be a non-empty string.",
-    );
-
-    await expect(
-      startPageRuntime({
-        document,
-        manifest: {
-          ...createManifest(),
-          assets: [],
-        } as never,
-      }),
-    ).rejects.toThrow(
-      "[evjs] Loaded provided manifest.assets must be an object.",
-    );
-
-    await expect(
-      startPageRuntime({
-        document,
-        manifest: {
-          ...createManifest(),
+        runtime: {
+          ...createRuntime(),
           pages: {
             home: {
-              ...createManifest().pages.home,
+              ...createRuntime().pages.home,
               module: { type: "lifecycle", href: " /home.js " },
             },
           },
         } as never,
       }),
     ).rejects.toThrow(
-      "[evjs] Loaded provided manifest.pages.home.module.href must not contain leading or trailing whitespace.",
+      "[evjs] Loaded provided runtime.pages.home.module.href must not contain leading or trailing whitespace.",
     );
 
     await expect(
       startPageRuntime({
         document,
-        manifest: {
-          ...createManifest(),
-          pages: {
-            home: {
-              ...createManifest().pages.home,
-              rendering: {
-                component: "server",
-                html: "server",
-                streaming: false,
-                hydrate: "viewport",
-              },
-            },
-          },
+        runtime: {
+          ...createRuntime(),
+          runtime: { ...createRuntime().runtime, transport: [] },
         } as never,
       }),
     ).rejects.toThrow(
-      '[evjs] Loaded provided manifest.pages.home.rendering.hydrate must be "none", "load", "visible", or "idle".',
+      "[evjs] Loaded provided runtime.runtime.transport must be an object.",
     );
 
     await expect(
       startPageRuntime({
         document,
-        manifest: {
-          ...createManifest(),
-          runtime: { ...createManifest().runtime, transport: [] },
-        } as never,
-      }),
-    ).rejects.toThrow(
-      "[evjs] Loaded provided manifest.runtime.transport must be an object.",
-    );
-
-    await expect(
-      startPageRuntime({
-        document,
-        manifest: {
-          ...createManifest(),
+        runtime: {
+          ...createRuntime(),
           runtime: {
-            ...createManifest().runtime,
+            ...createRuntime().runtime,
             transport: { baseUrl: "http://[::1" },
           },
         } as never,
       }),
     ).rejects.toThrow(
-      "[evjs] Loaded provided manifest.runtime.transport.baseUrl must be a valid URL string.",
+      "[evjs] Loaded provided runtime.runtime.transport.baseUrl must be a valid URL string.",
     );
 
     await expect(
       startPageRuntime({
         document,
-        manifest: {
-          ...createManifest(),
+        runtime: {
+          ...createRuntime(),
           apps: [],
         } as never,
       }),
-    ).rejects.toThrow(
-      "[evjs] Loaded provided manifest apps must be an object.",
-    );
+    ).rejects.toThrow("[evjs] Loaded provided runtime apps must be an object.");
 
     await expect(
       startPageRuntime({
         document,
-        manifest: {
-          ...createManifest(),
+        runtime: {
+          ...createRuntime(),
           routes: {},
         } as never,
       }),
     ).rejects.toThrow(
-      "[evjs] Loaded provided manifest routes must be an array.",
+      "[evjs] Loaded provided runtime routes must be an array.",
     );
 
     await expect(
       startPageRuntime({
         document,
-        manifest: {
-          ...createManifest(),
+        runtime: {
+          ...createRuntime(),
           routes: [{ id: "home", path: "home", pageId: "home" }],
         } as never,
       }),
     ).rejects.toThrow(
-      '[evjs] Loaded provided manifest.routes[0].path must start with "/".',
+      '[evjs] Loaded provided runtime.routes[0].path must start with "/".',
     );
   });
 
@@ -649,18 +601,18 @@ describe("startPageRuntime", () => {
     await expect(startPageRuntime(null as never)).rejects.toThrow(
       "[evjs] startPageRuntime() options must be an object.",
     );
-    await expect(startPageRuntime({ manifestUrl: "" })).rejects.toThrow(
-      "[evjs] startPageRuntime() manifestUrl must be a non-empty string.",
+    await expect(startPageRuntime({ runtimeUrl: "" })).rejects.toThrow(
+      "[evjs] startPageRuntime() runtimeUrl must be a non-empty string.",
     );
     await expect(
-      startPageRuntime({ manifestUrl: " /manifest.json" }),
+      startPageRuntime({ runtimeUrl: " /runtime.json" }),
     ).rejects.toThrow(
-      "[evjs] startPageRuntime() manifestUrl must not include leading or trailing whitespace.",
+      "[evjs] startPageRuntime() runtimeUrl must not include leading or trailing whitespace.",
     );
     await expect(
-      startPageRuntime({ manifestUrl: "javascript:alert(1)" }),
+      startPageRuntime({ runtimeUrl: "javascript:alert(1)" }),
     ).rejects.toThrow(
-      "[evjs] startPageRuntime() manifestUrl must be an http(s) URL or path.",
+      "[evjs] startPageRuntime() runtimeUrl must be an http(s) URL or path.",
     );
     await expect(startPageRuntime({ mount: "" })).rejects.toThrow(
       "[evjs] startPageRuntime() mount must be a non-empty selector string.",
@@ -706,7 +658,7 @@ describe("startPageRuntime", () => {
 
   it("reports invalid custom mount selectors with an evjs error", async () => {
     const document = createDocument({
-      manifest: createManifest(),
+      runtime: createRuntime(),
       mountPoint: {} as Element,
       attributes: {
         "data-evjs-kind": "page",
@@ -731,7 +683,7 @@ describe("startPageRuntime", () => {
 
   it("reports unresolved custom mount selectors with an evjs error", async () => {
     const document = createDocument({
-      manifest: createManifest(),
+      runtime: createRuntime(),
       mountPoint: {} as Element,
       attributes: {
         "data-evjs-kind": "page",
@@ -757,7 +709,7 @@ describe("startPageRuntime", () => {
   it("reports invalid custom mount selector results with an evjs error", async () => {
     const document = {
       ...createDocument({
-        manifest: createManifest(),
+        runtime: createRuntime(),
         mountPoint: {} as Element,
         attributes: {
           "data-evjs-kind": "page",
@@ -783,14 +735,14 @@ describe("startPageRuntime", () => {
     );
   });
 
-  it("initializes HTTP transport from manifest runtime metadata", async () => {
+  it("initializes HTTP transport from runtime runtime metadata", async () => {
     const mountPoint = {} as Element;
-    const manifest = createManifest();
-    manifest.runtime.transport = {
+    const runtime = createRuntime();
+    runtime.runtime.transport = {
       baseUrl: "https://api.example.com/framework",
     };
     const document = createDocument({
-      manifest,
+      runtime,
       mountPoint,
       attributes: {
         "data-evjs-kind": "page",
@@ -825,12 +777,12 @@ describe("startPageRuntime", () => {
     const send = vi.fn().mockResolvedValue("ok");
     initTransport({ adapter: { send } });
     const mountPoint = {} as Element;
-    const manifest = createManifest();
-    manifest.runtime.transport = {
+    const runtime = createRuntime();
+    runtime.runtime.transport = {
       baseUrl: "https://api.example.com/framework",
     };
     const document = createDocument({
-      manifest,
+      runtime,
       mountPoint,
       attributes: {
         "data-evjs-kind": "page",
@@ -852,30 +804,14 @@ describe("startPageRuntime", () => {
   });
 });
 
-function createManifest(): BuildOutput {
+function createRuntime(): ClientRuntime {
   return {
     version: 1,
     buildId: "test",
-    distDir: "dist",
-    publicPath: "/",
-    runtime: {
-      server: {
-        basePath: "/__evjs",
-        fn: "/__evjs/fn",
-      },
-    },
-    assets: {},
+    runtime: {},
     apps: {},
     pages: {
       home: {
-        assets: { js: ["home.js"], css: [] },
-        render: "ssr",
-        rendering: {
-          component: "server",
-          html: "server",
-          streaming: false,
-          hydrate: "load",
-        },
         mount: "#root",
         module: {
           type: "lifecycle",
@@ -884,17 +820,12 @@ function createManifest(): BuildOutput {
       },
     },
     routes: [],
-    server: {
-      assets: { js: [], css: [] },
-      functions: {},
-      routes: [],
-    },
   };
 }
 
 function createDocument(options: {
-  manifest?: BuildOutput;
-  embeddedManifestText?: unknown;
+  runtime?: ClientRuntime;
+  embeddedRuntimeText?: unknown;
   mountPoint: Element;
   attributes: Record<string, string>;
 }): Document {
@@ -905,15 +836,15 @@ function createDocument(options: {
       },
     },
     getElementById(id: string) {
-      if (id !== "__EVJS_MANIFEST__") return null;
-      if (options.embeddedManifestText !== undefined) {
+      if (id !== "__EVJS_CLIENT_RUNTIME__") return null;
+      if (options.embeddedRuntimeText !== undefined) {
         return {
-          textContent: options.embeddedManifestText,
+          textContent: options.embeddedRuntimeText,
         };
       }
-      if (!options.manifest) return null;
+      if (!options.runtime) return null;
       return {
-        textContent: JSON.stringify(options.manifest),
+        textContent: JSON.stringify(options.runtime),
       };
     },
     querySelector(selector: string) {

--- a/packages/client/tests/public-surface-types.ts
+++ b/packages/client/tests/public-surface-types.ts
@@ -90,9 +90,9 @@ export type HiddenCreateServerReference = typeof Client.createServerReference;
 // @ts-expect-error callServer is internal to generated server-function stubs.
 export type HiddenCallServer = typeof Client.callServer;
 
-export type HiddenInitTransportFromManifest =
-  // @ts-expect-error initTransportFromManifest is internal to generated bootstrap.
-  typeof Client.initTransportFromManifest;
+export type HiddenInitTransportFromRuntime =
+  // @ts-expect-error initTransportFromRuntime is internal to generated bootstrap.
+  typeof Client.initTransportFromRuntime;
 
 export type HiddenGetRscFetchResponseContentType =
   // @ts-expect-error getRscFetchResponseContentType is an internal runtime helper.
@@ -101,9 +101,9 @@ export type HiddenGetRscFetchResponseContentType =
 // @ts-expect-error FileRoute is a router implementation detail.
 export type HiddenFileRoute = Client.FileRoute;
 
-export type HiddenPublicTransportManifestInit =
-  // @ts-expect-error initTransportFromManifest is framework bootstrap-only.
-  typeof ClientTransport.initTransportFromManifest;
+export type HiddenPublicTransportRuntimeInit =
+  // @ts-expect-error initTransportFromRuntime is framework bootstrap-only.
+  typeof ClientTransport.initTransportFromRuntime;
 
 export type HiddenPublicTransportGetServerFunction =
   // @ts-expect-error getServerFunction is internal query runtime plumbing.

--- a/packages/client/tests/react-runtime.test.ts
+++ b/packages/client/tests/react-runtime.test.ts
@@ -1,4 +1,3 @@
-import type { BuildOutput } from "@evjs/shared/manifest";
 import { memo } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createReactPageModule, mountReactPage } from "../src/internal";
@@ -8,6 +7,7 @@ import {
   loadRscDebugPage,
   mountRscDebugPayload,
 } from "../src/react.js";
+import type { ClientRuntime } from "../src/runtime-config.js";
 
 const calls: string[] = [];
 const renderedElements: unknown[] = [];
@@ -343,19 +343,10 @@ describe("createReactPageModule", () => {
       pathname: "/users/settings",
       search: "",
     });
-    const manifest: BuildOutput = {
-      ...createRscManifest(),
+    const runtime: ClientRuntime = {
+      ...createRscRuntime(),
       pages: {
-        profile: {
-          assets: { js: [], css: [] },
-          render: "csr",
-          rendering: {
-            component: "client",
-            html: "client",
-            streaming: false,
-            hydrate: "load",
-          },
-        },
+        profile: {},
       },
       routes: [
         {
@@ -381,8 +372,8 @@ describe("createReactPageModule", () => {
       {
         id: "profile",
         kind: "page",
-        manifest,
-        output: manifest.pages.profile,
+        runtime,
+        output: runtime.pages.profile,
         request: { url: "/users/settings" },
       } as never,
     );
@@ -403,7 +394,7 @@ describe("createReactPageModule", () => {
       loaderData: undefined,
     });
     expect(element.props?.children?.props).toEqual({
-      manifest: { buildId: "test" },
+      runtime: { buildId: "test" },
       pageId: "profile",
       route: { id: "settings", path: "/users/settings" },
     });
@@ -580,27 +571,17 @@ describe("fetchRscFlight", () => {
     const fetchMock = vi.fn(async () => new Response("flight"));
 
     await fetchRscFlight({
-      manifest: {
+      runtime: {
         version: 1,
         buildId: "test",
-        distDir: "dist",
-        publicPath: "/",
         runtime: {
           server: {
-            basePath: "/__evjs",
-            fn: "/__evjs/fn",
             rsc: "/__evjs/rsc",
           },
         },
-        assets: {},
         apps: {},
         pages: {},
         routes: [],
-        server: {
-          assets: { js: [], css: [] },
-          functions: {},
-          routes: [],
-        },
       },
       pageId: "dashboard",
       url: "https://example.com/dashboard?tab=comments&tag=a&tag=b",
@@ -617,7 +598,7 @@ describe("fetchRscFlight", () => {
     const fetchMock = vi.fn(async () => new Response("flight"));
 
     await fetchRscFlight({
-      manifest: createRscManifest(),
+      runtime: createRscRuntime(),
       pageId: "dashboard",
       url: "/dashboard?tab=stats",
       fetch: fetchMock,
@@ -633,10 +614,10 @@ describe("fetchRscFlight", () => {
     const fetchMock = vi.fn(async () => new Response("flight"));
 
     await fetchRscFlight({
-      manifest: {
-        ...createRscManifest(),
+      runtime: {
+        ...createRscRuntime(),
         runtime: {
-          ...createRscManifest().runtime,
+          ...createRscRuntime().runtime,
           transport: {
             baseUrl: "https://runtime.example.com/service/",
           },
@@ -660,24 +641,24 @@ describe("fetchRscFlight", () => {
     );
     await expect(
       fetchRscFlight({
-        manifest: null,
+        runtime: null,
         fetch: fetchMock,
       } as never),
-    ).rejects.toThrow("[evjs] fetchRscFlight() manifest must be an object.");
+    ).rejects.toThrow("[evjs] fetchRscFlight() runtime must be an object.");
     await expect(
       fetchRscFlight({
-        manifest: {
-          ...createRscManifest(),
+        runtime: {
+          ...createRscRuntime(),
           runtime: null,
         } as never,
         fetch: fetchMock,
       }),
     ).rejects.toThrow(
-      "[evjs] fetchRscFlight() manifest.runtime must be an object.",
+      "[evjs] fetchRscFlight() runtime.runtime must be an object.",
     );
     await expect(
       fetchRscFlight({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "",
         fetch: fetchMock,
       }),
@@ -686,7 +667,7 @@ describe("fetchRscFlight", () => {
     );
     await expect(
       fetchRscFlight({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: " dashboard ",
         fetch: fetchMock,
       }),
@@ -695,7 +676,7 @@ describe("fetchRscFlight", () => {
     );
     await expect(
       fetchRscFlight({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         url: { pathname: "/dashboard" } as never,
         fetch: fetchMock,
       }),
@@ -712,7 +693,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscFlight({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "",
         fetch: fetchMock,
@@ -723,7 +704,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscFlight({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "dashboard",
         fetch: fetchMock,
@@ -734,7 +715,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscFlight({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "javascript:alert(1)",
         fetch: fetchMock,
@@ -745,7 +726,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscFlight({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "/dashboard#details",
         fetch: fetchMock,
@@ -754,7 +735,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscFlight({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://evil.example/dashboard",
         fetch: fetchMock,
@@ -770,7 +751,7 @@ describe("fetchRscFlight", () => {
     vi.stubGlobal("fetch", undefined);
     await expect(
       fetchRscFlight({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
       }),
     ).rejects.toThrow(
@@ -779,7 +760,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscFlight({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         fetch: "fetch" as never,
       }),
@@ -789,7 +770,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscFlight({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: async () => {
@@ -800,7 +781,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscFlight({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: async () => null as never,
@@ -811,7 +792,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscFlight({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: async () => ({}) as never,
@@ -834,7 +815,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscDebugPayload({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: fetchMock,
@@ -851,7 +832,7 @@ describe("fetchRscFlight", () => {
   it("rejects RSC debug payload responses with invalid JSON", async () => {
     await expect(
       fetchRscDebugPayload({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: async () =>
@@ -865,7 +846,7 @@ describe("fetchRscFlight", () => {
   it("rejects RSC debug payload responses without application/json content type", async () => {
     await expect(
       fetchRscDebugPayload({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: async () =>
@@ -888,7 +869,7 @@ describe("fetchRscFlight", () => {
   it("includes RSC debug payload error response bodies", async () => {
     await expect(
       fetchRscDebugPayload({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: async () =>
@@ -905,7 +886,7 @@ describe("fetchRscFlight", () => {
   it("reports malformed RSC debug payload response metadata", async () => {
     await expect(
       fetchRscDebugPayload({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: async () => ({ ok: false }) as never,
@@ -916,7 +897,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscDebugPayload({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: async () => ({ ok: false, status: 500 }) as never,
@@ -927,7 +908,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscDebugPayload({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: async () => ({ ok: true }) as never,
@@ -938,7 +919,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscDebugPayload({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: async () =>
@@ -954,7 +935,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscDebugPayload({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: async () =>
@@ -969,7 +950,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscDebugPayload({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: async () =>
@@ -985,7 +966,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscDebugPayload({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: async () =>
@@ -1002,7 +983,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscDebugPayload({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: async () =>
@@ -1022,7 +1003,7 @@ describe("fetchRscFlight", () => {
 
     await expect(
       fetchRscDebugPayload({
-        manifest: createRscManifest(),
+        runtime: createRscRuntime(),
         pageId: "dashboard",
         url: "https://example.com/dashboard",
         fetch: async () =>
@@ -1090,7 +1071,7 @@ describe("fetchRscFlight", () => {
   it("loads and mounts an RSC page", async () => {
     const mountPoint = { innerHTML: "" } as Element & { innerHTML: string };
     const payload = await loadRscDebugPage({
-      manifest: createRscManifest(),
+      runtime: createRscRuntime(),
       pageId: "dashboard",
       url: "https://example.com/dashboard",
       mount: mountPoint,
@@ -1109,27 +1090,17 @@ describe("fetchRscFlight", () => {
   });
 });
 
-function createRscManifest(): BuildOutput {
+function createRscRuntime(): ClientRuntime {
   return {
     version: 1,
     buildId: "test",
-    distDir: "dist",
-    publicPath: "/",
     runtime: {
       server: {
-        basePath: "/__evjs",
-        fn: "/__evjs/fn",
         rsc: "/__evjs/rsc",
       },
     },
-    assets: {},
     apps: {},
     pages: {},
     routes: [],
-    server: {
-      assets: { js: [], css: [] },
-      functions: {},
-      routes: [],
-    },
   };
 }

--- a/packages/client/tests/rsc-runtime.test.ts
+++ b/packages/client/tests/rsc-runtime.test.ts
@@ -1,4 +1,3 @@
-import type { BuildOutput } from "@evjs/shared/manifest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createReactRscModel,
@@ -7,6 +6,7 @@ import {
   startReactRscPageRuntime,
   unmountReactRscPage,
 } from "../src/rsc.js";
+import type { ClientRuntime } from "../src/runtime-config.js";
 
 const calls: string[] = [];
 const rootElements: unknown[] = [];
@@ -70,7 +70,7 @@ describe("React RSC runtime", () => {
     const fetchMock = vi.fn(async () => createFlightResponse());
 
     const model = (await createReactRscModel({
-      manifest: createManifest(),
+      runtime: createRuntime(),
       pageId: "insights",
       url: "https://example.com/insights",
       moduleBaseURL: "https://assets.example.com/",
@@ -96,7 +96,7 @@ describe("React RSC runtime", () => {
     calls.length = 0;
 
     const wrongTypeModel = (await createReactRscModel({
-      manifest: createManifest(),
+      runtime: createRuntime(),
       pageId: "insights",
       url: "https://example.com/insights",
       fetch: async () =>
@@ -113,7 +113,7 @@ describe("React RSC runtime", () => {
     );
 
     const missingTypeModel = (await createReactRscModel({
-      manifest: createManifest(),
+      runtime: createRuntime(),
       pageId: "insights",
       url: "https://example.com/insights",
       fetch: async () => new Response(null),
@@ -135,7 +135,7 @@ describe("React RSC runtime", () => {
     );
     await expect(
       createReactRscModel({
-        manifest: createManifest(),
+        runtime: createRuntime(),
         pageId: "insights",
         url: "https://example.com/insights",
         moduleBaseURL: "",
@@ -146,7 +146,7 @@ describe("React RSC runtime", () => {
     );
     await expect(
       createReactRscModel({
-        manifest: createManifest(),
+        runtime: createRuntime(),
         pageId: "insights",
         url: "https://example.com/insights",
         moduleBaseURL: " https://assets.example.com/ ",
@@ -164,7 +164,7 @@ describe("React RSC runtime", () => {
     const mount = {} as Element;
 
     await mountReactRscPage({
-      manifest: createManifest(),
+      runtime: createRuntime(),
       pageId: "insights",
       url: "https://example.com/insights",
       mount,
@@ -183,7 +183,7 @@ describe("React RSC runtime", () => {
     const mount = {} as Element;
 
     await mountReactRscPage({
-      manifest: createManifest(),
+      runtime: createRuntime(),
       pageId: "insights",
       url: "https://example.com/insights",
       mount,
@@ -205,7 +205,7 @@ describe("React RSC runtime", () => {
     const mount = {} as Element;
 
     await mountReactRscPage({
-      manifest: createManifest(),
+      runtime: createRuntime(),
       pageId: "insights",
       url: "https://example.com/insights",
       mount,
@@ -213,7 +213,7 @@ describe("React RSC runtime", () => {
       fetch: async () => createFlightResponse(),
     });
     await mountReactRscPage({
-      manifest: createManifest(),
+      runtime: createRuntime(),
       pageId: "insights",
       url: "https://example.com/insights?tab=summary",
       mount,
@@ -241,7 +241,7 @@ describe("React RSC runtime", () => {
     hydrateRootFailure = new Error("hydrate blocked");
     await expect(
       mountReactRscPage({
-        manifest: createManifest(),
+        runtime: createRuntime(),
         pageId: "insights",
         url: "https://example.com/insights",
         mount,
@@ -255,7 +255,7 @@ describe("React RSC runtime", () => {
     createRootFailure = new Error("create blocked");
     await expect(
       mountReactRscPage({
-        manifest: createManifest(),
+        runtime: createRuntime(),
         pageId: "insights",
         url: "https://example.com/insights",
         mount,
@@ -270,7 +270,7 @@ describe("React RSC runtime", () => {
     renderFailure = new Error("render blocked");
     await expect(
       mountReactRscPage({
-        manifest: createManifest(),
+        runtime: createRuntime(),
         pageId: "insights",
         url: "https://example.com/insights",
         mount,
@@ -289,7 +289,7 @@ describe("React RSC runtime", () => {
     renderFailure = undefined;
     unmountFailure = new Error("unmount blocked");
     await mountReactRscPage({
-      manifest: createManifest(),
+      runtime: createRuntime(),
       pageId: "insights",
       url: "https://example.com/insights",
       mount,
@@ -310,14 +310,14 @@ describe("React RSC runtime", () => {
     );
     await expect(
       mountReactRscPage({
-        manifest: createManifest(),
+        runtime: createRuntime(),
         mount: "",
         fetch: async () => createFlightResponse(),
       }),
     ).rejects.toThrow("[evjs] RSC mount must be a non-empty selector string.");
     await expect(
       mountReactRscPage({
-        manifest: createManifest(),
+        runtime: createRuntime(),
         mount: " #app",
         fetch: async () => createFlightResponse(),
       }),
@@ -326,14 +326,14 @@ describe("React RSC runtime", () => {
     );
     await expect(
       mountReactRscPage({
-        manifest: createManifest(),
+        runtime: createRuntime(),
         mount: 42 as never,
         fetch: async () => createFlightResponse(),
       }),
     ).rejects.toThrow("[evjs] RSC mount must be a selector string or Element.");
     await expect(
       mountReactRscPage({
-        manifest: createManifest(),
+        runtime: createRuntime(),
         mount: "#app",
         hydrate: "yes" as never,
         fetch: async () => createFlightResponse(),
@@ -348,7 +348,7 @@ describe("React RSC runtime", () => {
 
     await expect(
       mountReactRscPage({
-        manifest: createManifest(),
+        runtime: createRuntime(),
         mount: "#app",
         fetch: async () => createFlightResponse(),
       }),
@@ -821,28 +821,18 @@ function createBootstrap(
   };
 }
 
-function createManifest(): BuildOutput {
+function createRuntime(): ClientRuntime {
   return {
     version: 1,
     buildId: "test",
-    distDir: "dist",
-    publicPath: "/",
     runtime: {
       server: {
-        basePath: "/__evjs",
-        fn: "/__evjs/fn",
         rsc: "/__evjs/rsc",
       },
     },
-    assets: {},
     apps: {},
     pages: {},
     routes: [],
-    server: {
-      assets: { js: [], css: [] },
-      functions: {},
-      routes: [],
-    },
   };
 }
 

--- a/packages/client/tests/shell.test.ts
+++ b/packages/client/tests/shell.test.ts
@@ -1,4 +1,3 @@
-import type { BuildOutput } from "@evjs/shared/manifest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type AppModule,
@@ -8,22 +7,14 @@ import {
   type HistoryDriverOptions,
   registerShellModule,
 } from "../src/internal";
+import type { ClientRuntime } from "../src/runtime-config.js";
 
-const manifest: BuildOutput = {
+const runtime: ClientRuntime = {
   version: 1,
   buildId: "test",
-  distDir: "dist",
-  publicPath: "/",
-  runtime: {
-    server: {
-      basePath: "/__evjs",
-      fn: "/__evjs/fn",
-    },
-  },
-  assets: {},
+  runtime: {},
   apps: {
     default: {
-      assets: { js: ["default.js"], css: [] },
       module: {
         type: "lifecycle",
         href: "/default.js",
@@ -32,28 +23,12 @@ const manifest: BuildOutput = {
   },
   pages: {
     home: {
-      assets: { js: ["home.js"], css: [] },
-      render: "csr",
-      rendering: {
-        component: "client",
-        html: "client",
-        streaming: false,
-        hydrate: "load",
-      },
       module: {
         type: "lifecycle",
         href: "/home.js",
       },
     },
     about: {
-      assets: { js: ["about.js"], css: [] },
-      render: "csr",
-      rendering: {
-        component: "client",
-        html: "client",
-        streaming: false,
-        hydrate: "load",
-      },
       module: {
         type: "lifecycle",
         href: "/about.js",
@@ -77,11 +52,6 @@ const manifest: BuildOutput = {
       appId: "default",
     },
   ],
-  server: {
-    assets: { js: [], css: [] },
-    functions: {},
-    routes: [],
-  },
 };
 
 afterEach(() => {
@@ -96,97 +66,56 @@ describe("createShell", () => {
     );
     expect(() =>
       createShell({
-        manifest: null,
+        runtime: null,
         resolveMountPoint: () => ({}) as Element,
       } as never),
-    ).toThrow("[evjs] createShell() manifest must be an object.");
+    ).toThrow("[evjs] createShell() runtime must be an object.");
     expect(() =>
       createShell({
-        manifest: { ...manifest, version: 2 },
+        runtime: { ...runtime, version: 2 },
         resolveMountPoint: () => ({}) as Element,
       } as never),
-    ).toThrow("[evjs] createShell() manifest.version must be 1.");
+    ).toThrow("[evjs] createShell() runtime.version must be 1.");
     expect(() =>
       createShell({
-        manifest: { ...manifest, buildId: "" },
-        resolveMountPoint: () => ({}) as Element,
-      } as never),
-    ).toThrow(
-      "[evjs] createShell() manifest.buildId must be a non-empty string.",
-    );
-    expect(() =>
-      createShell({
-        manifest: { ...manifest, buildId: "build.1" },
+        runtime: { ...runtime, buildId: "" },
         resolveMountPoint: () => ({}) as Element,
       } as never),
     ).toThrow(
-      "[evjs] createShell() manifest.buildId must contain only letters, numbers, underscores, or hyphens.",
+      "[evjs] createShell() runtime.buildId must be a non-empty string.",
     );
     expect(() =>
       createShell({
-        manifest: { ...manifest, runtime: null },
-        resolveMountPoint: () => ({}) as Element,
-      } as never),
-    ).toThrow("[evjs] createShell() manifest.runtime must be an object.");
-    expect(() =>
-      createShell({
-        manifest: { ...manifest, assets: [] },
-        resolveMountPoint: () => ({}) as Element,
-      } as never),
-    ).toThrow("[evjs] createShell() manifest.assets must be an object.");
-    expect(() =>
-      createShell({
-        manifest: { ...manifest, assets: { main: { js: "main.js", css: [] } } },
-        resolveMountPoint: () => ({}) as Element,
-      } as never),
-    ).toThrow("[evjs] createShell() manifest.assets.main.js must be an array.");
-    expect(() =>
-      createShell({
-        manifest: {
-          ...manifest,
-          assets: { "main.entry": { js: [], css: [] } },
-        },
+        runtime: { ...runtime, buildId: "build.1" },
         resolveMountPoint: () => ({}) as Element,
       } as never),
     ).toThrow(
-      '[evjs] createShell() manifest.assets key "main.entry" must contain only letters, numbers, underscores, or hyphens.',
+      "[evjs] createShell() runtime.buildId must contain only letters, numbers, underscores, or hyphens.",
     );
     expect(() =>
       createShell({
-        manifest: { ...manifest, pages: [] },
+        runtime: { ...runtime, runtime: null },
         resolveMountPoint: () => ({}) as Element,
       } as never),
-    ).toThrow("[evjs] createShell() manifest.pages must be an object.");
+    ).toThrow("[evjs] createShell() runtime.runtime must be an object.");
     expect(() =>
       createShell({
-        manifest: {
-          ...manifest,
-          pages: {
-            ...manifest.pages,
-            home: {
-              ...manifest.pages.home,
-              assets: { js: [], css: [""] },
-            },
-          },
-        },
+        runtime: { ...runtime, pages: [] },
         resolveMountPoint: () => ({}) as Element,
       } as never),
-    ).toThrow(
-      "[evjs] createShell() manifest.pages.home.assets.css must contain only non-empty strings.",
-    );
+    ).toThrow("[evjs] createShell() runtime.pages must be an object.");
     expect(() =>
       createShell({
-        manifest: { ...manifest, apps: [] },
+        runtime: { ...runtime, apps: [] },
         resolveMountPoint: () => ({}) as Element,
       } as never),
-    ).toThrow("[evjs] createShell() manifest.apps must be an object.");
+    ).toThrow("[evjs] createShell() runtime.apps must be an object.");
     expect(() =>
       createShell({
-        manifest: {
-          ...manifest,
+        runtime: {
+          ...runtime,
           apps: {
             "admin.app": {
-              assets: { js: [], css: [] },
               module: { type: "lifecycle", href: "/admin.js" },
             },
           },
@@ -194,62 +123,62 @@ describe("createShell", () => {
         resolveMountPoint: () => ({}) as Element,
       } as never),
     ).toThrow(
-      '[evjs] createShell() manifest.apps key "admin.app" must contain only letters, numbers, underscores, or hyphens.',
+      '[evjs] createShell() runtime.apps key "admin.app" must contain only letters, numbers, underscores, or hyphens.',
     );
     expect(() =>
       createShell({
-        manifest: { ...manifest, routes: {} },
+        runtime: { ...runtime, routes: {} },
         resolveMountPoint: () => ({}) as Element,
       } as never),
-    ).toThrow("[evjs] createShell() manifest.routes must be an array.");
+    ).toThrow("[evjs] createShell() runtime.routes must be an array.");
     expect(() =>
       createShell({
-        manifest: {
-          ...manifest,
+        runtime: {
+          ...runtime,
           routes: [{ id: "home", path: "home", pageId: "home" }],
         },
         resolveMountPoint: () => ({}) as Element,
       } as never),
     ).toThrow(
-      '[evjs] createShell() manifest.routes[0].path must start with "/".',
+      '[evjs] createShell() runtime.routes[0].path must start with "/".',
     );
     expect(() =>
       createShell({
-        manifest: {
-          ...manifest,
+        runtime: {
+          ...runtime,
           routes: [{ id: " home", path: "/home", pageId: "home" }],
         },
         resolveMountPoint: () => ({}) as Element,
       } as never),
     ).toThrow(
-      "[evjs] createShell() manifest.routes[0].id must not contain leading or trailing whitespace.",
+      "[evjs] createShell() runtime.routes[0].id must not contain leading or trailing whitespace.",
     );
     expect(() =>
       createShell({
-        manifest: {
-          ...manifest,
+        runtime: {
+          ...runtime,
           routes: [{ id: "orders", path: "/orders", appId: "missing" }],
         },
         resolveMountPoint: () => ({}) as Element,
       } as never),
     ).toThrow(
-      '[evjs] createShell() manifest.routes[0].appId "missing" does not match any manifest.apps entry.',
+      '[evjs] createShell() runtime.routes[0].appId "missing" does not match any runtime.apps entry.',
     );
     expect(() =>
       createShell({
-        manifest: {
-          ...manifest,
+        runtime: {
+          ...runtime,
           routes: [{ id: "orders", path: "/orders", appId: "default " }],
         },
         resolveMountPoint: () => ({}) as Element,
       } as never),
     ).toThrow(
-      "[evjs] createShell() manifest.routes[0].appId must not contain leading or trailing whitespace.",
+      "[evjs] createShell() runtime.routes[0].appId must not contain leading or trailing whitespace.",
     );
     expect(() =>
       createShell({
-        manifest: {
-          ...manifest,
+        runtime: {
+          ...runtime,
           routes: [
             { id: "userById", path: "/users/$id", pageId: "home" },
             {
@@ -262,74 +191,72 @@ describe("createShell", () => {
         resolveMountPoint: () => ({}) as Element,
       } as never),
     ).toThrow(
-      '[evjs] createShell() manifest.routes[1].path has the same route shape as createShell() manifest.routes[0].path "/users/$id". Use one page route per URL shape.',
+      '[evjs] createShell() runtime.routes[1].path has the same route shape as createShell() runtime.routes[0].path "/users/$id". Use one page route per URL shape.',
     );
     expect(() =>
       createShell({
-        manifest: {
-          ...manifest,
-          runtime: { ...manifest.runtime, transport: [] },
+        runtime: {
+          ...runtime,
+          runtime: { ...runtime.runtime, transport: [] },
         },
         resolveMountPoint: () => ({}) as Element,
       } as never),
     ).toThrow(
-      "[evjs] createShell() manifest.runtime.transport must be an object.",
+      "[evjs] createShell() runtime.runtime.transport must be an object.",
     );
     expect(() =>
       createShell({
-        manifest: {
-          ...manifest,
+        runtime: {
+          ...runtime,
           runtime: {
-            ...manifest.runtime,
+            ...runtime.runtime,
             transport: { baseUrl: "http://[::1" },
           },
         },
         resolveMountPoint: () => ({}) as Element,
       } as never),
     ).toThrow(
-      "[evjs] createShell() manifest.runtime.transport.baseUrl must be a valid URL string.",
+      "[evjs] createShell() runtime.runtime.transport.baseUrl must be a valid URL string.",
     );
   });
 
   it("rejects invalid shell driver and callback shapes", () => {
-    expect(() => createShell({ manifest, drivers: {} as never })).toThrow(
+    expect(() => createShell({ runtime, drivers: {} as never })).toThrow(
       "[evjs] createShell() drivers must be an array.",
     );
-    expect(() => createShell({ manifest, drivers: [null as never] })).toThrow(
+    expect(() => createShell({ runtime, drivers: [null as never] })).toThrow(
       "[evjs] createShell() drivers[0] must be a shell driver object.",
     );
     expect(() =>
-      createShell({ manifest, drivers: [{ current: "now" } as never] }),
+      createShell({ runtime, drivers: [{ current: "now" } as never] }),
     ).toThrow("[evjs] createShell() drivers[0].current must be a function.");
     expect(() =>
       createShell({
-        manifest,
+        runtime,
         drivers: [{ current: () => ({}), subscribe: "listen" } as never],
       }),
     ).toThrow(
       "[evjs] createShell() drivers[0].subscribe must be a function when provided.",
     );
-    expect(() =>
-      createShell({ manifest, loadModule: "load" as never }),
-    ).toThrow(
+    expect(() => createShell({ runtime, loadModule: "load" as never })).toThrow(
       "[evjs] createShell() loadModule must be a function when provided.",
     );
     expect(() =>
-      createShell({ manifest, resolveMountPoint: "resolve" as never }),
+      createShell({ runtime, resolveMountPoint: "resolve" as never }),
     ).toThrow(
       "[evjs] createShell() resolveMountPoint must be a function when provided.",
     );
-    expect(() => createShell({ manifest, onError: "handle" as never })).toThrow(
+    expect(() => createShell({ runtime, onError: "handle" as never })).toThrow(
       "[evjs] createShell() onError must be a function when provided.",
     );
-    expect(() => createShell({ manifest, onWarning: "warn" as never })).toThrow(
+    expect(() => createShell({ runtime, onWarning: "warn" as never })).toThrow(
       "[evjs] createShell() onWarning must be a function when provided.",
     );
   });
 
   it("rejects invalid shell activation request shapes", async () => {
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
     });
 
@@ -356,7 +283,7 @@ describe("createShell", () => {
     await expect(
       shell.activate({ pageId: "home", buildId: "stale" }),
     ).rejects.toThrow(
-      '[evjs] Shell activate() request.buildId "stale" does not match manifest.buildId "test".',
+      '[evjs] Shell activate() request.buildId "stale" does not match runtime.buildId "test".',
     );
     await expect(
       shell.activate({ pageId: "home", buildId: "build.1" }),
@@ -396,35 +323,35 @@ describe("createShell", () => {
     const loadModule = vi.fn(async () => ({
       mount() {},
     }));
-    const createMalformedShell = (nextManifest: BuildOutput) =>
+    const createMalformedShell = (nextRuntime: ClientRuntime) =>
       createShell({
-        manifest: nextManifest,
+        runtime: nextRuntime,
         resolveMountPoint: () => ({}) as Element,
         loadModule,
       });
 
     expect(() =>
       createMalformedShell({
-        ...manifest,
+        ...runtime,
         pages: {
-          ...manifest.pages,
+          ...runtime.pages,
           home: {
-            ...manifest.pages.home,
+            ...runtime.pages.home,
             module: null as never,
           },
         },
       }),
     ).toThrow(
-      "[evjs] createShell() manifest.pages.home.module must be an object.",
+      "[evjs] createShell() runtime.pages.home.module must be an object.",
     );
 
     expect(() =>
       createMalformedShell({
-        ...manifest,
+        ...runtime,
         pages: {
-          ...manifest.pages,
+          ...runtime.pages,
           home: {
-            ...manifest.pages.home,
+            ...runtime.pages.home,
             module: {
               type: "lifecycle",
               href: 42,
@@ -433,15 +360,14 @@ describe("createShell", () => {
         },
       }),
     ).toThrow(
-      "[evjs] createShell() manifest.pages.home.module.href must be a non-empty string.",
+      "[evjs] createShell() runtime.pages.home.module.href must be a non-empty string.",
     );
 
     expect(() =>
       createMalformedShell({
-        ...manifest,
+        ...runtime,
         apps: {
           default: {
-            assets: { js: [], css: [] },
             module: {
               type: "lifecycle",
               href: " /app.js",
@@ -450,7 +376,7 @@ describe("createShell", () => {
         },
       }),
     ).toThrow(
-      "[evjs] createShell() manifest.apps.default.module.href must not contain leading or trailing whitespace.",
+      "[evjs] createShell() runtime.apps.default.module.href must not contain leading or trailing whitespace.",
     );
 
     expect(loadModule).not.toHaveBeenCalled();
@@ -458,7 +384,7 @@ describe("createShell", () => {
 
   it("rejects invalid shell preload request shapes", async () => {
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
     });
 
@@ -482,7 +408,7 @@ describe("createShell", () => {
     await expect(
       shell.preload({ pageId: "home", buildId: "stale" }),
     ).rejects.toThrow(
-      '[evjs] Shell preload() request.buildId "stale" does not match manifest.buildId "test".',
+      '[evjs] Shell preload() request.buildId "stale" does not match runtime.buildId "test".',
     );
     await expect(
       shell.preload({ pageId: "home", buildId: "build.1" }),
@@ -491,7 +417,7 @@ describe("createShell", () => {
     );
   });
 
-  it("activates and disposes manifest modules", async () => {
+  it("activates and disposes runtime modules", async () => {
     const events: string[] = [];
     const mountPoint = {} as Element;
     const mod: AppModule = {
@@ -503,7 +429,7 @@ describe("createShell", () => {
       },
     };
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => mountPoint,
       async loadModule(href) {
         events.push(`load:${href}`);
@@ -533,7 +459,7 @@ describe("createShell", () => {
       },
     };
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => mountPoint,
       async loadModule(href) {
         events.push(`load:${href}`);
@@ -573,7 +499,7 @@ describe("createShell", () => {
       },
     };
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
       async loadModule(href) {
         events.push(`load:${href}`);
@@ -602,7 +528,7 @@ describe("createShell", () => {
     });
 
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
     });
 
@@ -641,7 +567,7 @@ describe("createShell", () => {
   it("rejects malformed direct shell module registry state", async () => {
     const createDefaultLoaderShell = () =>
       createShell({
-        manifest,
+        runtime,
         resolveMountPoint: () => ({}) as Element,
       });
 
@@ -692,7 +618,7 @@ describe("createShell", () => {
   it("reports invalid shell modules as load errors", async () => {
     const events: string[] = [];
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
       async loadModule() {
         return null as never;
@@ -717,7 +643,7 @@ describe("createShell", () => {
   it("reports invalid shell module lifecycle hooks as load errors", async () => {
     const events: string[] = [];
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
       async loadModule() {
         return {
@@ -750,7 +676,7 @@ describe("createShell", () => {
     }));
 
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
     });
 
@@ -784,7 +710,7 @@ describe("createShell", () => {
     vi.stubGlobal("document", document);
 
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
     });
 
@@ -802,7 +728,7 @@ describe("createShell", () => {
       },
     });
     const scriptShell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
     });
 
@@ -823,12 +749,12 @@ describe("createShell", () => {
       },
     });
     const scriptShell = createShell({
-      manifest: {
-        ...manifest,
+      runtime: {
+        ...runtime,
         pages: {
-          ...manifest.pages,
+          ...runtime.pages,
           home: {
-            ...manifest.pages.home,
+            ...runtime.pages.home,
             module: {
               type: "lifecycle",
               href: "/invalid-create-element.js",
@@ -860,12 +786,12 @@ describe("createShell", () => {
       },
     });
     const scriptShell = createShell({
-      manifest: {
-        ...manifest,
+      runtime: {
+        ...runtime,
         pages: {
-          ...manifest.pages,
+          ...runtime.pages,
           home: {
-            ...manifest.pages.home,
+            ...runtime.pages.home,
             module: {
               type: "lifecycle",
               href: "/append-fail.js",
@@ -886,7 +812,7 @@ describe("createShell", () => {
   it("preloads without mounting", async () => {
     const events: string[] = [];
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
       async loadModule(href) {
         events.push(`load:${href}`);
@@ -907,7 +833,7 @@ describe("createShell", () => {
   it("serializes overlapping activations", async () => {
     const events: string[] = [];
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
       async loadModule(href, ctx) {
         events.push(`load:${ctx.id}:${href}`);
@@ -946,7 +872,7 @@ describe("createShell", () => {
       resolveModule = resolve;
     });
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
       async loadModule(href) {
         events.push(`load:${href}`);
@@ -983,7 +909,7 @@ describe("createShell", () => {
       finishMount = resolve;
     });
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
       async loadModule() {
         return {
@@ -1012,7 +938,7 @@ describe("createShell", () => {
 
   it("rejects shell lifecycle calls after dispose", async () => {
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
     });
 
@@ -1032,7 +958,7 @@ describe("createShell", () => {
   it("keeps the current activation mounted when the next module load fails", async () => {
     const events: string[] = [];
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
       async loadModule(href, ctx) {
         events.push(`load:${ctx.id}:${href}`);
@@ -1065,7 +991,7 @@ describe("createShell", () => {
   it("restores the current hydrated page when the next hydration fails", async () => {
     const events: string[] = [];
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
       async loadModule(href, ctx) {
         events.push(`load:${ctx.id}:${href}`);
@@ -1101,7 +1027,7 @@ describe("createShell", () => {
   it("starts from drivers and unsubscribes on dispose", async () => {
     const events: string[] = [];
     const shell = createShell({
-      manifest,
+      runtime,
       drivers: [
         {
           current() {
@@ -1145,7 +1071,7 @@ describe("createShell", () => {
     const error = new Error("mount failed");
     const events: string[] = [];
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
       async loadModule() {
         return {
@@ -1170,7 +1096,7 @@ describe("createShell", () => {
   it("reports missing mount points as resolve errors", async () => {
     const events: string[] = [];
     const shell = createShell({
-      manifest,
+      runtime,
       async loadModule() {
         return {
           mount() {},
@@ -1194,7 +1120,7 @@ describe("createShell", () => {
   it("reports invalid resolved mount points as resolve errors", async () => {
     const events: string[] = [];
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => "root" as never,
       async loadModule() {
         return {
@@ -1223,7 +1149,7 @@ describe("createShell", () => {
     const loadError = new Error("load failed");
     let loadCount = 0;
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
       async loadModule() {
         loadCount++;
@@ -1260,7 +1186,7 @@ describe("createShell", () => {
     const initError = new Error("init failed");
     let initCount = 0;
     const shell = createShell({
-      manifest,
+      runtime,
       resolveMountPoint: () => ({}) as Element,
       async loadModule() {
         events.push("load");
@@ -1406,18 +1332,18 @@ describe("createHistoryDriver", () => {
     expect(() => createHistoryDriver(null as never)).toThrow(
       "[evjs] createHistoryDriver() options must be an object.",
     );
-    expect(() => createHistoryDriver({ manifest: null } as never)).toThrow(
-      "[evjs] createHistoryDriver() manifest must be an object.",
+    expect(() => createHistoryDriver({ runtime: null } as never)).toThrow(
+      "[evjs] createHistoryDriver() runtime must be an object.",
     );
     expect(() =>
       createHistoryDriver({
-        manifest: { ...manifest, routes: {} },
+        runtime: { ...runtime, routes: {} },
         window: createMockWindow("https://example.com/home"),
       } as never),
-    ).toThrow("[evjs] createHistoryDriver() manifest.routes must be an array.");
+    ).toThrow("[evjs] createHistoryDriver() runtime.routes must be an array.");
     expect(() =>
       createHistoryDriver({
-        manifest,
+        runtime,
         window: {
           addEventListener() {},
           removeEventListener() {},
@@ -1428,7 +1354,7 @@ describe("createHistoryDriver", () => {
     );
     expect(() =>
       createHistoryDriver({
-        manifest,
+        runtime,
         window: {
           location: { href: "https://example.com/home" },
           removeEventListener() {},
@@ -1439,7 +1365,7 @@ describe("createHistoryDriver", () => {
     );
     expect(() =>
       createHistoryDriver({
-        manifest,
+        runtime,
         window: {
           addEventListener() {},
           location: { href: "https://example.com/home" },
@@ -1452,14 +1378,14 @@ describe("createHistoryDriver", () => {
 
   it("reports unavailable or invalid history window locations with evjs errors", () => {
     vi.stubGlobal("window", undefined);
-    const missingWindowDriver = createHistoryDriver({ manifest });
+    const missingWindowDriver = createHistoryDriver({ runtime });
 
     expect(() => missingWindowDriver.current()).toThrow(
       "[evjs] createHistoryDriver() window must be available or provided.",
     );
 
     const invalidHrefDriver = createHistoryDriver({
-      manifest,
+      runtime,
       window: {
         ...createMockWindow("https://example.com/home"),
         location: { href: "" } as Location,
@@ -1480,7 +1406,7 @@ describe("createHistoryDriver", () => {
       removeEventListener() {},
     };
     const addFailureDriver = createHistoryDriver({
-      manifest,
+      runtime,
       window: addFailureWindow,
     });
 
@@ -1496,7 +1422,7 @@ describe("createHistoryDriver", () => {
       },
     };
     const removeFailureDriver = createHistoryDriver({
-      manifest,
+      runtime,
       window: removeFailureWindow,
     });
     const unsubscribe = removeFailureDriver.subscribe(() => {});
@@ -1506,9 +1432,9 @@ describe("createHistoryDriver", () => {
     );
   });
 
-  it("creates activation requests from matched manifest routes", () => {
+  it("creates activation requests from matched runtime routes", () => {
     const driver = createHistoryDriver({
-      manifest,
+      runtime,
       window: createMockWindow("https://example.com/orders/123"),
     });
 
@@ -1519,9 +1445,9 @@ describe("createHistoryDriver", () => {
     });
   });
 
-  it("prefers the most specific manifest route for activation requests", () => {
-    const orderedManifest: BuildOutput = {
-      ...manifest,
+  it("prefers the most specific runtime route for activation requests", () => {
+    const orderedRuntime: ClientRuntime = {
+      ...runtime,
       routes: [
         {
           id: "user",
@@ -1536,7 +1462,7 @@ describe("createHistoryDriver", () => {
       ],
     };
     const driver = createHistoryDriver({
-      manifest: orderedManifest,
+      runtime: orderedRuntime,
       window: createMockWindow("https://example.com/users/settings"),
     });
 
@@ -1550,7 +1476,7 @@ describe("createHistoryDriver", () => {
   it("subscribes to browser history navigation", () => {
     const calls: unknown[] = [];
     const win = createMockWindow("https://example.com/home");
-    const driver = createHistoryDriver({ manifest, window: win });
+    const driver = createHistoryDriver({ runtime, window: win });
 
     const unsubscribe = driver.subscribe((request) => calls.push(request));
     win.dispatchPopState();

--- a/packages/client/tests/transport.test.ts
+++ b/packages/client/tests/transport.test.ts
@@ -8,7 +8,7 @@ import {
   getFnName,
   getServerFunction,
   initTransport,
-  initTransportFromManifest,
+  initTransportFromRuntime,
   type ServerFunction,
   type TransportAdapter,
   type TransportOptions,
@@ -317,38 +317,38 @@ describe("initTransport + callServer", () => {
     );
   });
 
-  it("rejects invalid manifest transport metadata", () => {
-    expect(() => initTransportFromManifest(null as never)).toThrow(
-      "[evjs] initTransportFromManifest() manifest must be a framework manifest object.",
+  it("rejects invalid runtime transport metadata", () => {
+    expect(() => initTransportFromRuntime(null as never)).toThrow(
+      "[evjs] initTransportFromRuntime() runtime must be a client runtime object.",
     );
-    expect(() => initTransportFromManifest({ runtime: null } as never)).toThrow(
-      "[evjs] initTransportFromManifest() manifest.runtime must be an object.",
+    expect(() => initTransportFromRuntime({ runtime: null } as never)).toThrow(
+      "[evjs] initTransportFromRuntime() runtime.runtime must be an object.",
     );
     expect(() =>
-      initTransportFromManifest({ runtime: { transport: [] } } as never),
+      initTransportFromRuntime({ runtime: { transport: [] } } as never),
     ).toThrow(
-      "[evjs] initTransportFromManifest() manifest.runtime.transport must be an object.",
+      "[evjs] initTransportFromRuntime() runtime.runtime.transport must be an object.",
     );
     expect(() =>
-      initTransportFromManifest({
+      initTransportFromRuntime({
         runtime: { transport: { baseUrl: "" } },
       } as never),
     ).toThrow(
-      "[evjs] initTransportFromManifest() manifest.runtime.transport.baseUrl must be a non-empty URL string.",
+      "[evjs] initTransportFromRuntime() runtime.runtime.transport.baseUrl must be a non-empty URL string.",
     );
     expect(() =>
-      initTransportFromManifest({
+      initTransportFromRuntime({
         runtime: { transport: { baseUrl: "https://api.example.com " } },
       } as never),
     ).toThrow(
-      "[evjs] initTransportFromManifest() manifest.runtime.transport.baseUrl must not contain leading or trailing whitespace.",
+      "[evjs] initTransportFromRuntime() runtime.runtime.transport.baseUrl must not contain leading or trailing whitespace.",
     );
     expect(() =>
-      initTransportFromManifest({
+      initTransportFromRuntime({
         runtime: { transport: { baseUrl: "http://[::1" } },
       } as never),
     ).toThrow(
-      "[evjs] initTransportFromManifest() manifest.runtime.transport.baseUrl must be a valid URL string.",
+      "[evjs] initTransportFromRuntime() runtime.runtime.transport.baseUrl must be a valid URL string.",
     );
   });
 
@@ -458,7 +458,7 @@ describe("public transport subpath", () => {
     expect(publicTransport.getFnId).toBe(getFnId);
     expect(publicTransport.getFnName).toBe(getFnName);
     expect(publicTransport.initTransport).toBe(initTransport);
-    expect("initTransportFromManifest" in publicTransport).toBe(false);
+    expect("initTransportFromRuntime" in publicTransport).toBe(false);
     expect("getServerFunction" in publicTransport).toBe(false);
     expect("__resetForTesting" in publicTransport).toBe(false);
   });

--- a/packages/ev/src/build-tools/graph/index.ts
+++ b/packages/ev/src/build-tools/graph/index.ts
@@ -124,6 +124,7 @@ export interface GraphConfig {
 
 const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx"]);
 const DEFAULT_TOP_LEVEL_ENTRY = "./src/main.tsx";
+const DEFAULT_SOURCE_ALIAS = "@/";
 
 interface FrameworkSourceFiles {
   analysisFiles: string[];
@@ -1552,7 +1553,15 @@ function extractStaticImportSpecifiers(source: string): string[] {
     specifiers.add(specifier);
   }
 
-  return [...specifiers].filter((specifier) => specifier.startsWith("."));
+  return [...specifiers].filter(isLocalSourceImportSpecifier);
+}
+
+function isLocalSourceImportSpecifier(specifier: string): boolean {
+  return (
+    specifier.startsWith(".") ||
+    specifier === DEFAULT_SOURCE_ALIAS.slice(0, -1) ||
+    specifier.startsWith(DEFAULT_SOURCE_ALIAS)
+  );
 }
 
 function extractParsedStaticImportSpecifiers(source: string): string[] {
@@ -1611,6 +1620,15 @@ async function resolveSourceImport(
   fromFile: string,
   specifier: string,
 ): Promise<string | undefined> {
+  if (specifier === DEFAULT_SOURCE_ALIAS.slice(0, -1)) {
+    return resolveSourcePath(cwd, path.resolve(cwd, "src"));
+  }
+  if (specifier.startsWith(DEFAULT_SOURCE_ALIAS)) {
+    return resolveSourcePath(
+      cwd,
+      path.resolve(cwd, "src", specifier.slice(DEFAULT_SOURCE_ALIAS.length)),
+    );
+  }
   return resolveSourcePath(
     cwd,
     path.resolve(path.dirname(fromFile), specifier),

--- a/packages/ev/src/commands.ts
+++ b/packages/ev/src/commands.ts
@@ -54,6 +54,10 @@ import {
   resolveConfig,
   resolvePluginsConfig,
 } from "./config.js";
+import {
+  createClientRuntime,
+  createFrameworkRuntime,
+} from "./framework-runtime.js";
 import { buildHtml } from "./html.js";
 import {
   type BuildResult,
@@ -73,6 +77,7 @@ const DEV_PAGE_RENDER_PROXY_HEADER = "x-evjs-dev-page-render";
 const DEV_DIST_DIR = "dist";
 const DEV_DIST_LOCK_FILE = ".evjs-dev.lock";
 const MANIFEST_FILE = "manifest.json";
+const RUNTIME_FILE = "runtime.json";
 const BUILD_OUTPUT_FILE = "build-output.json";
 const PLUGIN_HOOK_NAMES = [
   "buildStart",
@@ -1221,27 +1226,53 @@ async function emitFrameworkManifest(
   await fs.promises.rm(path.join(serverDir, BUILD_OUTPUT_FILE), {
     force: true,
   });
-  await removeManifestIfInactive(rootDir, [clientDir, serverDir]);
-  await removeManifestIfInactive(path.join(rootDir, "client"), [
+  await removeFrameworkOutputFileIfInactive(rootDir, MANIFEST_FILE, [
     clientDir,
     serverDir,
   ]);
-  await removeManifestIfInactive(path.join(rootDir, "server"), [
+  await removeFrameworkOutputFileIfInactive(rootDir, RUNTIME_FILE, [
     clientDir,
     serverDir,
   ]);
+  await removeFrameworkOutputFileIfInactive(
+    path.join(rootDir, "client"),
+    MANIFEST_FILE,
+    [clientDir, serverDir],
+  );
+  await removeFrameworkOutputFileIfInactive(
+    path.join(rootDir, "client"),
+    RUNTIME_FILE,
+    [clientDir, serverDir],
+  );
+  await removeFrameworkOutputFileIfInactive(
+    path.join(rootDir, "server"),
+    MANIFEST_FILE,
+    [clientDir, serverDir],
+  );
+  await removeFrameworkOutputFileIfInactive(
+    path.join(rootDir, "server"),
+    RUNTIME_FILE,
+    [clientDir, serverDir],
+  );
 
   const publicManifest = createPublicManifest(output);
+  const clientRuntime = createClientRuntime(output);
   await fs.promises.mkdir(clientDir, { recursive: true });
   await fs.promises.writeFile(
     path.join(clientDir, MANIFEST_FILE),
     JSON.stringify(publicManifest, null, 2),
     "utf-8",
   );
+  await fs.promises.writeFile(
+    path.join(clientDir, RUNTIME_FILE),
+    JSON.stringify(clientRuntime, null, 2),
+    "utf-8",
+  );
 }
 
-async function removeManifestIfInactive(
+async function removeFrameworkOutputFileIfInactive(
   dir: string,
+  fileName: string,
   activeDirs: string[],
 ): Promise<void> {
   const normalizedDir = path.resolve(dir);
@@ -1250,7 +1281,7 @@ async function removeManifestIfInactive(
   ) {
     return;
   }
-  await fs.promises.rm(path.join(normalizedDir, MANIFEST_FILE), {
+  await fs.promises.rm(path.join(normalizedDir, fileName), {
     force: true,
   });
 }
@@ -1487,6 +1518,24 @@ function readServerEntryFromManifest(
     );
   } catch (err) {
     logger.warn`Failed to parse build manifest for server entry: ${err}`;
+    return undefined;
+  }
+}
+
+function readFrameworkRuntime(
+  cwd: string,
+  distDir: string,
+): ReturnType<typeof createFrameworkRuntime> | undefined {
+  const outputPath = path.resolve(cwd, distDir, BUILD_OUTPUT_FILE);
+  if (!fs.existsSync(outputPath)) return undefined;
+
+  try {
+    const output = JSON.parse(
+      fs.readFileSync(outputPath, "utf-8"),
+    ) as BuildOutput;
+    return createFrameworkRuntime(output);
+  } catch (err) {
+    logger.warn`Failed to parse build output for framework runtime: ${err}`;
     return undefined;
   }
 }
@@ -2234,6 +2283,7 @@ export async function dev<TBundlerCfg = DefaultBundlerConfig>(
     const bootstrapPath = path.join(devRootDir, "_dev_start.cjs");
     try {
       const serverBundlePath = path.join(devRootDir, "server", serverEntry);
+      const frameworkRuntime = readFrameworkRuntime(cwd, activePlan.distDir);
 
       if (!fs.existsSync(path.dirname(bootstrapPath))) {
         fs.mkdirSync(path.dirname(bootstrapPath), { recursive: true });
@@ -2242,12 +2292,9 @@ export async function dev<TBundlerCfg = DefaultBundlerConfig>(
         bootstrapPath,
         [
           `(async () => {`,
-          `const fs = require("node:fs");`,
           `const path = require("node:path");`,
           `const { pathToFileURL } = require("node:url");`,
-          `const manifestPath = ${JSON.stringify(path.join(devRootDir, BUILD_OUTPUT_FILE))};`,
-          `const manifest = fs.existsSync(manifestPath) ? JSON.parse(fs.readFileSync(manifestPath, "utf-8")) : undefined;`,
-          `if (manifest) globalThis.__EVJS_MANIFEST__ = manifest;`,
+          `globalThis.__EVJS_FRAMEWORK_RUNTIME__ = ${JSON.stringify(frameworkRuntime, null, 2)};`,
           `globalThis.__EVJS_DEV_PAGE_RENDER_PROXY_HEADER__ = ${JSON.stringify(DEV_PAGE_RENDER_PROXY_HEADER)};`,
           `const serverDir = path.dirname(${JSON.stringify(serverBundlePath)});`,
           `globalThis.__EVJS_SERVER_MODULE_LOADER__ = async (asset) => { const mod = await import(pathToFileURL(path.resolve(serverDir, asset)).href); const nested = mod && typeof mod.default === "object" ? mod.default : undefined; return nested && ("default" in nested || "render" in nested) ? nested : mod; };`,

--- a/packages/ev/src/deployment.ts
+++ b/packages/ev/src/deployment.ts
@@ -7,7 +7,6 @@ import type {
   PublicPathOutput,
   RenderMode,
   RuntimeOutput,
-  ServerRuntime,
 } from "@evjs/shared/manifest";
 import { createFrameworkRuntime } from "./framework-runtime.js";
 import type { Plugin } from "./plugin.js";
@@ -67,7 +66,6 @@ export interface DeploymentArtifact {
   distDir: string;
   paths?: BuildOutput["paths"];
   publicPath: PublicPathOutput;
-  runtime: RuntimeOutput;
   assets?: Record<string, AssetGroup>;
   apps: Record<string, DeploymentApp>;
   pages: Record<string, DeploymentPage>;
@@ -104,8 +102,6 @@ export interface DeploymentRoute {
   path: string;
   appId?: string;
   pageId?: string;
-  render?: RenderMode;
-  runtime?: ServerRuntime;
 }
 
 export interface DeploymentServer {
@@ -114,6 +110,7 @@ export interface DeploymentServer {
   fn?: string;
   ppr?: string;
   rsc?: string;
+  transport?: RuntimeOutput["transport"];
   assets?: AssetGroup;
   renderers: string[];
   functions: string[];
@@ -159,7 +156,6 @@ export function createDeploymentArtifact(
     distDir: output.distDir,
     paths: getDeploymentOutputPaths(output),
     publicPath: output.publicPath,
-    runtime: output.runtime,
     ...(includeAssets ? { assets: output.assets } : {}),
     apps: Object.fromEntries(
       Object.entries(output.apps).map(([id, app]) => [
@@ -192,8 +188,6 @@ export function createDeploymentArtifact(
       path: route.path,
       appId: route.appId,
       pageId: route.pageId,
-      render: route.render,
-      runtime: route.runtime,
     })),
     server: {
       entry: output.server.entry,
@@ -201,6 +195,9 @@ export function createDeploymentArtifact(
       fn: output.runtime.server.fn,
       ppr: output.runtime.server.ppr,
       rsc: output.runtime.server.rsc,
+      ...(output.runtime.transport
+        ? { transport: output.runtime.transport }
+        : {}),
       ...(includeAssets ? { assets: output.server.assets } : {}),
       renderers: Object.keys(output.server.renderers ?? {}),
       functions: Object.keys(output.server.functions),

--- a/packages/ev/src/deployment.ts
+++ b/packages/ev/src/deployment.ts
@@ -9,6 +9,7 @@ import type {
   RuntimeOutput,
   ServerRuntime,
 } from "@evjs/shared/manifest";
+import { createFrameworkRuntime } from "./framework-runtime.js";
 import type { Plugin } from "./plugin.js";
 
 export interface DeploymentArtifactOptions {
@@ -435,6 +436,7 @@ function createNodeServerModule(
   const clientRoot = getPublicDirRelativeToRoot(output);
   const portEnv = options.portEnv ?? "PORT";
   const defaultPort = options.defaultPort ?? 3000;
+  const frameworkRuntime = createFrameworkRuntime(output);
 
   return `import { readFile } from "node:fs/promises";
 import path from "node:path";
@@ -451,8 +453,7 @@ const frameworkRoutes = ${JSON.stringify(frameworkRoutes, null, 2)};
 const staticRoutes = ${JSON.stringify(staticRoutes, null, 2)};
 const staticFallback = ${JSON.stringify(staticFallback ?? "")};
 const staticAssetPrefix = ${JSON.stringify(staticAssetPrefix ?? "")};
-const manifest = ${JSON.stringify(output, null, 2)};
-globalThis.__EVJS_MANIFEST__ = manifest;
+globalThis.__EVJS_FRAMEWORK_RUNTIME__ = ${JSON.stringify(frameworkRuntime, null, 2)};
 globalThis.__EVJS_SERVER_MODULE_LOADER__ = async (asset) => {
   const mod = await import(pathToFileURL(path.resolve(serverDir, asset)).href);
   return normalizeServerModule(mod);
@@ -614,10 +615,10 @@ function createEdgeWorkerModule(
   const frameworkRequestCondition = serverEntry
     ? "isFrameworkRequest(url.pathname)"
     : "false";
+  const frameworkRuntime = createFrameworkRuntime(output);
 
   return [
-    `const manifest = ${JSON.stringify(output, null, 2)};`,
-    "globalThis.__EVJS_MANIFEST__ = manifest;",
+    `globalThis.__EVJS_FRAMEWORK_RUNTIME__ = ${JSON.stringify(frameworkRuntime, null, 2)};`,
     "globalThis.__EVJS_SERVER_MODULE_LOADER__ = async (asset) => {",
     '  return normalizeServerModule(await import("./server/" + asset));',
     "};",

--- a/packages/ev/src/framework-runtime.ts
+++ b/packages/ev/src/framework-runtime.ts
@@ -1,13 +1,6 @@
-import {
-  type BuildOutput,
-  createPublicManifest,
-  type PublicManifestOutput,
-} from "@evjs/shared/manifest";
+import type { BuildOutput } from "@evjs/shared/manifest";
 
-export type ClientRuntimeOutput = Pick<
-  PublicManifestOutput,
-  "version" | "buildId"
-> & {
+export type ClientRuntimeOutput = Pick<BuildOutput, "version" | "buildId"> & {
   runtime: ClientRuntimeOutputRuntime;
   apps: Record<string, ClientRuntimeTargetOutput>;
   pages: Record<string, ClientRuntimeTargetOutput>;
@@ -18,16 +11,16 @@ export interface ClientRuntimeOutputRuntime {
   server?: {
     rsc?: string;
   };
-  transport?: PublicManifestOutput["runtime"]["transport"];
+  transport?: BuildOutput["runtime"]["transport"];
 }
 
 export type ClientRuntimeTargetOutput = Pick<
-  PublicManifestOutput["apps"][string],
+  BuildOutput["apps"][string],
   "mount" | "module"
 >;
 
 export type ClientRuntimeRouteOutput = Pick<
-  PublicManifestOutput["routes"][number],
+  BuildOutput["routes"][number],
   "id" | "path" | "appId" | "pageId"
 >;
 
@@ -95,13 +88,12 @@ export type FrameworkRuntimeRscPage = Pick<
 >;
 
 export function createClientRuntime(output: BuildOutput): ClientRuntimeOutput {
-  const manifest = createPublicManifest(output);
   return pruneUndefined({
-    version: manifest.version,
-    buildId: manifest.buildId,
-    runtime: createClientRuntimeRuntime(manifest.runtime),
+    version: output.version,
+    buildId: output.buildId,
+    runtime: createClientRuntimeRuntime(output.runtime),
     apps: Object.fromEntries(
-      Object.entries(manifest.apps).map(([id, app]) => [
+      Object.entries(output.apps).map(([id, app]) => [
         id,
         pruneUndefined({
           mount: app.mount,
@@ -110,7 +102,7 @@ export function createClientRuntime(output: BuildOutput): ClientRuntimeOutput {
       ]),
     ),
     pages: Object.fromEntries(
-      Object.entries(manifest.pages).map(([id, page]) => [
+      Object.entries(output.pages).map(([id, page]) => [
         id,
         pruneUndefined({
           mount: page.mount,
@@ -118,7 +110,7 @@ export function createClientRuntime(output: BuildOutput): ClientRuntimeOutput {
         }),
       ]),
     ),
-    routes: manifest.routes.map((route) =>
+    routes: output.routes.map((route) =>
       pruneUndefined({
         id: route.id,
         path: route.path,
@@ -130,7 +122,7 @@ export function createClientRuntime(output: BuildOutput): ClientRuntimeOutput {
 }
 
 function createClientRuntimeRuntime(
-  runtime: PublicManifestOutput["runtime"],
+  runtime: BuildOutput["runtime"],
 ): ClientRuntimeOutputRuntime {
   return pruneUndefined({
     server: runtime.server.rsc

--- a/packages/ev/src/framework-runtime.ts
+++ b/packages/ev/src/framework-runtime.ts
@@ -1,0 +1,247 @@
+import {
+  type BuildOutput,
+  createPublicManifest,
+  type PublicManifestOutput,
+} from "@evjs/shared/manifest";
+
+export type ClientRuntimeOutput = Pick<
+  PublicManifestOutput,
+  "version" | "buildId"
+> & {
+  runtime: ClientRuntimeOutputRuntime;
+  apps: Record<string, ClientRuntimeTargetOutput>;
+  pages: Record<string, ClientRuntimeTargetOutput>;
+  routes: ClientRuntimeRouteOutput[];
+};
+
+export interface ClientRuntimeOutputRuntime {
+  server?: {
+    rsc?: string;
+  };
+  transport?: PublicManifestOutput["runtime"]["transport"];
+}
+
+export type ClientRuntimeTargetOutput = Pick<
+  PublicManifestOutput["apps"][string],
+  "mount" | "module"
+>;
+
+export type ClientRuntimeRouteOutput = Pick<
+  PublicManifestOutput["routes"][number],
+  "id" | "path" | "appId" | "pageId"
+>;
+
+export interface FrameworkRuntimeOutput {
+  version: 1;
+  buildId: string;
+  publicPath: string;
+  runtime: BuildOutput["runtime"];
+  pages: Record<string, FrameworkRuntimePage>;
+  routes: FrameworkRuntimeRoute[];
+  server: {
+    renderers?: Record<string, FrameworkRuntimeRenderer>;
+  };
+  rsc?: FrameworkRuntimeRsc;
+}
+
+export type FrameworkRuntimePage = Pick<
+  BuildOutput["pages"][string],
+  | "assets"
+  | "render"
+  | "rendering"
+  | "path"
+  | "routeId"
+  | "componentModel"
+  | "mount"
+> & {
+  ppr?: FrameworkRuntimePprPage;
+};
+
+export interface FrameworkRuntimePprPage {
+  delivery: NonNullable<BuildOutput["pages"][string]["ppr"]>["delivery"];
+  shell: NonNullable<BuildOutput["pages"][string]["ppr"]>["shell"];
+  regions: Record<string, FrameworkRuntimePprRegion>;
+}
+
+export type FrameworkRuntimePprRegion = Pick<
+  NonNullable<BuildOutput["pages"][string]["ppr"]>["regions"][string],
+  "id" | "assets" | "cache"
+>;
+
+export type FrameworkRuntimeRoute = Pick<
+  BuildOutput["routes"][number],
+  "id" | "path" | "pageId"
+>;
+
+export interface FrameworkRuntimeRenderer {
+  kind: NonNullable<BuildOutput["server"]["renderers"]>[string]["kind"];
+  owner?: FrameworkRuntimeOwner;
+  assets: NonNullable<BuildOutput["server"]["renderers"]>[string]["assets"];
+}
+
+export type FrameworkRuntimeOwner = Pick<
+  NonNullable<NonNullable<BuildOutput["server"]["renderers"]>[string]["owner"]>,
+  "pageId" | "routeId" | "regionId"
+>;
+
+export interface FrameworkRuntimeRsc {
+  pages?: Record<string, FrameworkRuntimeRscPage>;
+  clientReferenceManifest?: Record<string, unknown>;
+}
+
+export type FrameworkRuntimeRscPage = Pick<
+  NonNullable<NonNullable<BuildOutput["rsc"]>["pages"]>[string],
+  "renderer" | "assets" | "routeId"
+>;
+
+export function createClientRuntime(output: BuildOutput): ClientRuntimeOutput {
+  const manifest = createPublicManifest(output);
+  return pruneUndefined({
+    version: manifest.version,
+    buildId: manifest.buildId,
+    runtime: createClientRuntimeRuntime(manifest.runtime),
+    apps: Object.fromEntries(
+      Object.entries(manifest.apps).map(([id, app]) => [
+        id,
+        pruneUndefined({
+          mount: app.mount,
+          module: app.module,
+        }),
+      ]),
+    ),
+    pages: Object.fromEntries(
+      Object.entries(manifest.pages).map(([id, page]) => [
+        id,
+        pruneUndefined({
+          mount: page.mount,
+          module: page.module,
+        }),
+      ]),
+    ),
+    routes: manifest.routes.map((route) =>
+      pruneUndefined({
+        id: route.id,
+        path: route.path,
+        appId: route.appId,
+        pageId: route.pageId,
+      }),
+    ),
+  });
+}
+
+function createClientRuntimeRuntime(
+  runtime: PublicManifestOutput["runtime"],
+): ClientRuntimeOutputRuntime {
+  return pruneUndefined({
+    server: runtime.server.rsc
+      ? {
+          rsc: runtime.server.rsc,
+        }
+      : undefined,
+    transport: runtime.transport,
+  });
+}
+
+export function createFrameworkRuntime(
+  output: BuildOutput,
+): FrameworkRuntimeOutput {
+  return pruneUndefined({
+    version: 1 as const,
+    buildId: output.buildId,
+    publicPath: output.publicPath,
+    runtime: output.runtime,
+    pages: Object.fromEntries(
+      Object.entries(output.pages).map(([id, page]) => [
+        id,
+        pruneUndefined({
+          assets: page.assets,
+          render: page.render,
+          rendering: page.rendering,
+          path: page.path,
+          routeId: page.routeId,
+          componentModel: page.componentModel,
+          mount: page.mount,
+          ppr: page.ppr
+            ? {
+                delivery: page.ppr.delivery,
+                shell: page.ppr.shell,
+                regions: Object.fromEntries(
+                  Object.entries(page.ppr.regions).map(([regionId, region]) => [
+                    regionId,
+                    pruneUndefined({
+                      id: region.id,
+                      assets: region.assets,
+                      cache: region.cache,
+                    }),
+                  ]),
+                ),
+              }
+            : undefined,
+        }),
+      ]),
+    ),
+    routes: output.routes.map((route) =>
+      pruneUndefined({
+        id: route.id,
+        path: route.path,
+        pageId: route.pageId,
+      }),
+    ),
+    server: pruneUndefined({
+      renderers: output.server.renderers
+        ? Object.fromEntries(
+            Object.entries(output.server.renderers).map(([id, renderer]) => [
+              id,
+              pruneUndefined({
+                kind: renderer.kind,
+                owner: createFrameworkRuntimeOwner(renderer.owner),
+                assets: renderer.assets,
+              }),
+            ]),
+          )
+        : undefined,
+    }),
+    rsc: createFrameworkRuntimeRsc(output.rsc),
+  });
+}
+
+function createFrameworkRuntimeRsc(
+  rsc: BuildOutput["rsc"],
+): FrameworkRuntimeRsc | undefined {
+  if (!rsc) return undefined;
+  const runtimeRsc = pruneUndefined({
+    pages: rsc.pages
+      ? Object.fromEntries(
+          Object.entries(rsc.pages).map(([id, page]) => [
+            id,
+            pruneUndefined({
+              renderer: page.renderer,
+              assets: page.assets,
+              routeId: page.routeId,
+            }),
+          ]),
+        )
+      : undefined,
+    clientReferenceManifest: rsc.clientReferenceManifest,
+  });
+  return Object.keys(runtimeRsc).length > 0 ? runtimeRsc : undefined;
+}
+
+function createFrameworkRuntimeOwner(
+  owner: NonNullable<BuildOutput["server"]["renderers"]>[string]["owner"],
+): FrameworkRuntimeOwner | undefined {
+  if (!owner) return undefined;
+  const runtimeOwner = pruneUndefined({
+    pageId: owner.pageId,
+    routeId: owner.routeId,
+    regionId: owner.regionId,
+  });
+  return Object.keys(runtimeOwner).length > 0 ? runtimeOwner : undefined;
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(value: T): T {
+  for (const key of Object.keys(value)) {
+    if (value[key] === undefined) delete value[key];
+  }
+  return value;
+}

--- a/packages/ev/src/internal/client/index.ts
+++ b/packages/ev/src/internal/client/index.ts
@@ -34,7 +34,7 @@ export {
   createShell,
   getFnId,
   getFnName,
-  initTransportFromManifest,
+  initTransportFromRuntime,
   mountReactPage,
   PageProvider,
   registerShellModule,

--- a/packages/ev/src/plugin.ts
+++ b/packages/ev/src/plugin.ts
@@ -151,9 +151,9 @@ export interface ServerManifest {
   /** Server bundle asset paths. */
   assets: ManifestAssets;
   /** Registered server functions. */
-  fns: Record<string, ServerFnEntry>;
+  functions: Record<string, ServerFnEntry>;
   /** Registered server route handlers. */
-  routes?: ServerRouteEntry[];
+  routes: ServerRouteEntry[];
 }
 
 /** Base context passed to plugin bundler hooks. */

--- a/packages/ev/tests/build-tools-graph-plan.test.ts
+++ b/packages/ev/tests/build-tools-graph-plan.test.ts
@@ -3894,6 +3894,39 @@ describe("createAppGraph and createBuildPlan", () => {
     );
   });
 
+  it("follows the default source alias when discovering server functions", async () => {
+    const cwd = await createFixture({
+      "src/main.tsx": `
+        import { saveOrder } from "@/actions";
+        void saveOrder();
+      `,
+      "src/actions.ts": `
+        "use server";
+
+        export async function saveOrder() {
+          return { ok: true };
+        }
+      `,
+    });
+    const config = createConfig({
+      server: {
+        basePath: "/__evjs",
+      },
+    });
+    const analysis = await createAppGraph(config, cwd);
+
+    expect(analysis.diagnostics).toEqual([]);
+    expect(
+      analysis.graph.serverFunctions.map((fn) => ({
+        module: fn.module,
+        exportName: fn.exportName,
+      })),
+    ).toEqual([{ module: "src/actions.ts", exportName: "saveOrder" }]);
+    expect(relativeFileDependencies(cwd, analysis.fileDependencies)).toEqual([
+      "src/actions.ts",
+    ]);
+  });
+
   it("collects page route declarations", async () => {
     const cwd = await createFixture({
       "src/main.tsx": "console.log('app');",

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -1435,6 +1435,7 @@ describe("build", () => {
       path.join(cwd, "dist/build-output.json"),
       "utf-8",
     );
+    const publicManifestJson = JSON.parse(publicManifest);
     const serverManifestJson = JSON.parse(serverManifest);
     const clientRuntimeJson = JSON.parse(clientRuntime);
     const buildOutputJson = JSON.parse(buildOutput);
@@ -1442,6 +1443,14 @@ describe("build", () => {
     expect(rawOutputComponents).toEqual(["./src/pages/Dashboard.tsx"]);
     expect(publicManifest).not.toContain(".tsx");
     expect(publicManifest).not.toContain("server.js");
+    expect(publicManifestJson).not.toHaveProperty("runtime");
+    expect(
+      publicManifestJson.routes.flatMap((route: Record<string, unknown>) =>
+        Object.keys(route),
+      ),
+    ).not.toEqual(
+      expect.arrayContaining(["module", "render", "hydrate", "runtime"]),
+    );
     expect(clientRuntime).not.toContain(".tsx");
     expect(clientRuntime).not.toContain("server.js");
     expect(clientRuntimeJson).not.toHaveProperty("publicPath");

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -438,6 +438,7 @@ describe("build", () => {
     );
 
     expect(fs.existsSync(path.join(cwd, "dist/manifest.json"))).toBe(false);
+    expect(fs.existsSync(path.join(cwd, "dist/runtime.json"))).toBe(false);
     expect(events).toEqual([
       "bundler.build",
       "bundler.entries:main,server",
@@ -1422,6 +1423,10 @@ describe("build", () => {
       path.join(cwd, "dist/client/manifest.json"),
       "utf-8",
     );
+    const clientRuntime = fs.readFileSync(
+      path.join(cwd, "dist/client/runtime.json"),
+      "utf-8",
+    );
     const serverManifest = fs.readFileSync(
       path.join(cwd, "dist/server/manifest.json"),
       "utf-8",
@@ -1431,16 +1436,61 @@ describe("build", () => {
       "utf-8",
     );
     const serverManifestJson = JSON.parse(serverManifest);
+    const clientRuntimeJson = JSON.parse(clientRuntime);
     const buildOutputJson = JSON.parse(buildOutput);
 
     expect(rawOutputComponents).toEqual(["./src/pages/Dashboard.tsx"]);
     expect(publicManifest).not.toContain(".tsx");
     expect(publicManifest).not.toContain("server.js");
+    expect(clientRuntime).not.toContain(".tsx");
+    expect(clientRuntime).not.toContain("server.js");
+    expect(clientRuntimeJson).not.toHaveProperty("publicPath");
+    expect(clientRuntimeJson).not.toHaveProperty("assets");
+    expect(Object.keys(clientRuntimeJson.runtime.server ?? {})).not.toEqual(
+      expect.arrayContaining(["basePath", "fn", "ppr"]),
+    );
+    expect(
+      Object.values(clientRuntimeJson.apps).flatMap((app) =>
+        Object.keys(app as Record<string, unknown>),
+      ),
+    ).not.toEqual(expect.arrayContaining(["assets", "document", "entry"]));
+    expect(
+      Object.values(clientRuntimeJson.pages).flatMap((page) =>
+        Object.keys(page as Record<string, unknown>),
+      ),
+    ).not.toEqual(
+      expect.arrayContaining([
+        "assets",
+        "document",
+        "render",
+        "rendering",
+        "path",
+        "routeId",
+        "componentModel",
+        "hydrate",
+        "ppr",
+      ]),
+    );
+    expect(clientRuntimeJson).not.toHaveProperty("rsc");
+    expect(
+      clientRuntimeJson.routes.flatMap((route: Record<string, unknown>) =>
+        Object.keys(route),
+      ),
+    ).not.toEqual(
+      expect.arrayContaining([
+        "parentId",
+        "kind",
+        "render",
+        "hydrate",
+        "runtime",
+      ]),
+    );
     expect(serverManifestJson).toEqual({
       version: 1,
       entry: "server.js",
       assets: { js: ["server.js"], css: [] },
-      fns: {},
+      functions: {},
+      routes: [],
     });
     expect(serverManifestJson.server).toBeUndefined();
     expect(serverManifest).not.toContain("./src/pages/Dashboard.tsx");
@@ -1451,6 +1501,7 @@ describe("build", () => {
     expect(buildOutput).toContain("./src/pages/Dashboard.tsx");
     expect(buildOutput).toContain("server.js");
     expect(fs.existsSync(path.join(cwd, "dist/manifest.json"))).toBe(false);
+    expect(fs.existsSync(path.join(cwd, "dist/runtime.json"))).toBe(false);
     expect(fs.existsSync(path.join(cwd, "dist/build-output.json"))).toBe(true);
     expect(fs.existsSync(path.join(cwd, "dist/server/build-output.json"))).toBe(
       false,
@@ -1466,11 +1517,18 @@ describe("build", () => {
     expect(fs.existsSync(path.join(cwd, "dist/client/manifest.json"))).toBe(
       true,
     );
+    expect(fs.existsSync(path.join(cwd, "dist/client/runtime.json"))).toBe(
+      true,
+    );
 
     await build({ output: { client: "dist" } }, { cwd, bundler });
 
     expect(fs.existsSync(path.join(cwd, "dist/manifest.json"))).toBe(true);
+    expect(fs.existsSync(path.join(cwd, "dist/runtime.json"))).toBe(true);
     expect(fs.existsSync(path.join(cwd, "dist/client/manifest.json"))).toBe(
+      false,
+    );
+    expect(fs.existsSync(path.join(cwd, "dist/client/runtime.json"))).toBe(
       false,
     );
   });
@@ -2349,6 +2407,7 @@ describe("build", () => {
     );
     expect(events).toContain("bundler.build");
     expect(fs.existsSync(path.join(cwd, "dist/manifest.json"))).toBe(true);
+    expect(fs.existsSync(path.join(cwd, "dist/runtime.json"))).toBe(true);
     expect(fs.existsSync(path.join(cwd, "dist/server/manifest.json"))).toBe(
       true,
     );

--- a/packages/ev/tests/deployment.test.ts
+++ b/packages/ev/tests/deployment.test.ts
@@ -273,7 +273,7 @@ describe("createDeploymentArtifact", () => {
       'import { fileURLToPath, pathToFileURL } from "node:url";',
     );
     expect(files.serverModule).toContain(
-      "globalThis.__EVJS_MANIFEST__ = manifest",
+      "globalThis.__EVJS_FRAMEWORK_RUNTIME__ =",
     );
     expect(files.serverModule).toContain('"buildId": "build-1"');
     expect(files.serverModule).toContain('"renderers": {}');
@@ -825,7 +825,9 @@ describe("createDeploymentArtifact", () => {
     expect(files.artifactFileName).toBe("deployment.edge.json");
     expect(files.workerFileName).toBe("worker.mjs");
     expect(files.artifact.platform).toBe("edge");
-    expect(files.workerModule).toContain("globalThis.__EVJS_MANIFEST__");
+    expect(files.workerModule).toContain(
+      "globalThis.__EVJS_FRAMEWORK_RUNTIME__",
+    );
     expect(files.workerModule).toContain(
       "globalThis.__EVJS_SERVER_MODULE_LOADER__",
     );

--- a/packages/ev/tests/deployment.test.ts
+++ b/packages/ev/tests/deployment.test.ts
@@ -43,6 +43,9 @@ describe("createDeploymentArtifact", () => {
           ppr: "/framework/ppr",
           rsc: "/framework/rsc",
         },
+        transport: {
+          baseUrl: "https://api.example.com",
+        },
       },
       assets: {
         main: { js: ["main.js"], css: ["main.css"] },
@@ -77,7 +80,6 @@ describe("createDeploymentArtifact", () => {
           id: "insights",
           path: "/insights",
           pageId: "insights",
-          render: "ssr",
         },
       ],
       server: {
@@ -148,7 +150,6 @@ describe("createDeploymentArtifact", () => {
         serverDir: "dist/server",
       },
       publicPath: "auto",
-      runtime: output.runtime,
       apps: {
         default: {
           entry: "./src/main.tsx",
@@ -172,8 +173,6 @@ describe("createDeploymentArtifact", () => {
           path: "/insights",
           appId: undefined,
           pageId: "insights",
-          render: "ssr",
-          runtime: undefined,
         },
       ],
       server: {
@@ -182,6 +181,9 @@ describe("createDeploymentArtifact", () => {
         fn: "/framework/fn",
         ppr: "/framework/ppr",
         rsc: "/framework/rsc",
+        transport: {
+          baseUrl: "https://api.example.com",
+        },
         renderers: ["insights-rsc"],
         functions: ["search"],
         routes: [
@@ -243,7 +245,6 @@ describe("createDeploymentArtifact", () => {
           id: "insights",
           path: "/insights/$id",
           pageId: "insights",
-          render: "ssr",
         },
       ],
       server: {
@@ -342,13 +343,11 @@ describe("createDeploymentArtifact", () => {
           id: "orders",
           path: "/orders/$orderId",
           appId: "default",
-          render: "csr",
         },
         {
           id: "pricing",
           path: "/pricing",
           pageId: "pricing",
-          render: "ssg",
         },
       ],
       server: {
@@ -572,25 +571,21 @@ describe("createDeploymentArtifact", () => {
           id: "orders",
           path: "/orders/$orderId",
           appId: "default",
-          render: "csr",
         },
         {
           id: "dashboard",
           path: "/dashboard",
           pageId: "dashboard",
-          render: "ssr",
         },
         {
           id: "campaign",
           path: "/campaign",
           pageId: "campaign",
-          render: "ssr",
         },
         {
           id: "insights",
           path: "/insights",
           pageId: "insights",
-          render: "ssr",
         },
       ],
       server: {
@@ -679,7 +674,6 @@ describe("createDeploymentArtifact", () => {
           id: "article",
           path: "/article",
           pageId: "article",
-          render: "ssr",
         },
       ],
       server: {
@@ -741,7 +735,6 @@ describe("createDeploymentArtifact", () => {
           id: "pricing",
           path: "/pricing",
           pageId: "pricing",
-          render: "ssg",
         },
       ],
       server: {
@@ -799,7 +792,6 @@ describe("createDeploymentArtifact", () => {
           id: "insights",
           path: "/insights/$id",
           pageId: "insights",
-          render: "ssr",
         },
       ],
       server: {
@@ -979,19 +971,16 @@ function createMpaStaticDeploymentOutput(): BuildOutput {
         id: "index",
         path: "/",
         pageId: "index",
-        render: "csr",
       },
       {
         id: "pricing",
         path: "/pricing",
         pageId: "pricing",
-        render: "ssg",
       },
       {
         id: "users_userId",
         path: "/users/$userId",
         pageId: "users_userId",
-        render: "csr",
       },
     ],
     server: {
@@ -1034,7 +1023,6 @@ function createServerDeploymentOutput(paths: {
         id: "app",
         path: "/app",
         appId: "default",
-        render: "csr",
       },
     ],
     server: {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -18,7 +18,6 @@ import {
   type ServerRouteParamSegmentValidationError,
   serverRoutePathShapeFromPath,
 } from "@evjs/shared";
-import { assertFrameworkManifestShape } from "@evjs/shared/manifest";
 import type {
   Context as HonoContext,
   Env as HonoEnv,
@@ -29,6 +28,7 @@ import { bodyLimit } from "hono/body-limit";
 import { contextStorage } from "hono/context-storage";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import {
+  assertFrameworkRuntime,
   type FrameworkServerOptions,
   handleFrameworkRenderRequest,
   handlePprRegionRequest,
@@ -72,7 +72,7 @@ export function createApp(options?: CreateAppOptions): Hono {
   assertCreateAppOptions(options);
   const { routes = [], middlewares = [], framework } = options ?? {};
   const endpoint =
-    framework?.manifest.runtime.server?.fn ?? getFunctionEndpoint();
+    framework?.runtime.runtime.server.fn ?? getFunctionEndpoint();
   const maxServerFunctionBodySize = 1024 * 1024;
 
   const app = new Hono();
@@ -173,8 +173,7 @@ export function createApp(options?: CreateAppOptions): Hono {
   });
 
   const rscPath = framework?.rsc
-    ? (framework.manifest.rsc?.endpoint ??
-      framework.manifest.runtime.server?.rsc)
+    ? framework.runtime.runtime.server.rsc
     : undefined;
   if (framework?.rsc && rscPath) {
     app.all(rscPath, async (c, next) => {
@@ -186,8 +185,8 @@ export function createApp(options?: CreateAppOptions): Hono {
 
   if (framework?.render) {
     const pprPath =
-      framework.manifest.runtime.server?.ppr ??
-      joinPath(framework.manifest.runtime.server?.basePath ?? "/__evjs", "ppr");
+      framework.runtime.runtime.server.ppr ??
+      joinPath(framework.runtime.runtime.server.basePath, "ppr");
     app.on(["GET", "HEAD"], [`${pprPath}/*`], async (c, next) => {
       const response = await handlePprRegionRequest(framework, c.req.raw);
       if (!response) return next();
@@ -366,21 +365,12 @@ function assertFrameworkServerOptions(value: unknown): void {
     );
   }
 
-  if (!isRecord(value.manifest)) {
+  if (!isRecord(value.runtime)) {
     throw new Error(
-      "[evjs] createApp() framework.manifest must be a framework manifest object.",
+      "[evjs] createApp() framework.runtime must be a framework runtime object.",
     );
   }
-  assertFrameworkManifestShape(
-    value.manifest,
-    "createApp() framework.manifest",
-    {
-      serverFunctionModules: "optional",
-      pageRendererReferences: "optional",
-      pprRendererReferences: "optional",
-      rscRendererReferences: "optional",
-    },
-  );
+  assertFrameworkRuntime(value.runtime, "createApp() framework.runtime");
   assertOptionalRenderCoordinator(value.render, "framework.render");
   assertOptionalRscCoordinator(value.rsc, "framework.rsc");
   assertOptionalPprRuntimeOptions(value.ppr, "framework.ppr");

--- a/packages/server/src/framework.ts
+++ b/packages/server/src/framework.ts
@@ -2,35 +2,131 @@ import {
   BUILD_IDENTIFIER_DESCRIPTION,
   findBestPageRoute,
   formatContentTypeHeaderValue,
+  getPageRouteParamSegmentValidationError,
+  getPathPatternValidationError,
+  getUrlStringValidationError,
   isBuildIdentifier,
   isHeadersInit,
   isHttpBodyStatus,
   isRscFlightContentType,
   isTextHtmlContentType,
   normalizeRoutePathname,
+  type PageRouteParamSegmentValidationError,
+  type PathPatternValidationError,
   pageRoutePathMatches,
+  pageRoutePathShapeFromPath,
   RSC_FLIGHT_CONTENT_TYPE,
   type RscFlightRequestPageUrlError,
   resolveRscFlightRequestPageUrl,
   TEXT_HTML_UTF8_CONTENT_TYPE,
+  type UrlStringValidationError,
 } from "@evjs/shared";
-import type {
-  BuildEntryOwner,
-  BuildOutput,
-  PageOutput,
-  PprCachePolicy,
-  RouteOutput,
-  RscPageOutput,
-  ServerRendererOutput,
-  ServerRenderPlan,
-} from "@evjs/shared/manifest";
-import { assertFrameworkManifestShape } from "@evjs/shared/manifest";
 import { tryGetContext } from "hono/context-storage";
 import { textResponse } from "./responses.js";
 import { formatUnknownError, isRecord } from "./validation.js";
 
+export interface FrameworkRuntime {
+  version: 1;
+  buildId: string;
+  publicPath: string;
+  runtime: {
+    server: FrameworkRuntimeServer;
+    transport?: FrameworkRuntimeTransport;
+  };
+  pages: Record<string, FrameworkPageRuntime>;
+  routes: FrameworkRouteRuntime[];
+  server: FrameworkServerRuntime;
+  rsc?: FrameworkRscRuntime;
+}
+
+export interface FrameworkRuntimeServer {
+  basePath: string;
+  fn: string;
+  ppr?: string;
+  rsc?: string;
+}
+
+export interface FrameworkRuntimeTransport {
+  baseUrl?: string;
+}
+
+export interface FrameworkAssetGroup {
+  js: string[];
+  css: string[];
+}
+
+export interface FrameworkPageRuntime {
+  assets: FrameworkAssetGroup;
+  render: "csr" | "ssr" | "ssg";
+  rendering: {
+    component: "client" | "server" | "rsc";
+    html: "client" | "server" | "static" | "partial";
+    prerender?: "full" | "partial";
+    streaming: boolean;
+    hydrate: "none" | "load" | "visible" | "idle";
+  };
+  path?: string;
+  routeId?: string;
+  componentModel?: "client" | "rsc";
+  mount?: string;
+  ppr?: FrameworkPprPageRuntime;
+}
+
+export interface FrameworkPprPageRuntime {
+  delivery: "merge" | "stream";
+  shell: FrameworkAssetGroup;
+  regions: Record<string, FrameworkPprRegionRuntime>;
+}
+
+export interface FrameworkPprRegionRuntime {
+  id: string;
+  assets: FrameworkAssetGroup;
+  cache?: "no-store" | { revalidate: number };
+}
+
+type PprCachePolicy = NonNullable<FrameworkPprRegionRuntime["cache"]>;
+
+export interface FrameworkRouteRuntime {
+  id: string;
+  path: string;
+  pageId?: string;
+}
+
+export interface FrameworkServerRuntime {
+  renderers?: Record<string, FrameworkServerRenderer>;
+}
+
+export interface FrameworkServerRenderer {
+  kind: FrameworkServerRendererKind;
+  owner?: FrameworkRuntimeOwner;
+  assets: FrameworkAssetGroup;
+}
+
+export type FrameworkServerRendererKind =
+  | "page-server"
+  | "rsc-page"
+  | "ppr-shell"
+  | "ppr-region";
+
+export interface FrameworkRuntimeOwner {
+  pageId?: string;
+  routeId?: string;
+  regionId?: string;
+}
+
+export interface FrameworkRscRuntime {
+  pages?: Record<string, FrameworkRscPageRuntime>;
+  clientReferenceManifest?: Record<string, unknown>;
+}
+
+export interface FrameworkRscPageRuntime {
+  renderer: string;
+  assets: FrameworkAssetGroup;
+  routeId?: string;
+}
+
 export interface FrameworkServerOptions {
-  manifest: BuildOutput;
+  runtime: FrameworkRuntime;
   render?: ServerRenderHandler | ServerRenderCoordinator;
   rsc?: RscFlightHandler | RscCoordinator;
   ppr?: PprRuntimeOptions;
@@ -46,10 +142,10 @@ export interface PprRuntimeOptions {
 
 export interface ServerRenderContext {
   request: Request;
-  manifest: BuildOutput;
+  runtime: FrameworkRuntime;
   pageUrl?: string;
-  route?: RouteOutput;
-  page?: PageOutput;
+  route?: FrameworkRouteRuntime;
+  page?: FrameworkPageRuntime;
   pageId?: string;
   regionId?: string;
 }
@@ -79,8 +175,8 @@ export type ServerRenderHandler = (
 export type ServerRendererModule = Record<string, unknown>;
 
 export interface ServerRendererRegistryEntry {
-  kind: ServerRenderPlan["kind"];
-  owner?: BuildEntryOwner;
+  kind: FrameworkServerRendererKind;
+  owner?: FrameworkRuntimeOwner;
   load(): Promise<ServerRendererModule>;
 }
 
@@ -104,26 +200,26 @@ export type ServerModuleRenderHandler = (
   },
 ) => ServerRenderResult | undefined | Promise<ServerRenderResult | undefined>;
 
-export type ManifestServerModuleLoader = (
+export type FrameworkServerModuleLoader = (
   asset: string,
-  renderer: ServerRendererOutput,
+  renderer: FrameworkServerRenderer,
 ) => Promise<ServerRendererModule>;
 
-export interface ManifestRenderCoordinatorOptions {
-  manifest: BuildOutput;
-  loadModule: ManifestServerModuleLoader;
+export interface FrameworkRenderCoordinatorOptions {
+  runtime: FrameworkRuntime;
+  loadModule: FrameworkServerModuleLoader;
   renderModule?: ServerModuleRenderHandler;
   fallback?: ServerRenderHandler | ServerRenderCoordinator;
 }
 
 export interface RscFlightContext {
   request: Request;
-  manifest: BuildOutput;
+  runtime: FrameworkRuntime;
   pageUrl?: string;
   pageId?: string;
-  page?: PageOutput;
-  rscPage?: RscPageOutput;
-  renderer?: ServerRendererOutput;
+  page?: FrameworkPageRuntime;
+  rscPage?: FrameworkRscPageRuntime;
+  renderer?: FrameworkServerRenderer;
 }
 
 export type RscFlightHandler = (
@@ -249,14 +345,14 @@ export function createModuleRenderCoordinator(
   };
 }
 
-export function createManifestRenderCoordinator(
-  options: ManifestRenderCoordinatorOptions,
+export function createFrameworkRenderCoordinator(
+  options: FrameworkRenderCoordinatorOptions,
 ): ServerRenderCoordinator {
-  assertManifestRenderCoordinatorOptions(options);
+  assertFrameworkRenderCoordinatorOptions(options);
 
   return createModuleRenderCoordinator({
-    renderers: createRendererRegistryFromManifest(
-      options.manifest,
+    renderers: createRendererRegistryFromRuntime(
+      options.runtime,
       options.loadModule,
     ),
     renderModule: options.renderModule,
@@ -287,30 +383,30 @@ function assertModuleRenderCoordinatorOptions(
   );
 }
 
-function assertManifestRenderCoordinatorOptions(
+function assertFrameworkRenderCoordinatorOptions(
   value: unknown,
-): asserts value is ManifestRenderCoordinatorOptions {
+): asserts value is FrameworkRenderCoordinatorOptions {
   if (!isRecord(value)) {
     throw new Error(
-      "[evjs] createManifestRenderCoordinator() options must be an object.",
+      "[evjs] createFrameworkRenderCoordinator() options must be an object.",
     );
   }
 
-  assertFrameworkManifestShape(
-    value.manifest,
-    "createManifestRenderCoordinator() manifest",
+  assertFrameworkRuntime(
+    value.runtime,
+    "createFrameworkRenderCoordinator() runtime",
   );
   assertFunction(
     value.loadModule,
-    "createManifestRenderCoordinator() loadModule",
+    "createFrameworkRenderCoordinator() loadModule",
   );
   assertOptionalFunction(
     value.renderModule,
-    "createManifestRenderCoordinator() renderModule",
+    "createFrameworkRenderCoordinator() renderModule",
   );
   assertOptionalRenderCoordinator(
     value.fallback,
-    "createManifestRenderCoordinator() fallback",
+    "createFrameworkRenderCoordinator() fallback",
   );
 }
 
@@ -357,6 +453,627 @@ function assertObject(
   }
 }
 
+export function assertFrameworkRuntime(
+  value: unknown,
+  source: string,
+): asserts value is FrameworkRuntime {
+  assertObject(value, source);
+  if (value.version !== 1) {
+    throw new Error(`[evjs] ${source}.version must be 1.`);
+  }
+  assertBuildIdentifier(value.buildId, `${source}.buildId`);
+  assertRuntimeString(value.publicPath, `${source}.publicPath`);
+  assertObject(value.runtime, `${source}.runtime`);
+  assertObject(value.runtime.server, `${source}.runtime.server`);
+  assertRuntimePathname(
+    value.runtime.server.basePath,
+    `${source}.runtime.server.basePath`,
+    true,
+  );
+  assertRuntimePathname(
+    value.runtime.server.fn,
+    `${source}.runtime.server.fn`,
+    true,
+  );
+  assertRuntimePathname(
+    value.runtime.server.ppr,
+    `${source}.runtime.server.ppr`,
+  );
+  assertRuntimePathname(
+    value.runtime.server.rsc,
+    `${source}.runtime.server.rsc`,
+  );
+  if (value.runtime.transport !== undefined) {
+    assertObject(value.runtime.transport, `${source}.runtime.transport`);
+    assertRuntimeTransportBaseUrl(
+      value.runtime.transport.baseUrl,
+      `${source}.runtime.transport.baseUrl`,
+    );
+  }
+  assertObject(value.pages, `${source}.pages`);
+  assertFrameworkRuntimePages(value.pages, `${source}.pages`);
+  if (!Array.isArray(value.routes)) {
+    throw new Error(`[evjs] ${source}.routes must be an array.`);
+  }
+  assertFrameworkRuntimeRoutes(value.routes, `${source}.routes`, value.pages);
+  assertObject(value.server, `${source}.server`);
+  if (
+    value.server.renderers !== undefined &&
+    !isRecord(value.server.renderers)
+  ) {
+    throw new Error(`[evjs] ${source}.server.renderers must be an object.`);
+  }
+  if (isRecord(value.server.renderers)) {
+    assertFrameworkRuntimeRenderers(
+      value.server.renderers,
+      `${source}.server.renderers`,
+      value.pages,
+      value.routes,
+    );
+  }
+  if (value.rsc !== undefined) {
+    assertFrameworkRuntimeRsc(value.rsc, `${source}.rsc`, value.pages);
+  }
+}
+
+function assertBuildIdentifier(value: unknown, source: string): void {
+  assertString(value, source);
+  if (!isBuildIdentifier(value)) {
+    throw new Error(
+      `[evjs] ${source} must contain only ${BUILD_IDENTIFIER_DESCRIPTION}.`,
+    );
+  }
+}
+
+function assertString(value: unknown, source: string): asserts value is string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`[evjs] ${source} must be a non-empty string.`);
+  }
+}
+
+function assertRuntimeString(
+  value: unknown,
+  source: string,
+): asserts value is string {
+  assertString(value, source);
+  if (value.trim() !== value) {
+    throw new Error(
+      `[evjs] ${source} must not contain leading or trailing whitespace.`,
+    );
+  }
+}
+
+function assertFrameworkRuntimePages(
+  value: Record<string, unknown>,
+  source: string,
+): void {
+  for (const [name, page] of Object.entries(value)) {
+    assertRuntimeBuildIdentifierKey(name, source);
+    const pageSource = `${source}.${name}`;
+    assertObject(page, pageSource);
+    assertAssetGroup(page.assets, `${pageSource}.assets`);
+    assertRenderMode(page.render, `${pageSource}.render`);
+    assertPageRendering(page.rendering, `${pageSource}.rendering`);
+    if (page.path !== undefined) {
+      assertRuntimePathname(page.path, `${pageSource}.path`);
+    }
+    if (page.routeId !== undefined) {
+      assertRuntimeString(page.routeId, `${pageSource}.routeId`);
+    }
+    if (page.componentModel !== undefined) {
+      assertComponentModel(page.componentModel, `${pageSource}.componentModel`);
+    }
+    if (page.mount !== undefined) {
+      assertRuntimeString(page.mount, `${pageSource}.mount`);
+    }
+    if (page.ppr !== undefined) {
+      assertPprPageRuntime(page.ppr, `${pageSource}.ppr`);
+      assertPprPageRuntimeContract(page, pageSource);
+    }
+  }
+}
+
+function assertPageRendering(value: unknown, source: string): void {
+  assertObject(value, source);
+  assertComponentModel(value.component, `${source}.component`);
+  assertHtmlRendering(value.html, `${source}.html`);
+  if (value.prerender !== undefined) {
+    assertPrerenderMode(value.prerender, `${source}.prerender`);
+  }
+  if (typeof value.streaming !== "boolean") {
+    throw new Error(`[evjs] ${source}.streaming must be a boolean.`);
+  }
+  assertHydrationMode(value.hydrate, `${source}.hydrate`);
+}
+
+function assertPprPageRuntime(value: unknown, source: string): void {
+  assertObject(value, source);
+  assertPprDeliveryMode(value.delivery, `${source}.delivery`);
+  assertAssetGroup(value.shell, `${source}.shell`);
+  assertObject(value.regions, `${source}.regions`);
+  for (const [name, region] of Object.entries(value.regions)) {
+    assertRuntimeBuildIdentifierKey(name, `${source}.regions`);
+    const regionSource = `${source}.regions.${name}`;
+    assertObject(region, regionSource);
+    assertRuntimeString(region.id, `${regionSource}.id`);
+    if (region.id !== name) {
+      throw new Error(
+        `[evjs] ${regionSource}.id must match region key "${name}".`,
+      );
+    }
+    assertAssetGroup(region.assets, `${regionSource}.assets`);
+    if (region.cache !== undefined) {
+      assertPprRegionCache(region.cache, `${regionSource}.cache`);
+    }
+  }
+}
+
+function assertPprPageRuntimeContract(
+  page: Record<string, unknown>,
+  source: string,
+): void {
+  if (page.ppr === undefined) return;
+  const rendering = page.rendering;
+  if (!isRecord(rendering) || !isRecord(page.ppr)) return;
+
+  if (page.componentModel === "rsc" || rendering.component === "rsc") {
+    throw new Error(`[evjs] ${source}.ppr is not supported for RSC pages.`);
+  }
+  if (page.render !== "ssr") {
+    throw new Error(`[evjs] ${source}.render must be "ssr" for PPR pages.`);
+  }
+  if (rendering.component !== "server") {
+    throw new Error(
+      `[evjs] ${source}.rendering.component must be "server" for PPR pages.`,
+    );
+  }
+  if (rendering.html !== "partial") {
+    throw new Error(
+      `[evjs] ${source}.rendering.html must be "partial" for PPR pages.`,
+    );
+  }
+  if (rendering.prerender !== "partial") {
+    throw new Error(
+      `[evjs] ${source}.rendering.prerender must be "partial" for PPR pages.`,
+    );
+  }
+  const streams = page.ppr.delivery === "stream";
+  if (rendering.streaming !== streams) {
+    throw new Error(
+      `[evjs] ${source}.rendering.streaming must be ${String(streams)} when ${source}.ppr.delivery is "${page.ppr.delivery}".`,
+    );
+  }
+  if (rendering.hydrate !== "none") {
+    throw new Error(
+      `[evjs] ${source}.rendering.hydrate must be "none" for PPR pages.`,
+    );
+  }
+}
+
+function assertFrameworkRuntimeRoutes(
+  value: unknown[],
+  source: string,
+  pages: Record<string, unknown>,
+): void {
+  const idOwners = new Map<string, string>();
+  const pathOwners = new Map<string, { path: string; source: string }>();
+  const shapeOwners = new Map<string, { path: string; source: string }>();
+
+  value.forEach((route, index) => {
+    const routeSource = `${source}[${index}]`;
+    assertObject(route, routeSource);
+    assertRuntimeString(route.id, `${routeSource}.id`);
+    assertUniqueRuntimeRouteId(route.id, `${routeSource}.id`, idOwners);
+    assertRuntimePathname(route.path, `${routeSource}.path`, true);
+    const path = route.path as string;
+    assertPageRouteParamSegments(path, `${routeSource}.path`);
+    assertUniquePageRoutePath(path, `${routeSource}.path`, pathOwners);
+    assertUniquePageRouteShape(path, `${routeSource}.path`, shapeOwners);
+    const page = assertOptionalPageReference(
+      route.pageId,
+      `${routeSource}.pageId`,
+      pages,
+    );
+    if (page) {
+      assertPageRouteContract(route, page, routeSource);
+    }
+  });
+}
+
+function assertFrameworkRuntimeRenderers(
+  value: Record<string, unknown>,
+  source: string,
+  pages: Record<string, unknown>,
+  routes: unknown[],
+): void {
+  const routesById = createRouteRuntimeMap(routes);
+  for (const [name, renderer] of Object.entries(value)) {
+    assertRuntimeBuildIdentifierKey(name, source);
+    const rendererSource = `${source}.${name}`;
+    assertObject(renderer, rendererSource);
+    assertServerRendererKind(renderer.kind, `${rendererSource}.kind`);
+    assertAssetGroup(renderer.assets, `${rendererSource}.assets`);
+    assertServerRendererOwner(
+      renderer.owner,
+      `${rendererSource}.owner`,
+      renderer.kind,
+      pages,
+      routesById,
+    );
+  }
+}
+
+function assertFrameworkRuntimeRsc(
+  value: unknown,
+  source: string,
+  pages: Record<string, unknown>,
+): void {
+  assertObject(value, source);
+  if (value.pages !== undefined) {
+    assertObject(value.pages, `${source}.pages`);
+    for (const [name, page] of Object.entries(value.pages)) {
+      const pageSource = `${source}.pages.${name}`;
+      assertObject(page, pageSource);
+      assertAssetGroup(page.assets, `${pageSource}.assets`);
+      assertOptionalPageReference(name, pageSource, pages);
+      const frameworkPage = pages[name];
+      if (
+        isRecord(frameworkPage) &&
+        frameworkPage.componentModel !== "rsc" &&
+        isRecord(frameworkPage.rendering) &&
+        frameworkPage.rendering.component !== "rsc"
+      ) {
+        throw new Error(
+          `[evjs] ${pageSource} requires ${source.replace(/\.rsc$/, "")}.pages.${name}.componentModel to be "rsc".`,
+        );
+      }
+      assertRuntimeString(page.renderer, `${pageSource}.renderer`);
+      if (page.routeId !== undefined) {
+        assertRuntimeString(page.routeId, `${pageSource}.routeId`);
+      }
+    }
+  }
+  if (value.clientReferenceManifest !== undefined) {
+    assertObject(
+      value.clientReferenceManifest,
+      `${source}.clientReferenceManifest`,
+    );
+  }
+}
+
+function assertOptionalPageReference(
+  value: unknown,
+  source: string,
+  pages: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (value === undefined) return undefined;
+  assertRuntimeString(value, source);
+  if (!Object.hasOwn(pages, value)) {
+    throw new Error(
+      `[evjs] ${source} "${value}" does not match any runtime.pages entry.`,
+    );
+  }
+  const page = pages[value];
+  return isRecord(page) ? page : undefined;
+}
+
+function assertPageRouteContract(
+  route: Record<string, unknown>,
+  page: Record<string, unknown>,
+  routeSource: string,
+): void {
+  if (
+    typeof page.path === "string" &&
+    normalizeRoutePathname(route.path as string) !==
+      normalizeRoutePathname(page.path)
+  ) {
+    throw new Error(
+      `[evjs] ${routeSource}.path "${route.path as string}" must match runtime.pages.${route.pageId as string}.path "${page.path}".`,
+    );
+  }
+}
+
+function assertUniqueRuntimeRouteId(
+  id: string,
+  source: string,
+  idOwners: Map<string, string>,
+): void {
+  const existingSource = idOwners.get(id);
+  if (existingSource) {
+    throw new Error(
+      `[evjs] ${source} duplicates ${existingSource} "${id}". Route ids must be unique.`,
+    );
+  }
+  idOwners.set(id, source);
+}
+
+function assertUniquePageRoutePath(
+  path: string,
+  source: string,
+  pathOwners: Map<string, { path: string; source: string }>,
+): void {
+  const normalizedPath = normalizeRoutePathname(path);
+  const existing = pathOwners.get(normalizedPath);
+  if (existing) {
+    throw new Error(
+      `[evjs] ${source} duplicates ${existing.source} "${existing.path}". Page route paths must be unique.`,
+    );
+  }
+  pathOwners.set(normalizedPath, { path, source });
+}
+
+function assertUniquePageRouteShape(
+  path: string,
+  source: string,
+  shapeOwners: Map<string, { path: string; source: string }>,
+): void {
+  const shape = pageRoutePathShapeFromPath(path);
+  const existing = shapeOwners.get(shape);
+  if (existing) {
+    throw new Error(
+      `[evjs] ${source} has the same route shape as ${existing.source} "${existing.path}". Use one page route per URL shape.`,
+    );
+  }
+  shapeOwners.set(shape, { path, source });
+}
+
+function assertPageRouteParamSegments(path: string, source: string): void {
+  const error = getPageRouteParamSegmentValidationError(path);
+  if (!error) return;
+  throw new Error(
+    `[evjs] ${source} ${formatPageRouteParamSegmentError(error)}`,
+  );
+}
+
+function formatPageRouteParamSegmentError(
+  error: PageRouteParamSegmentValidationError,
+): string {
+  if (error.error === "empty") {
+    return `contains dynamic segment "${error.segment}" without a param name.`;
+  }
+  if (error.error === "reserved") {
+    return `uses reserved dynamic param name "${error.name}" in segment "${error.segment}". Use a safe application-specific name.`;
+  }
+  if (error.error === "duplicate") {
+    return `uses duplicate dynamic param name "${error.name}" in segment "${error.segment}". Use unique param names within one route path.`;
+  }
+  return `contains more than one wildcard segment "${error.segment}". Use at most one wildcard segment in a route path.`;
+}
+
+function createRouteRuntimeMap(
+  routes: unknown[],
+): Map<string, Record<string, unknown>> {
+  const byId = new Map<string, Record<string, unknown>>();
+  for (const route of routes) {
+    if (!isRecord(route) || typeof route.id !== "string") continue;
+    byId.set(route.id, route);
+  }
+  return byId;
+}
+
+function assertServerRendererOwner(
+  value: unknown,
+  source: string,
+  kind: unknown,
+  pages: Record<string, unknown>,
+  routesById: Map<string, Record<string, unknown>>,
+): void {
+  if (value === undefined) {
+    if (kind === "ppr-region") {
+      throw new Error(`[evjs] ${source} is required for ppr-region renderers.`);
+    }
+    return;
+  }
+
+  assertObject(value, source);
+  const supportedKeys = new Set(["pageId", "routeId", "regionId"]);
+  for (const key of Object.keys(value)) {
+    if (supportedKeys.has(key)) continue;
+    throw new Error(
+      `[evjs] ${source}.${key} is not supported for server renderers. Use pageId, routeId, or regionId.`,
+    );
+  }
+  if (value.pageId !== undefined) {
+    assertOptionalPageReference(value.pageId, `${source}.pageId`, pages);
+  }
+  if (value.routeId !== undefined) {
+    assertRuntimeString(value.routeId, `${source}.routeId`);
+    const route = routesById.get(value.routeId);
+    if (!route) {
+      throw new Error(
+        `[evjs] ${source}.routeId "${value.routeId}" does not match any runtime.routes entry.`,
+      );
+    }
+  }
+  if (value.regionId !== undefined) {
+    assertRuntimeString(value.regionId, `${source}.regionId`);
+  }
+}
+
+function assertAssetGroup(value: unknown, source: string): void {
+  assertObject(value, source);
+  assertStringArray(value.js, `${source}.js`);
+  assertStringArray(value.css, `${source}.css`);
+}
+
+function assertStringArray(value: unknown, source: string): void {
+  if (!Array.isArray(value)) {
+    throw new Error(`[evjs] ${source} must be an array.`);
+  }
+  for (const item of value) {
+    if (typeof item !== "string" || !item.trim()) {
+      throw new Error(`[evjs] ${source} must contain only non-empty strings.`);
+    }
+    if (item.trim() !== item) {
+      throw new Error(
+        `[evjs] ${source} item "${item}" must not contain leading or trailing whitespace.`,
+      );
+    }
+  }
+}
+
+function assertRenderMode(value: unknown, source: string): void {
+  if (value === "csr" || value === "ssr" || value === "ssg") return;
+  throw new Error(`[evjs] ${source} must be "csr", "ssr", or "ssg".`);
+}
+
+function assertComponentModel(value: unknown, source: string): void {
+  if (value === "client" || value === "server" || value === "rsc") return;
+  throw new Error(`[evjs] ${source} must be "client", "server", or "rsc".`);
+}
+
+function assertHtmlRendering(value: unknown, source: string): void {
+  if (
+    value === "client" ||
+    value === "server" ||
+    value === "static" ||
+    value === "partial"
+  ) {
+    return;
+  }
+  throw new Error(
+    `[evjs] ${source} must be "client", "server", "static", or "partial".`,
+  );
+}
+
+function assertPrerenderMode(value: unknown, source: string): void {
+  if (value === "full" || value === "partial") return;
+  throw new Error(`[evjs] ${source} must be "full" or "partial".`);
+}
+
+function assertHydrationMode(value: unknown, source: string): void {
+  if (
+    value === "none" ||
+    value === "load" ||
+    value === "visible" ||
+    value === "idle"
+  ) {
+    return;
+  }
+  throw new Error(
+    `[evjs] ${source} must be "none", "load", "visible", or "idle".`,
+  );
+}
+
+function assertPprDeliveryMode(value: unknown, source: string): void {
+  if (value === "merge" || value === "stream") return;
+  throw new Error(`[evjs] ${source} must be "merge" or "stream".`);
+}
+
+function assertPprRegionCache(value: unknown, source: string): void {
+  if (value === "no-store") return;
+  if (!isRecord(value)) {
+    throw new Error(
+      `[evjs] ${source} must be "no-store" or an object with a positive integer revalidate.`,
+    );
+  }
+  const keys = Object.keys(value);
+  if (keys.length !== 1 || keys[0] !== "revalidate") {
+    throw new Error(`[evjs] ${source} can only contain revalidate.`);
+  }
+  if (
+    typeof value.revalidate !== "number" ||
+    !Number.isInteger(value.revalidate) ||
+    value.revalidate <= 0
+  ) {
+    throw new Error(
+      `[evjs] ${source}.revalidate must be a positive integer number of seconds.`,
+    );
+  }
+}
+
+function assertServerRendererKind(value: unknown, source: string): void {
+  if (
+    value === "page-server" ||
+    value === "ppr-shell" ||
+    value === "ppr-region" ||
+    value === "rsc-page"
+  ) {
+    return;
+  }
+  throw new Error(
+    `[evjs] ${source} must be "page-server", "ppr-shell", "ppr-region", or "rsc-page".`,
+  );
+}
+
+function assertRuntimeBuildIdentifierKey(key: string, source: string): void {
+  if (!isBuildIdentifier(key)) {
+    throw new Error(
+      `[evjs] ${source} key "${key}" must contain only ${BUILD_IDENTIFIER_DESCRIPTION}.`,
+    );
+  }
+  if (key.trim() !== key) {
+    throw new Error(
+      `[evjs] ${source} key "${key}" must not contain leading or trailing whitespace.`,
+    );
+  }
+}
+
+function assertRuntimePathname(
+  value: unknown,
+  source: string,
+  required = false,
+): void {
+  if (value === undefined) {
+    if (required) {
+      throw new Error(`[evjs] ${source} must be a non-empty pathname.`);
+    }
+    return;
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`[evjs] ${source} must be a non-empty pathname.`);
+  }
+  if (value.trim() !== value) {
+    throw new Error(
+      `[evjs] ${source} must not contain leading or trailing whitespace.`,
+    );
+  }
+
+  const error = getPathPatternValidationError(value);
+  if (error) {
+    throw new Error(`[evjs] ${source} ${formatRuntimePathnameError(error)}`);
+  }
+}
+
+function assertRuntimeTransportBaseUrl(value: unknown, source: string): void {
+  if (value === undefined) return;
+
+  const error = getUrlStringValidationError(value, {
+    baseUrl: "http://evjs.local/",
+  });
+  if (error) {
+    throw new Error(
+      `[evjs] ${source} ${formatRuntimeTransportBaseUrlError(error)}`,
+    );
+  }
+}
+
+function formatRuntimeTransportBaseUrlError(
+  error: UrlStringValidationError,
+): string {
+  switch (error) {
+    case "empty":
+      return "must be a non-empty URL string.";
+    case "whitespace":
+      return "must not contain leading or trailing whitespace.";
+    case "invalid-url":
+      return "must be a valid URL string.";
+  }
+}
+
+function formatRuntimePathnameError(error: PathPatternValidationError): string {
+  switch (error) {
+    case "empty":
+      return "must be a non-empty pathname.";
+    case "missing-leading-slash":
+      return 'must start with "/".';
+    case "whitespace":
+      return "must not contain whitespace.";
+    case "query-or-hash":
+      return "must not include a query string or hash.";
+  }
+}
+
 export async function handleFrameworkRenderRequest(
   options: FrameworkServerOptions,
   request: Request,
@@ -372,15 +1089,15 @@ export async function handleFrameworkRenderRequest(
   }
 
   const url = new URL(request.url);
-  const route = matchRoute(options.manifest.routes, url.pathname);
-  const pageId = route?.pageId ?? inferPageId(options.manifest, url.pathname);
-  const page = pageId ? options.manifest.pages[pageId] : undefined;
+  const route = matchRoute(options.runtime.routes, url.pathname);
+  const pageId = route?.pageId ?? inferPageId(options.runtime, url.pathname);
+  const page = pageId ? options.runtime.pages[pageId] : undefined;
 
   if (!route && !page) return undefined;
 
   const ctx: ServerRenderContext = {
     request,
-    manifest: options.manifest,
+    runtime: options.runtime,
     pageUrl: url.toString(),
     route,
     page,
@@ -470,9 +1187,9 @@ export async function handlePprRegionRequest(
   const url = new URL(request.url);
   let match: PprRegionMatch | undefined;
   try {
-    match = matchPprRegion(options.manifest, url.pathname);
+    match = matchPprRegion(options.runtime, url.pathname);
     if (match) {
-      match = withPprRegionPageUrl(options.manifest, match, url);
+      match = withPprRegionPageUrl(options.runtime, match, url);
     }
   } catch (error) {
     if (error instanceof PprRegionRequestError) {
@@ -485,7 +1202,7 @@ export async function handlePprRegionRequest(
   }
   if (!match) return undefined;
 
-  const page = options.manifest.pages[match.pageId];
+  const page = options.runtime.pages[match.pageId];
   if (!page?.ppr) return undefined;
   const region = page.ppr?.regions[match.regionId];
   if (!region) return undefined;
@@ -509,7 +1226,7 @@ async function renderPprPageResponse(
   coordinator: ServerRenderCoordinator,
 ): Promise<Response> {
   const pageId = ctx.pageId;
-  const page = pageId ? options.manifest.pages[pageId] : undefined;
+  const page = pageId ? options.runtime.pages[pageId] : undefined;
   if (!pageId || !page?.ppr) {
     return request.method === "HEAD" ? withoutResponseBody(response) : response;
   }
@@ -553,7 +1270,7 @@ async function renderPprMergedPageResponse(
   response: Response,
   coordinator: ServerRenderCoordinator,
 ): Promise<Response> {
-  const page = options.manifest.pages[pageId];
+  const page = options.runtime.pages[pageId];
   if (!page?.ppr) return response;
 
   let html = await response.text();
@@ -605,7 +1322,7 @@ async function renderPprStreamingPageResponse(
   response: Response,
   coordinator: ServerRenderCoordinator,
 ): Promise<Response> {
-  const page = options.manifest.pages[pageId];
+  const page = options.runtime.pages[pageId];
   if (!page?.ppr) return response;
 
   const html = await response.text();
@@ -663,7 +1380,7 @@ async function renderPprRegionResponse(
   match: PprRegionMatch,
   coordinator: ServerRenderCoordinator,
 ): Promise<Response | undefined> {
-  const page = options.manifest.pages[match.pageId];
+  const page = options.runtime.pages[match.pageId];
   if (!page?.ppr) return undefined;
   const region = page.ppr?.regions[match.regionId];
   if (!region) return undefined;
@@ -726,11 +1443,11 @@ async function renderFreshPprRegionResponse(
   match: PprRegionMatch,
   coordinator: ServerRenderCoordinator,
 ): Promise<Response | undefined> {
-  const page = options.manifest.pages[match.pageId];
+  const page = options.runtime.pages[match.pageId];
   if (!page?.ppr) return undefined;
   const ctx: ServerRenderContext = {
     request,
-    manifest: options.manifest,
+    runtime: options.runtime,
     pageUrl: match.pageUrl,
     page,
     pageId: match.pageId,
@@ -767,8 +1484,7 @@ export async function handleRscFlightRequest(
 ): Promise<Response | undefined> {
   if (!options.rsc) return undefined;
 
-  const rscPath =
-    options.manifest.rsc?.endpoint ?? options.manifest.runtime.server?.rsc;
+  const rscPath = options.runtime.runtime.server.rsc;
   if (!rscPath) return undefined;
 
   const url = new URL(request.url);
@@ -788,8 +1504,8 @@ export async function handleRscFlightRequest(
   try {
     ctx = {
       request,
-      manifest: options.manifest,
-      ...createRscFlightPageContext(options.manifest, url),
+      runtime: options.runtime,
+      ...createRscFlightPageContext(options.runtime, url),
     };
   } catch (error) {
     if (error instanceof RscFlightRequestError) {
@@ -853,17 +1569,17 @@ export async function handleRscFlightRequest(
 }
 
 function createRscFlightPageContext(
-  manifest: BuildOutput,
+  runtime: FrameworkRuntime,
   url: URL,
 ): Pick<
   RscFlightContext,
   "pageUrl" | "pageId" | "page" | "rscPage" | "renderer"
 > {
   const pageId = url.searchParams.get("page") ?? undefined;
-  const page = pageId ? manifest.pages[pageId] : undefined;
-  const rscPage = pageId ? manifest.rsc?.pages?.[pageId] : undefined;
+  const page = pageId ? runtime.pages[pageId] : undefined;
+  const rscPage = pageId ? runtime.rsc?.pages?.[pageId] : undefined;
   const renderer = rscPage?.renderer
-    ? manifest.server?.renderers?.[rscPage.renderer]
+    ? runtime.server?.renderers?.[rscPage.renderer]
     : undefined;
   const pageUrl = resolveRscFlightPageUrl(url);
 
@@ -887,20 +1603,20 @@ function resolveRscFlightPageUrl(url: URL): string | undefined {
 }
 
 function withPprRegionPageUrl(
-  manifest: BuildOutput,
+  runtime: FrameworkRuntime,
   match: PprRegionMatch,
   url: URL,
 ): PprRegionMatch {
-  const page = manifest.pages[match.pageId];
+  const page = runtime.pages[match.pageId];
   const explicitPageUrl = resolvePprRegionPageUrl(url);
   const pageUrl =
-    explicitPageUrl ?? inferStaticPprRegionPageUrl(manifest, match, page, url);
-  if (!pageUrl && shouldRequirePprRegionPageUrl(manifest, match, page)) {
+    explicitPageUrl ?? inferStaticPprRegionPageUrl(runtime, match, page, url);
+  if (!pageUrl && shouldRequirePprRegionPageUrl(runtime, match, page)) {
     throw new PprRegionRequestError(
       `[evjs] PPR region request url is required for page "${match.pageId}" because its route cannot be inferred from the direct region endpoint.`,
     );
   }
-  if (pageUrl && !pageUrlMatchesPage(manifest, match.pageId, page, pageUrl)) {
+  if (pageUrl && !pageUrlMatchesPage(runtime, match.pageId, page, pageUrl)) {
     throw new PprRegionRequestError(
       `[evjs] PPR region request url does not match page "${match.pageId}".`,
     );
@@ -909,34 +1625,34 @@ function withPprRegionPageUrl(
 }
 
 function inferStaticPprRegionPageUrl(
-  manifest: BuildOutput,
+  runtime: FrameworkRuntime,
   match: PprRegionMatch,
-  page: PageOutput | undefined,
+  page: FrameworkPageRuntime | undefined,
   requestUrl: URL,
 ): string | undefined {
-  const paths = getPprRegionPagePaths(manifest, match.pageId, page);
+  const paths = getPprRegionPagePaths(runtime, match.pageId, page);
   return paths.length === 1 && isStaticPagePath(paths[0])
     ? new URL(paths[0], requestUrl).toString()
     : undefined;
 }
 
 function shouldRequirePprRegionPageUrl(
-  manifest: BuildOutput,
+  runtime: FrameworkRuntime,
   match: PprRegionMatch,
-  page: PageOutput | undefined,
+  page: FrameworkPageRuntime | undefined,
 ): boolean {
-  const paths = getPprRegionPagePaths(manifest, match.pageId, page);
+  const paths = getPprRegionPagePaths(runtime, match.pageId, page);
   return (
     paths.length > 0 && !(paths.length === 1 && isStaticPagePath(paths[0]))
   );
 }
 
 function getPprRegionPagePaths(
-  manifest: BuildOutput,
+  runtime: FrameworkRuntime,
   pageId: string,
-  page: PageOutput | undefined,
+  page: FrameworkPageRuntime | undefined,
 ): string[] {
-  const routePaths = manifest.routes
+  const routePaths = runtime.routes
     .filter((route) => route.pageId === pageId)
     .map((route) => route.path);
   return routePaths.length > 0 ? routePaths : page?.path ? [page.path] : [];
@@ -1000,7 +1716,7 @@ function validateRscFlightContext(ctx: RscFlightContext): Response | undefined {
 
   if (!ctx.page) {
     return textResponse(
-      `[evjs] RSC page "${ctx.pageId}" is not in the manifest.`,
+      `[evjs] RSC page "${ctx.pageId}" is not in the runtime.`,
       404,
     );
   }
@@ -1021,7 +1737,7 @@ function validateRscFlightContext(ctx: RscFlightContext): Response | undefined {
 
   if (!ctx.rscPage) {
     return textResponse(
-      `[evjs] RSC page "${ctx.pageId}" has no RSC manifest metadata.`,
+      `[evjs] RSC page "${ctx.pageId}" has no RSC runtime metadata.`,
       501,
     );
   }
@@ -1038,17 +1754,17 @@ function validateRscFlightContext(ctx: RscFlightContext): Response | undefined {
 
 function rscFlightPageUrlMatchesPage(ctx: RscFlightContext): boolean {
   if (!ctx.pageUrl || !ctx.pageId) return true;
-  return pageUrlMatchesPage(ctx.manifest, ctx.pageId, ctx.page, ctx.pageUrl);
+  return pageUrlMatchesPage(ctx.runtime, ctx.pageId, ctx.page, ctx.pageUrl);
 }
 
 function pageUrlMatchesPage(
-  manifest: BuildOutput,
+  runtime: FrameworkRuntime,
   pageId: string,
-  page: PageOutput | undefined,
+  page: FrameworkPageRuntime | undefined,
   pageUrl: string,
 ): boolean {
   const pathname = normalizeRoutePathname(new URL(pageUrl).pathname);
-  const pageRoutes = manifest.routes.filter((route) => route.pageId === pageId);
+  const pageRoutes = runtime.routes.filter((route) => route.pageId === pageId);
 
   if (pageRoutes.length > 0) {
     return pageRoutes.some((route) =>
@@ -1125,11 +1841,11 @@ function withoutResponseBody(response: Response): Response {
   });
 }
 
-function createRendererRegistryFromManifest(
-  manifest: BuildOutput,
-  loadModule: ManifestServerModuleLoader,
+function createRendererRegistryFromRuntime(
+  runtime: FrameworkRuntime,
+  loadModule: FrameworkServerModuleLoader,
 ): ServerRendererRegistry {
-  const renderers = manifest.server?.renderers ?? {};
+  const renderers = runtime.server?.renderers ?? {};
   return Object.fromEntries(
     Object.entries(renderers).map(([name, renderer]) => {
       const asset = renderer.assets.js[0];
@@ -1320,39 +2036,39 @@ function isServerRenderContext(value: unknown): value is ServerRenderContext {
   return (
     isRecord(value) &&
     value.request instanceof Request &&
-    isRecord(value.manifest)
+    isRecord(value.runtime)
   );
 }
 
 function matchRoute(
-  routes: RouteOutput[],
+  routes: FrameworkRouteRuntime[],
   pathname: string,
-): RouteOutput | undefined {
+): FrameworkRouteRuntime | undefined {
   return findBestPageRoute(routes, pathname);
 }
 
 function inferPageId(
-  manifest: BuildOutput,
+  runtime: FrameworkRuntime,
   pathname: string,
 ): string | undefined {
   const normalized = normalizeRoutePathname(pathname);
   const directId = normalized === "/" ? "index" : normalized.slice(1);
   const withoutHtml = directId.replace(/\.html$/, "");
 
-  if (manifest.pages[withoutHtml]) return withoutHtml;
-  if (manifest.pages[directId]) return directId;
+  if (runtime.pages[withoutHtml]) return withoutHtml;
+  if (runtime.pages[directId]) return directId;
 
   const dotted = withoutHtml.replaceAll("/", ".");
-  return manifest.pages[dotted] ? dotted : undefined;
+  return runtime.pages[dotted] ? dotted : undefined;
 }
 
 function matchPprRegion(
-  manifest: BuildOutput,
+  runtime: FrameworkRuntime,
   pathname: string,
 ): PprRegionMatch | undefined {
   const endpoint = normalizeRoutePathname(
-    manifest.runtime.server?.ppr ??
-      joinPath(manifest.runtime.server?.basePath ?? "/__evjs", "ppr"),
+    runtime.runtime.server?.ppr ??
+      joinPath(runtime.runtime.server?.basePath ?? "/__evjs", "ppr"),
   );
   const normalized = normalizeRoutePathname(pathname);
   if (normalized === endpoint || !normalized.startsWith(`${endpoint}/`)) {
@@ -1629,7 +2345,7 @@ function waitUntilPprRegionRevalidation(promise: Promise<unknown>): void {
 
 function applyDefaultPprPageCacheHeaders(
   headers: Headers,
-  page: PageOutput,
+  page: FrameworkPageRuntime,
   options: FrameworkServerOptions,
 ): void {
   if (headers.has("Cache-Control")) return;
@@ -1641,7 +2357,7 @@ function applyDefaultPprPageCacheHeaders(
 }
 
 function getPprPageCacheControl(
-  page: PageOutput,
+  page: FrameworkPageRuntime,
   options: FrameworkServerOptions,
 ): string | undefined {
   if (!page.ppr) return undefined;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -27,9 +27,10 @@ export {
   waitUntil,
 } from "./context.js";
 export type {
+  FrameworkRenderCoordinatorOptions,
+  FrameworkRuntime,
+  FrameworkServerModuleLoader,
   FrameworkServerOptions,
-  ManifestRenderCoordinatorOptions,
-  ManifestServerModuleLoader,
   ModuleRenderCoordinatorOptions,
   PprRegionCache,
   PprRegionCacheEntry,
@@ -46,7 +47,7 @@ export type {
   ServerRenderResult,
 } from "./framework.js";
 export {
-  createManifestRenderCoordinator,
+  createFrameworkRenderCoordinator,
   createModuleRenderCoordinator,
   handleFrameworkRenderRequest,
   handlePprRegionRequest,

--- a/packages/server/src/react-renderer.ts
+++ b/packages/server/src/react-renderer.ts
@@ -7,16 +7,17 @@ import {
   matchPageRouteParams,
   parsePageSearch,
 } from "@evjs/shared";
-import type {
-  AssetGroup,
-  BuildOutput,
-  PageOutput,
-  RouteOutput,
-  ServerRendererOutput,
-} from "@evjs/shared/manifest";
 import { type ComponentType, createElement, type ReactNode } from "react";
 import * as ReactDomServer from "react-dom/server";
-import type { RscCoordinator, RscFlightContext } from "./framework.js";
+import type {
+  FrameworkAssetGroup,
+  FrameworkPageRuntime,
+  FrameworkRouteRuntime,
+  FrameworkRuntime,
+  FrameworkServerRenderer,
+  RscCoordinator,
+  RscFlightContext,
+} from "./framework.js";
 import { textResponse } from "./responses.js";
 import {
   formatUnknownError,
@@ -39,10 +40,10 @@ export interface PageProviderProps<
 
 export interface ReactServerRenderContext {
   request: Request;
-  manifest: BuildOutput;
+  runtime: FrameworkRuntime;
   pageUrl?: string;
-  route?: RouteOutput;
-  page?: PageOutput;
+  route?: FrameworkRouteRuntime;
+  page?: FrameworkPageRuntime;
   pageId?: string;
   regionId?: string;
 }
@@ -71,7 +72,7 @@ export interface ReactServerRenderAdapterOptions {
 export interface ReactRscFlightAdapterOptions {
   loadModule?: (
     asset: string,
-    renderer: ServerRendererOutput,
+    renderer: FrameworkServerRenderer,
   ) => Promise<ReactServerRendererModule>;
   createProps?(
     ctx: RscFlightContext,
@@ -89,10 +90,8 @@ export interface ReactRscDebugPayload {
   pageId?: string;
   renderer?: string;
   html?: string;
-  assets: AssetGroup;
-  clientReferences?: Record<string, unknown>;
-  serverReferences?: Record<string, unknown>;
-  pages?: NonNullable<BuildOutput["rsc"]>["pages"];
+  assets: FrameworkAssetGroup;
+  pages?: NonNullable<FrameworkRuntime["rsc"]>["pages"];
 }
 
 export function createReactServerRenderAdapter(
@@ -192,7 +191,7 @@ export function createReactRscFlightAdapter(
   return {
     match(ctx) {
       return Boolean(
-        getRscEndpoint(ctx.manifest) &&
+        getRscEndpoint(ctx.runtime) &&
           ctx.pageId &&
           ctx.page?.componentModel === "rsc" &&
           ctx.rscPage &&
@@ -391,21 +390,19 @@ async function renderDefaultRscDebugPayload(
   return {
     version: 1,
     type: "evjs.rsc",
-    buildId: ctx.manifest.buildId,
-    endpoint: getRscEndpoint(ctx.manifest),
+    buildId: ctx.runtime.buildId,
+    endpoint: getRscEndpoint(ctx.runtime),
     pageId: ctx.pageId,
     renderer: rendererName,
     html,
     assets: ctx.rscPage?.assets ?? emptyAssets(),
-    clientReferences: ctx.manifest.rsc?.clientReferences,
-    serverReferences: ctx.manifest.rsc?.serverReferences,
-    pages: ctx.manifest.rsc?.pages ?? {},
+    pages: ctx.runtime.rsc?.pages ?? {},
   };
 }
 
 async function renderRscRendererModule(
   ctx: RscFlightContext,
-  renderer: ServerRendererOutput,
+  renderer: FrameworkServerRenderer,
   options: ReactRscFlightAdapterOptions,
 ): Promise<string | Response | undefined> {
   const asset = renderer.assets.js[0];
@@ -472,20 +469,20 @@ function isReactServerRenderResult(
 
 function defaultRscProps(ctx: RscFlightContext): Record<string, unknown> {
   return {
-    manifest: {
-      buildId: ctx.manifest.buildId,
+    runtime: {
+      buildId: ctx.runtime.buildId,
     },
     pageId: ctx.pageId,
     route: findRouteForPage(
-      ctx.manifest,
+      ctx.runtime,
       ctx.pageId,
       readUrlPathname(ctx.pageUrl),
     ),
   };
 }
 
-function getRscEndpoint(manifest: BuildOutput): string | undefined {
-  return manifest.rsc?.endpoint ?? manifest.runtime.server?.rsc;
+function getRscEndpoint(runtime: FrameworkRuntime): string | undefined {
+  return runtime.runtime.server.rsc;
 }
 
 async function resolveRscRenderProps(
@@ -501,8 +498,8 @@ async function resolveRscRenderProps(
 
 function defaultProps(ctx: ReactServerRenderContext): Record<string, unknown> {
   return {
-    manifest: {
-      buildId: ctx.manifest.buildId,
+    runtime: {
+      buildId: ctx.runtime.buildId,
     },
     route: ctx.route
       ? {
@@ -565,13 +562,13 @@ function assertHeadersInit(
 }
 
 function findRouteForPage(
-  manifest: BuildOutput,
+  runtime: FrameworkRuntime,
   pageId: string | undefined,
   pathname?: string,
 ): { id: string; path: string } | undefined {
   if (!pageId) return undefined;
 
-  const pageRoutes = manifest.routes.filter(
+  const pageRoutes = runtime.routes.filter(
     (candidate) => candidate.pageId === pageId,
   );
   const route = pathname
@@ -587,9 +584,9 @@ function findRouteForPage(
 
 interface PageElementContext {
   request: Request;
-  manifest: BuildOutput;
+  runtime: FrameworkRuntime;
   pageUrl?: string;
-  route?: RouteOutput;
+  route?: FrameworkRouteRuntime;
   pageId?: string;
 }
 
@@ -655,7 +652,7 @@ function resolveRouteContext(
   return (
     ctx.route ??
     readRouteContext(props.route) ??
-    findRouteForPage(ctx.manifest, ctx.pageId, readPageElementPathname(ctx))
+    findRouteForPage(ctx.runtime, ctx.pageId, readPageElementPathname(ctx))
   );
 }
 
@@ -711,11 +708,11 @@ function renderDefaultDocument(
 
   return [
     "<!doctype html>",
-    `<html data-evjs-kind="page" data-evjs-id="${escapeHtmlAttr(ctx.pageId ?? "")}" data-evjs-build="${escapeHtmlAttr(ctx.manifest.buildId)}">`,
+    `<html data-evjs-kind="page" data-evjs-id="${escapeHtmlAttr(ctx.pageId ?? "")}" data-evjs-build="${escapeHtmlAttr(ctx.runtime.buildId)}">`,
     "<head>",
     ...assets.css.map(
       (asset) =>
-        `<link rel="stylesheet" href="${escapeHtmlAttr(assetHref(ctx.manifest, asset))}">`,
+        `<link rel="stylesheet" href="${escapeHtmlAttr(assetHref(ctx.runtime, asset))}">`,
     ),
     "</head>",
     "<body>",
@@ -728,7 +725,7 @@ function renderDefaultDocument(
       : []),
     ...assets.js.map(
       (asset) =>
-        `<script defer src="${escapeHtmlAttr(assetHref(ctx.manifest, asset))}"></script>`,
+        `<script defer src="${escapeHtmlAttr(assetHref(ctx.runtime, asset))}"></script>`,
     ),
     "</body>",
     "</html>",
@@ -748,26 +745,26 @@ function createRscBootstrap(
       pageId: string;
       endpoint: string;
       basePath?: string;
-      publicPath: BuildOutput["publicPath"];
+      publicPath: FrameworkRuntime["publicPath"];
       mount: string;
       page: {
-        assets: AssetGroup;
+        assets: FrameworkAssetGroup;
         routeId?: string;
       };
     }
   | undefined {
   if (ctx.page?.componentModel !== "rsc" || !ctx.pageId) return undefined;
 
-  const endpoint = getRscEndpoint(ctx.manifest);
+  const endpoint = getRscEndpoint(ctx.runtime);
   if (!endpoint) return undefined;
 
   return {
     version: 1,
-    buildId: ctx.manifest.buildId,
+    buildId: ctx.runtime.buildId,
     pageId: ctx.pageId,
     endpoint,
-    basePath: ctx.manifest.runtime.server?.basePath,
-    publicPath: ctx.manifest.publicPath,
+    basePath: ctx.runtime.runtime.server?.basePath,
+    publicPath: ctx.runtime.publicPath,
     mount:
       mount.attribute === "id"
         ? `#${mount.value}`
@@ -813,8 +810,8 @@ function serializePageProps(props: Record<string, unknown>): string {
   }
 }
 
-function assetHref(manifest: BuildOutput, asset: string): string {
-  const publicPath = manifest.publicPath;
+function assetHref(runtime: FrameworkRuntime, asset: string): string {
+  const publicPath = runtime.publicPath;
   if (publicPath === "auto") {
     return /^(?:https?:)?\/\//.test(asset) || asset.startsWith("/")
       ? asset
@@ -825,7 +822,7 @@ function assetHref(manifest: BuildOutput, asset: string): string {
   return `${base}${asset}`;
 }
 
-function emptyAssets(): AssetGroup {
+function emptyAssets(): FrameworkAssetGroup {
   return { js: [], css: [] };
 }
 

--- a/packages/server/src/react.ts
+++ b/packages/server/src/react.ts
@@ -1,12 +1,10 @@
 import {
-  assertFrameworkManifestShape,
-  type BuildOutput,
-  type ServerRendererOutput,
-} from "@evjs/shared/manifest";
-import {
-  createManifestRenderCoordinator,
+  assertFrameworkRuntime,
+  createFrameworkRenderCoordinator,
+  type FrameworkRuntime,
+  type FrameworkServerModuleLoader,
   type FrameworkServerOptions,
-  type ManifestServerModuleLoader,
+  type FrameworkServerRenderer,
   type ServerModuleRenderHandler,
   type ServerRenderCoordinator,
   type ServerRendererModule,
@@ -33,27 +31,27 @@ export {
 } from "./react-renderer.js";
 
 declare global {
-  var __EVJS_MANIFEST__: BuildOutput | undefined;
+  var __EVJS_FRAMEWORK_RUNTIME__: FrameworkRuntime | undefined;
   var __EVJS_DEV_PAGE_RENDER_PROXY_HEADER__: string | undefined;
   var __EVJS_SERVER_MODULE_LOADER__:
     | ((
         asset: string,
-        renderer: ServerRendererOutput,
+        renderer: FrameworkServerRenderer,
       ) => Promise<ServerRendererModule>)
     | undefined;
 }
 
 export interface ReactFrameworkServerOptions {
   /**
-   * Framework manifest to serve. Defaults to the manifest injected by the ev
+   * Framework runtime metadata. Defaults to the runtime injected by the ev
    * dev/build runtime bootstrap.
    */
-  manifest?: BuildOutput;
+  runtime?: FrameworkRuntime;
   /**
    * Server module loader for renderer assets. Defaults to the loader injected by
    * the ev dev/build runtime bootstrap.
    */
-  loadModule?: ManifestServerModuleLoader;
+  loadModule?: FrameworkServerModuleLoader;
   /**
    * Override the module renderer. By default, evjs renders default-exported
    * React components with the built-in server React renderer.
@@ -64,7 +62,7 @@ export interface ReactFrameworkServerOptions {
    */
   react?: ReactServerRenderAdapterOptions;
   /**
-   * Options passed to the default RSC Flight adapter when the manifest declares
+   * Options passed to the default RSC Flight adapter when the runtime declares
    * an RSC endpoint and no custom `rscCoordinator` is provided.
    */
   rsc?: ReactRscFlightAdapterOptions;
@@ -84,20 +82,19 @@ export function createReactFrameworkServer(
 ): FrameworkServerOptions | undefined {
   assertReactFrameworkServerOptions(options);
 
-  const manifest = options.manifest ?? globalThis.__EVJS_MANIFEST__;
-  if (!manifest) return undefined;
-  assertReactFrameworkManifest(manifest);
+  const runtime = options.runtime ?? globalThis.__EVJS_FRAMEWORK_RUNTIME__;
+  if (!runtime) return undefined;
 
-  const hasRenderers = Boolean(manifest.server?.renderers);
+  const hasRenderers = Boolean(runtime.server.renderers);
   const rsc =
-    options.rscCoordinator ?? createDefaultRscCoordinator(manifest, options);
+    options.rscCoordinator ?? createDefaultRscCoordinator(runtime, options);
   if (!hasRenderers && !rsc) return undefined;
 
   return {
-    manifest,
+    runtime,
     render: hasRenderers
-      ? createManifestRenderCoordinator({
-          manifest,
+      ? createFrameworkRenderCoordinator({
+          runtime,
           loadModule: options.loadModule ?? loadModuleFromRuntimeGlobal,
           renderModule:
             options.renderModule ??
@@ -119,7 +116,12 @@ function assertReactFrameworkServerOptions(
     );
   }
 
-  assertOptionalObject(value.manifest, "createReactFrameworkServer() manifest");
+  if (value.runtime !== undefined) {
+    assertFrameworkRuntime(
+      value.runtime,
+      "createReactFrameworkServer() runtime",
+    );
+  }
   assertOptionalFunction(
     value.loadModule,
     "createReactFrameworkServer() loadModule",
@@ -144,12 +146,6 @@ function assertOptionalObject(value: unknown, source: string): void {
   if (value !== undefined && !isRecord(value)) {
     throw new Error(`[evjs] ${source} must be an object.`);
   }
-}
-
-function assertReactFrameworkManifest(
-  value: unknown,
-): asserts value is BuildOutput {
-  assertFrameworkManifestShape(value, "createReactFrameworkServer() manifest");
 }
 
 function assertOptionalFunction(value: unknown, source: string): void {
@@ -184,11 +180,10 @@ function createDevPageRenderGuard():
 }
 
 function createDefaultRscCoordinator(
-  manifest: BuildOutput,
+  runtime: FrameworkRuntime,
   options: ReactFrameworkServerOptions,
 ): FrameworkServerOptions["rsc"] | undefined {
-  if (!manifest.runtime.server?.rsc && !manifest.rsc?.endpoint)
-    return undefined;
+  if (!runtime.runtime.server.rsc) return undefined;
   return createReactRscFlightAdapter({
     loadModule: options.loadModule ?? loadModuleFromRuntimeGlobal,
     ...options.rsc,
@@ -197,7 +192,7 @@ function createDefaultRscCoordinator(
 
 async function loadModuleFromRuntimeGlobal(
   asset: string,
-  renderer: ServerRendererOutput,
+  renderer: FrameworkServerRenderer,
 ): Promise<ServerRendererModule> {
   const loader = globalThis.__EVJS_SERVER_MODULE_LOADER__;
   if (loader) return loader(asset, renderer);

--- a/packages/server/tests/app.test.ts
+++ b/packages/server/tests/app.test.ts
@@ -1,13 +1,13 @@
 import { ServerError } from "@evjs/shared";
-import type { BuildOutput } from "@evjs/shared/manifest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../src/app.js";
 import type {
+  FrameworkRuntime,
   PprRegionCacheEntry,
   ServerRenderContext,
 } from "../src/framework.js";
 import {
-  createManifestRenderCoordinator,
+  createFrameworkRenderCoordinator,
   createModuleRenderCoordinator,
 } from "../src/framework.js";
 import {
@@ -41,7 +41,7 @@ describe("createApp", () => {
     expect(await res.json()).toEqual({ result: "ok" });
   });
 
-  it("uses the framework manifest server function endpoint when available", async () => {
+  it("uses the framework runtime server function endpoint when available", async () => {
     vi.stubGlobal("__EVJS_FUNCTION_ENDPOINT__", "/stale/rpc");
     registerServerReference(async () => "ok", "fn1");
     const manifest = createManifest();
@@ -52,7 +52,7 @@ describe("createApp", () => {
 
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
       },
     });
     const stale = await app.request("/stale/rpc", {
@@ -320,7 +320,7 @@ describe("createApp", () => {
     });
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render() {
           return "<h1>framework fallback</h1>";
         },
@@ -361,116 +361,33 @@ describe("createApp", () => {
     expect(() => createApp({ framework: [] as never })).toThrow(
       "[evjs] createApp() framework must be a framework server object.",
     );
-    expect(() => createApp({ framework: { manifest: null } as never })).toThrow(
-      "[evjs] createApp() framework.manifest must be a framework manifest object.",
+    expect(() => createApp({ framework: { runtime: null } as never })).toThrow(
+      "[evjs] createApp() framework.runtime must be a framework runtime object.",
     );
     expect(() =>
       createApp({
-        framework: { manifest: { ...manifest, version: 2 } } as never,
+        framework: { runtime: { ...manifest, version: 2 } } as never,
       }),
-    ).toThrow("[evjs] createApp() framework.manifest.version must be 1.");
+    ).toThrow("[evjs] createApp() framework.runtime.version must be 1.");
     expect(() =>
       createApp({
-        framework: { manifest: { ...manifest, buildId: "build.1" } } as never,
+        framework: { runtime: { ...manifest, buildId: "build.1" } } as never,
       }),
     ).toThrow(
-      "[evjs] createApp() framework.manifest.buildId must contain only letters, numbers, underscores, or hyphens.",
+      "[evjs] createApp() framework.runtime.buildId must contain only letters, numbers, underscores, or hyphens.",
     );
     expect(() =>
       createApp({
-        framework: {
-          manifest: {
-            ...manifest,
-            paths: { rootDir: "dist", publicDir: "" },
-          },
-        } as never,
+        framework: { runtime: { ...manifest, runtime: null } } as never,
       }),
     ).toThrow(
-      "[evjs] createApp() framework.manifest.paths.publicDir must be a non-empty string.",
+      "[evjs] createApp() framework.runtime.runtime must be an object.",
     );
     expect(() =>
       createApp({
-        framework: { manifest: { ...manifest, runtime: null } } as never,
+        framework: { runtime: { ...manifest, pages: null } } as never,
       }),
-    ).toThrow(
-      "[evjs] createApp() framework.manifest.runtime must be an object.",
-    );
-    expect(() =>
-      createApp({
-        framework: { manifest: { ...manifest, assets: [] } } as never,
-      }),
-    ).toThrow(
-      "[evjs] createApp() framework.manifest.assets must be an object.",
-    );
-    expect(() =>
-      createApp({
-        framework: {
-          manifest: {
-            ...manifest,
-            assets: { main: { js: [" main.js "], css: [] } },
-          },
-        } as never,
-      }),
-    ).toThrow(
-      '[evjs] createApp() framework.manifest.assets.main.js item " main.js " must not contain leading or trailing whitespace.',
-    );
-    expect(() =>
-      createApp({
-        framework: { manifest: { ...manifest, apps: [] } } as never,
-      }),
-    ).toThrow("[evjs] createApp() framework.manifest.apps must be an object.");
-    expect(() =>
-      createApp({
-        framework: {
-          manifest: {
-            ...manifest,
-            apps: {
-              default: { assets: { js: "main.js", css: [] } },
-            },
-          },
-        } as never,
-      }),
-    ).toThrow(
-      "[evjs] createApp() framework.manifest.apps.default.assets.js must be an array.",
-    );
-    expect(() =>
-      createApp({
-        framework: {
-          manifest: {
-            ...manifest,
-            apps: {
-              default: {
-                assets: { js: [], css: [] },
-                module: { type: "lifecycle", href: "" },
-              },
-            },
-          },
-        } as never,
-      }),
-    ).toThrow(
-      "[evjs] createApp() framework.manifest.apps.default.module.href must be a non-empty string.",
-    );
-    expect(() =>
-      createApp({
-        framework: {
-          manifest: {
-            ...manifest,
-            server: {
-              assets: { js: [" server.js "], css: [] },
-              functions: {},
-              routes: [],
-            },
-          },
-        } as never,
-      }),
-    ).toThrow(
-      '[evjs] createApp() framework.manifest.server.assets.js item " server.js " must not contain leading or trailing whitespace.',
-    );
-    expect(() =>
-      createApp({
-        framework: { manifest: { ...manifest, pages: null } } as never,
-      }),
-    ).toThrow("[evjs] createApp() framework.manifest.pages must be an object.");
+    ).toThrow("[evjs] createApp() framework.runtime.pages must be an object.");
 
     const renderingManifest = createManifest();
     renderingManifest.pages.dashboard.rendering = {
@@ -480,9 +397,9 @@ describe("createApp", () => {
       hydrate: "load",
     } as never;
     expect(() =>
-      createApp({ framework: { manifest: renderingManifest } }),
+      createApp({ framework: { runtime: renderingManifest } }),
     ).toThrow(
-      "[evjs] createApp() framework.manifest.pages.dashboard.rendering.streaming must be a boolean.",
+      "[evjs] createApp() framework.runtime.pages.dashboard.rendering.streaming must be a boolean.",
     );
 
     const pprManifest = createManifest();
@@ -491,79 +408,79 @@ describe("createApp", () => {
       shell: { js: "dashboard-ppr-shell.js", css: [] } as never,
       regions: {},
     };
-    expect(() => createApp({ framework: { manifest: pprManifest } })).toThrow(
-      "[evjs] createApp() framework.manifest.pages.dashboard.ppr.shell.js must be an array.",
+    expect(() => createApp({ framework: { runtime: pprManifest } })).toThrow(
+      "[evjs] createApp() framework.runtime.pages.dashboard.ppr.shell.js must be an array.",
     );
 
     expect(() =>
       createApp({
-        framework: { manifest: { ...manifest, routes: {} } } as never,
+        framework: { runtime: { ...manifest, routes: {} } } as never,
       }),
-    ).toThrow("[evjs] createApp() framework.manifest.routes must be an array.");
+    ).toThrow("[evjs] createApp() framework.runtime.routes must be an array.");
     expect(() =>
       createApp({
         framework: {
-          manifest: {
+          runtime: {
             ...manifest,
             routes: [{ id: "dashboard", path: "dashboard" }],
           },
         } as never,
       }),
     ).toThrow(
-      '[evjs] createApp() framework.manifest.routes[0].path must start with "/".',
+      '[evjs] createApp() framework.runtime.routes[0].path must start with "/".',
     );
     expect(() =>
       createApp({
         framework: {
-          manifest: {
+          runtime: {
             ...manifest,
             routes: [{ id: "missing", path: "/missing", pageId: "missing" }],
           },
         } as never,
       }),
     ).toThrow(
-      '[evjs] createApp() framework.manifest.routes[0].pageId "missing" does not match any manifest.pages entry.',
+      '[evjs] createApp() framework.runtime.routes[0].pageId "missing" does not match any runtime.pages entry.',
     );
     expect(() =>
       createApp({
         framework: {
-          manifest: {
+          runtime: {
             ...manifest,
             runtime: { server: "runtime" },
           },
         } as never,
       }),
     ).toThrow(
-      "[evjs] createApp() framework.manifest.runtime.server must be an object.",
+      "[evjs] createApp() framework.runtime.runtime.server must be an object.",
     );
     expect(() =>
       createApp({
         framework: {
-          manifest: {
+          runtime: {
             ...manifest,
             runtime: { ...manifest.runtime, transport: [] },
           },
         } as never,
       }),
     ).toThrow(
-      "[evjs] createApp() framework.manifest.runtime.transport must be an object.",
+      "[evjs] createApp() framework.runtime.runtime.transport must be an object.",
     );
     expect(() =>
       createApp({
         framework: {
-          manifest: {
+          runtime: {
             ...manifest,
             runtime: { server: { fn: "/__evjs/fn" } },
           },
         } as never,
       }),
     ).toThrow(
-      "[evjs] createApp() framework.manifest.runtime.server.basePath must be a non-empty pathname.",
+      "[evjs] createApp() framework.runtime.runtime.server.basePath must be a non-empty pathname.",
     );
     expect(() =>
       createApp({
         framework: {
-          manifest: {
+          runtime: {
             ...manifest,
             runtime: {
               server: {
@@ -575,12 +492,12 @@ describe("createApp", () => {
         } as never,
       }),
     ).toThrow(
-      '[evjs] createApp() framework.manifest.runtime.server.fn must start with "/".',
+      '[evjs] createApp() framework.runtime.runtime.server.fn must start with "/".',
     );
     expect(() =>
       createApp({
         framework: {
-          manifest: {
+          runtime: {
             ...manifest,
             runtime: {
               server: {
@@ -593,12 +510,12 @@ describe("createApp", () => {
         } as never,
       }),
     ).toThrow(
-      "[evjs] createApp() framework.manifest.runtime.server.ppr must not contain leading or trailing whitespace.",
+      "[evjs] createApp() framework.runtime.runtime.server.ppr must not contain leading or trailing whitespace.",
     );
     expect(() =>
       createApp({
         framework: {
-          manifest: {
+          runtime: {
             ...manifest,
             runtime: {
               server: {
@@ -611,108 +528,47 @@ describe("createApp", () => {
         } as never,
       }),
     ).toThrow(
-      "[evjs] createApp() framework.manifest.runtime.server.rsc must not include a query string or hash.",
+      "[evjs] createApp() framework.runtime.runtime.server.rsc must not include a query string or hash.",
     );
     expect(() =>
       createApp({
         framework: {
-          manifest: {
+          runtime: {
             ...manifest,
             server: { renderers: [] },
           },
         } as never,
       }),
     ).toThrow(
-      "[evjs] createApp() framework.manifest.server.renderers must be an object.",
+      "[evjs] createApp() framework.runtime.server.renderers must be an object.",
     );
     expect(() =>
       createApp({
         framework: {
-          manifest: {
+          runtime: {
             ...manifest,
             server: {
               assets: { js: [], css: [] },
               renderers: {
                 "dashboard.server": {
                   kind: "page-server",
-                  module: "./src/pages/Dashboard.tsx",
                   assets: { js: [], css: [] },
                 },
               },
-              functions: {},
-              routes: [],
             },
           },
         } as never,
       }),
     ).toThrow(
-      '[evjs] createApp() framework.manifest.server.renderers key "dashboard.server" must contain only letters, numbers, underscores, or hyphens.',
+      '[evjs] createApp() framework.runtime.server.renderers key "dashboard.server" must contain only letters, numbers, underscores, or hyphens.',
     );
     expect(() =>
       createApp({
-        framework: {
-          manifest: {
-            ...manifest,
-            server: {
-              assets: { js: [], css: [] },
-              functions: {},
-              routes: [
-                {
-                  path: "/api/health",
-                  methods: ["TRACE"],
-                  assets: { js: [], css: [] },
-                },
-              ],
-            },
-          },
-        } as never,
+        framework: { runtime: { ...manifest, rsc: "rsc" } } as never,
       }),
-    ).toThrow(
-      '[evjs] createApp() framework.manifest.server.routes[0].methods item "TRACE" is not a supported HTTP method. Supported methods: GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS.',
-    );
-    expect(() =>
-      createApp({
-        framework: {
-          manifest: {
-            ...manifest,
-            server: {
-              assets: { js: [], css: [] },
-              functions: {},
-              routes: [
-                {
-                  path: "/api/users/:id",
-                  methods: ["GET"],
-                  assets: { js: [], css: [] },
-                },
-                {
-                  path: "/api/users/:userId",
-                  methods: ["GET"],
-                  assets: { js: [], css: [] },
-                },
-              ],
-            },
-          },
-        } as never,
-      }),
-    ).toThrow(
-      '[evjs] createApp() framework.manifest.server.routes[1].path has the same route shape as createApp() framework.manifest.server.routes[0].path "/api/users/:id". Use one server route per URL shape.',
-    );
-    expect(() =>
-      createApp({
-        framework: { manifest: { ...manifest, rsc: "rsc" } } as never,
-      }),
-    ).toThrow("[evjs] createApp() framework.manifest.rsc must be an object.");
-    expect(() =>
-      createApp({
-        framework: { manifest: { ...manifest, rsc: { pages: {} } } } as never,
-      }),
-    ).toThrow(
-      "[evjs] createApp() framework.manifest.rsc.endpoint must be a non-empty pathname.",
-    );
-
+    ).toThrow("[evjs] createApp() framework.runtime.rsc must be an object.");
     const rscManifest = createManifest();
     rscManifest.rsc = {
-      endpoint: "/__evjs/rsc",
       pages: {
         dashboard: {
           renderer: "dashboard-rsc",
@@ -720,14 +576,13 @@ describe("createApp", () => {
         },
       },
     };
-    expect(() => createApp({ framework: { manifest: rscManifest } })).toThrow(
-      "[evjs] createApp() framework.manifest.rsc.pages.dashboard.assets.css must contain only non-empty strings.",
+    expect(() => createApp({ framework: { runtime: rscManifest } })).toThrow(
+      "[evjs] createApp() framework.runtime.rsc.pages.dashboard.assets.css must contain only non-empty strings.",
     );
 
     const publicRscManifest = createManifest();
     configureRscPage(publicRscManifest);
     publicRscManifest.rsc = {
-      endpoint: "/__evjs/rsc",
       pages: {
         dashboard: {
           renderer: "dashboard-rsc",
@@ -738,31 +593,33 @@ describe("createApp", () => {
     expect(() =>
       createApp({
         framework: {
-          manifest: publicRscManifest,
+          runtime: publicRscManifest,
           render: () => new Response("ok"),
         },
       }),
     ).not.toThrow();
 
     expect(() =>
-      createApp({ framework: { manifest, render: "render" } as never }),
+      createApp({
+        framework: { runtime: manifest, render: "render" } as never,
+      }),
     ).toThrow(
       "[evjs] createApp() framework.render must be a render function or coordinator object.",
     );
     expect(() =>
       createApp({
-        framework: { manifest, rsc: { match: () => true } } as never,
+        framework: { runtime: manifest, rsc: { match: () => true } } as never,
       }),
     ).toThrow(
       "[evjs] createApp() framework.rsc must be an RSC Flight function or coordinator object.",
     );
     expect(() =>
-      createApp({ framework: { manifest, ppr: [] } as never }),
+      createApp({ framework: { runtime: manifest, ppr: [] } as never }),
     ).toThrow("[evjs] createApp() framework.ppr must be an object.");
     expect(() =>
       createApp({
         framework: {
-          manifest,
+          runtime: manifest,
           ppr: { regionCache: { get: () => undefined } },
         } as never,
       }),
@@ -772,7 +629,7 @@ describe("createApp", () => {
     expect(() =>
       createApp({
         framework: {
-          manifest,
+          runtime: manifest,
           ppr: {
             regionCache: {
               get: () => undefined,
@@ -788,7 +645,7 @@ describe("createApp", () => {
     expect(() =>
       createApp({
         framework: {
-          manifest,
+          runtime: manifest,
           ppr: { staleWhileRevalidate: 1.5 },
         } as never,
       }),
@@ -798,7 +655,7 @@ describe("createApp", () => {
     expect(() =>
       createApp({
         framework: {
-          manifest,
+          runtime: manifest,
           allowPageRenderRequest: "allow",
         } as never,
       }),
@@ -1086,7 +943,7 @@ describe("createApp", () => {
         }),
       ],
       framework: {
-        manifest,
+        runtime: manifest,
         render(ctx) {
           return `<h1>${ctx.pageId}</h1>`;
         },
@@ -1109,7 +966,7 @@ describe("createApp", () => {
     const manifest = createManifest();
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render(ctx) {
           return `<h1>${ctx.pageId}:${ctx.page?.render}</h1>`;
         },
@@ -1127,7 +984,7 @@ describe("createApp", () => {
     const manifest = createManifest();
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         allowPageRenderRequest() {
           throw new Error("guard exploded");
         },
@@ -1152,7 +1009,7 @@ describe("createApp", () => {
     const manifest = createManifest();
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         allowPageRenderRequest() {
           return new Response("blocked by guard", {
             status: 403,
@@ -1180,7 +1037,7 @@ describe("createApp", () => {
     const manifest = createManifest();
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         async allowPageRenderRequest(request) {
           return request.headers.get("x-evjs-render") === "1";
         },
@@ -1204,7 +1061,7 @@ describe("createApp", () => {
     const manifest = createManifest();
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         async allowPageRenderRequest() {
           return new Response("async guard blocked", {
             status: 401,
@@ -1232,7 +1089,7 @@ describe("createApp", () => {
     const manifest = createManifest();
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         allowPageRenderRequest() {
           return "yes" as never;
         },
@@ -1257,7 +1114,7 @@ describe("createApp", () => {
     const manifest = createManifest();
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render() {
           return null as never;
         },
@@ -1276,7 +1133,7 @@ describe("createApp", () => {
     const manifest = createManifest();
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render() {
           return { html: "no body status", status: 204 } as never;
         },
@@ -1295,7 +1152,7 @@ describe("createApp", () => {
     const manifest = createManifest();
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render(ctx) {
           return {
             html: `<h1>${ctx.pageId}:${ctx.page?.render}</h1>`,
@@ -1318,7 +1175,7 @@ describe("createApp", () => {
     configureRscPage(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-server": {
@@ -1341,7 +1198,7 @@ describe("createApp", () => {
     expect(await res.text()).toBe("<h1>dashboard:ssr:rsc</h1>");
   });
 
-  it("matches dynamic manifest routes for framework rendering", async () => {
+  it("matches dynamic runtime routes for framework rendering", async () => {
     const manifest = createManifest();
     manifest.pages.orderDetail = {
       assets: { js: [], css: [] },
@@ -1360,7 +1217,7 @@ describe("createApp", () => {
     });
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render(ctx) {
           return `<h1>${ctx.route?.id}:${ctx.pageId}</h1>`;
         },
@@ -1373,7 +1230,7 @@ describe("createApp", () => {
     expect(await res.text()).toBe("<h1>order.detail:orderDetail</h1>");
   });
 
-  it("prefers the most specific manifest route for framework rendering", async () => {
+  it("prefers the most specific runtime route for framework rendering", async () => {
     const manifest = createManifest();
     manifest.pages.user = {
       assets: { js: [], css: [] },
@@ -1409,7 +1266,7 @@ describe("createApp", () => {
     );
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render(ctx) {
           return `<h1>${ctx.route?.id}:${ctx.pageId}</h1>`;
         },
@@ -1426,7 +1283,7 @@ describe("createApp", () => {
     const manifest = createManifest();
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: {
           match(ctx) {
             if (ctx.pageId !== "dashboard") return undefined;
@@ -1453,7 +1310,7 @@ describe("createApp", () => {
     const manifest = createManifest();
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: {
           match() {
             return true as never;
@@ -1477,7 +1334,7 @@ describe("createApp", () => {
     const manifest = createManifest();
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: {
           match() {
             throw new Error("match exploded");
@@ -1504,7 +1361,7 @@ describe("createApp", () => {
     const manifest = createManifest();
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: {
           render() {
             throw new Error("render exploded");
@@ -1528,7 +1385,7 @@ describe("createApp", () => {
     const manifest = createManifest();
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-server": {
@@ -1560,7 +1417,7 @@ describe("createApp", () => {
     let loadCount = 0;
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-server": {
@@ -1601,7 +1458,6 @@ describe("createApp", () => {
 
   it("uses the PPR shell renderer for PPR pages", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -1609,14 +1465,13 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
         },
       },
     };
     configurePprRendering(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-ppr-shell": {
@@ -1683,7 +1538,6 @@ describe("createApp", () => {
           details: {
             id: "details",
             assets: { js: ["order-details-ppr-region.js"], css: [] },
-            component: "./src/pages/orders/Details.region.tsx",
             cache: { revalidate: 60 },
           },
         },
@@ -1697,7 +1551,7 @@ describe("createApp", () => {
     let renderCount = 0;
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "order-details-region": {
@@ -1751,7 +1605,6 @@ describe("createApp", () => {
 
   it("leaves PPR page responses with non-html media types unchanged", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -1759,7 +1612,6 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
         },
       },
     };
@@ -1767,7 +1619,7 @@ describe("createApp", () => {
     let regionRenderCount = 0;
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-ppr-shell": {
@@ -1818,7 +1670,6 @@ describe("createApp", () => {
 
   it("merges PPR regions into React Suspense fallback boundaries", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -1826,14 +1677,13 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
         },
       },
     };
     configurePprRendering(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-ppr-shell": {
@@ -1875,7 +1725,6 @@ describe("createApp", () => {
 
   it("streams PPR page shells and patches Suspense fallback boundaries", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "stream" };
     manifest.pages.dashboard.ppr = {
       delivery: "stream",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -1883,14 +1732,13 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
         },
       },
     };
     configurePprRendering(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-ppr-shell": {
@@ -1934,7 +1782,6 @@ describe("createApp", () => {
 
   it("derives merged PPR page cache headers from region revalidate policies", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -1942,13 +1789,11 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
           cache: { revalidate: 60 },
         },
         inventory: {
           id: "inventory",
           assets: { js: ["dashboard-inventory-ppr-region.js"], css: [] },
-          component: "./src/pages/Inventory.region.tsx",
           cache: { revalidate: 15 },
         },
       },
@@ -1956,7 +1801,7 @@ describe("createApp", () => {
     configurePprRendering(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-ppr-shell": {
@@ -2002,7 +1847,6 @@ describe("createApp", () => {
 
   it("sets no-store cache headers on PPR pages with dynamic regions", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2010,7 +1854,6 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
         },
       },
     };
@@ -2018,7 +1861,7 @@ describe("createApp", () => {
     let regionRenderCount = 0;
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-ppr-shell": {
@@ -2057,7 +1900,6 @@ describe("createApp", () => {
 
   it("preserves explicit PPR shell cache headers", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2065,7 +1907,6 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
           cache: { revalidate: 60 },
         },
       },
@@ -2073,7 +1914,7 @@ describe("createApp", () => {
     configurePprRendering(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-ppr-shell": {
@@ -2114,7 +1955,6 @@ describe("createApp", () => {
 
   it("derives streamed PPR page cache headers from region revalidate policies", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "stream" };
     manifest.pages.dashboard.ppr = {
       delivery: "stream",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2122,7 +1962,6 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
           cache: { revalidate: 30 },
         },
       },
@@ -2130,7 +1969,7 @@ describe("createApp", () => {
     configurePprRendering(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-ppr-shell": {
@@ -2170,7 +2009,6 @@ describe("createApp", () => {
 
   it("adds stale-while-revalidate to PPR page cache headers when configured", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2178,7 +2016,6 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
           cache: { revalidate: 45 },
         },
       },
@@ -2186,7 +2023,7 @@ describe("createApp", () => {
     configurePprRendering(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         ppr: { staleWhileRevalidate: 10 },
         render: createModuleRenderCoordinator({
           renderers: {
@@ -2222,7 +2059,6 @@ describe("createApp", () => {
 
   it("normalizes PPR region document responses into fragments", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2230,7 +2066,6 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
           cache: "no-store",
         },
       },
@@ -2238,7 +2073,7 @@ describe("createApp", () => {
     configurePprRendering(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-hero-region": {
@@ -2273,7 +2108,6 @@ describe("createApp", () => {
 
   it("leaves PPR region responses with non-html media types unchanged", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2281,7 +2115,6 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
           cache: "no-store",
         },
       },
@@ -2295,7 +2128,7 @@ describe("createApp", () => {
     ].join("");
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-hero-region": {
@@ -2326,7 +2159,6 @@ describe("createApp", () => {
 
   it("skips non-html PPR regions during merged page composition", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2334,7 +2166,6 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
           cache: "no-store",
         },
       },
@@ -2343,7 +2174,7 @@ describe("createApp", () => {
     let regionRenderCount = 0;
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-ppr-shell": {
@@ -2383,7 +2214,6 @@ describe("createApp", () => {
 
   it("skips non-html PPR regions during streamed page composition", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "stream" };
     manifest.pages.dashboard.ppr = {
       delivery: "stream",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2391,7 +2221,6 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
           cache: "no-store",
         },
       },
@@ -2400,7 +2229,7 @@ describe("createApp", () => {
     let regionRenderCount = 0;
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-ppr-shell": {
@@ -2442,7 +2271,6 @@ describe("createApp", () => {
 
   it("requires exact PPR region endpoint paths", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2450,7 +2278,6 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
         },
       },
     };
@@ -2458,7 +2285,7 @@ describe("createApp", () => {
     let renderCount = 0;
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-hero-region": {
@@ -2522,7 +2349,6 @@ describe("createApp", () => {
 
   it("returns 405 for unsupported PPR region methods", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2530,7 +2356,6 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
         },
       },
     };
@@ -2538,7 +2363,7 @@ describe("createApp", () => {
     let renderCount = 0;
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render() {
           renderCount += 1;
           return "<p>should not render</p>";
@@ -2559,7 +2384,6 @@ describe("createApp", () => {
 
   it("reports PPR region render coordinator match exceptions with evjs context", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2567,14 +2391,13 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
         },
       },
     };
     configurePprRendering(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: {
           match() {
             throw new Error("region match exploded");
@@ -2601,7 +2424,6 @@ describe("createApp", () => {
 
   it("reports PPR region render coordinator render exceptions with evjs context", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2609,14 +2431,13 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
         },
       },
     };
     configurePprRendering(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: {
           render() {
             throw new Error("region render exploded");
@@ -2640,7 +2461,6 @@ describe("createApp", () => {
 
   it("caches PPR regions with revalidate policy", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2648,7 +2468,6 @@ describe("createApp", () => {
         inventory: {
           id: "inventory",
           assets: { js: ["dashboard-inventory-ppr-region.js"], css: [] },
-          component: "./src/pages/Inventory.region.tsx",
           cache: { revalidate: 60 },
         },
       },
@@ -2657,7 +2476,7 @@ describe("createApp", () => {
     let renderCount = 0;
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-inventory-region": {
@@ -2685,7 +2504,6 @@ describe("createApp", () => {
 
   it("uses a custom PPR region cache when provided", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2693,7 +2511,6 @@ describe("createApp", () => {
         inventory: {
           id: "inventory",
           assets: { js: ["dashboard-inventory-ppr-region.js"], css: [] },
-          component: "./src/pages/Inventory.region.tsx",
           cache: { revalidate: 60 },
         },
       },
@@ -2709,7 +2526,7 @@ describe("createApp", () => {
     let renderCount = 0;
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         ppr: { regionCache },
         render: createModuleRenderCoordinator({
           renderers: {
@@ -2739,7 +2556,6 @@ describe("createApp", () => {
 
   it("serves stale PPR regions while refreshing the cache", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2747,7 +2563,6 @@ describe("createApp", () => {
         inventory: {
           id: "inventory",
           assets: { js: ["dashboard-inventory-ppr-region.js"], css: [] },
-          component: "./src/pages/Inventory.region.tsx",
           cache: { revalidate: 60 },
         },
       },
@@ -2782,7 +2597,7 @@ describe("createApp", () => {
     let renderCount = 0;
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         ppr: { regionCache, staleWhileRevalidate: 30 },
         render: createModuleRenderCoordinator({
           renderers: {
@@ -2819,7 +2634,6 @@ describe("createApp", () => {
       .spyOn(console, "error")
       .mockImplementation(() => {});
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2827,7 +2641,6 @@ describe("createApp", () => {
         inventory: {
           id: "inventory",
           assets: { js: ["dashboard-inventory-ppr-region.js"], css: [] },
-          component: "./src/pages/Inventory.region.tsx",
           cache: { revalidate: 60 },
         },
       },
@@ -2843,7 +2656,7 @@ describe("createApp", () => {
     };
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         ppr: { regionCache },
         render: createModuleRenderCoordinator({
           renderers: {
@@ -2874,7 +2687,6 @@ describe("createApp", () => {
 
   it("does not populate PPR region cache from HEAD misses", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2882,7 +2694,6 @@ describe("createApp", () => {
         inventory: {
           id: "inventory",
           assets: { js: ["dashboard-inventory-ppr-region.js"], css: [] },
-          component: "./src/pages/Inventory.region.tsx",
           cache: { revalidate: 60 },
         },
       },
@@ -2891,7 +2702,7 @@ describe("createApp", () => {
     let renderCount = 0;
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-inventory-region": {
@@ -2926,7 +2737,6 @@ describe("createApp", () => {
 
   it("serves cached PPR region HEAD requests without rerendering", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2934,7 +2744,6 @@ describe("createApp", () => {
         inventory: {
           id: "inventory",
           assets: { js: ["dashboard-inventory-ppr-region.js"], css: [] },
-          component: "./src/pages/Inventory.region.tsx",
           cache: { revalidate: 60 },
         },
       },
@@ -2943,7 +2752,7 @@ describe("createApp", () => {
     let renderCount = 0;
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-inventory-region": {
@@ -2976,7 +2785,6 @@ describe("createApp", () => {
 
   it("does not cache no-store PPR regions", async () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -2984,7 +2792,6 @@ describe("createApp", () => {
         hero: {
           id: "hero",
           assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-          component: "./src/pages/Hero.region.tsx",
           cache: "no-store",
         },
       },
@@ -2993,7 +2800,7 @@ describe("createApp", () => {
     let renderCount = 0;
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-hero-region": {
@@ -3019,7 +2826,6 @@ describe("createApp", () => {
 
   it("rejects invalid PPR region revalidate policies", () => {
     const manifest = createManifest();
-    manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
     manifest.pages.dashboard.ppr = {
       delivery: "merge",
       shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -3027,21 +2833,19 @@ describe("createApp", () => {
         zero: {
           id: "zero",
           assets: { js: ["dashboard-zero-ppr-region.js"], css: [] },
-          component: "./src/pages/Zero.region.tsx",
           cache: { revalidate: 0 } as never,
         },
         fractional: {
           id: "fractional",
           assets: { js: ["dashboard-fractional-ppr-region.js"], css: [] },
-          component: "./src/pages/Fractional.region.tsx",
           cache: { revalidate: 1.5 } as never,
         },
       },
     };
     configurePprRendering(manifest);
 
-    expect(() => createApp({ framework: { manifest } })).toThrow(
-      "[evjs] createApp() framework.manifest.pages.dashboard.ppr.regions.zero.cache.revalidate must be a positive integer number of seconds.",
+    expect(() => createApp({ framework: { runtime: manifest } })).toThrow(
+      "[evjs] createApp() framework.runtime.pages.dashboard.ppr.regions.zero.cache.revalidate must be a positive integer number of seconds.",
     );
   });
 
@@ -3049,7 +2853,7 @@ describe("createApp", () => {
     const manifest = createManifest();
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         render: createModuleRenderCoordinator({
           renderers: {
             "dashboard-server": {
@@ -3078,7 +2882,7 @@ describe("createApp", () => {
     });
     const ctx: ServerRenderContext = {
       request: new Request("https://example.com/dashboard"),
-      manifest,
+      runtime: manifest,
       route: manifest.routes[0],
       page: manifest.pages.dashboard,
       pageId: "dashboard",
@@ -3141,81 +2945,76 @@ describe("createApp", () => {
       "[evjs] createModuleRenderCoordinator() fallback must be a render function or coordinator object.",
     );
 
-    expect(() => createManifestRenderCoordinator(null as never)).toThrow(
-      "[evjs] createManifestRenderCoordinator() options must be an object.",
+    expect(() => createFrameworkRenderCoordinator(null as never)).toThrow(
+      "[evjs] createFrameworkRenderCoordinator() options must be an object.",
     );
     expect(() =>
-      createManifestRenderCoordinator({ manifest: null } as never),
+      createFrameworkRenderCoordinator({ runtime: null } as never),
     ).toThrow(
-      "[evjs] createManifestRenderCoordinator() manifest must be an object.",
+      "[evjs] createFrameworkRenderCoordinator() runtime must be an object.",
     );
     expect(() =>
-      createManifestRenderCoordinator({
-        manifest: { ...manifest, version: 2 },
+      createFrameworkRenderCoordinator({
+        runtime: { ...manifest, version: 2 },
         loadModule: async () => ({}),
       } as never),
     ).toThrow(
-      "[evjs] createManifestRenderCoordinator() manifest.version must be 1.",
+      "[evjs] createFrameworkRenderCoordinator() runtime.version must be 1.",
     );
     expect(() =>
-      createManifestRenderCoordinator({
-        manifest: { ...manifest, routes: {} },
+      createFrameworkRenderCoordinator({
+        runtime: { ...manifest, routes: {} },
         loadModule: async () => ({}),
       } as never),
     ).toThrow(
-      "[evjs] createManifestRenderCoordinator() manifest.routes must be an array.",
+      "[evjs] createFrameworkRenderCoordinator() runtime.routes must be an array.",
     );
     expect(() =>
-      createManifestRenderCoordinator({
-        manifest: {
+      createFrameworkRenderCoordinator({
+        runtime: {
           ...manifest,
           server: { renderers: [] },
         },
         loadModule: async () => ({}),
       } as never),
     ).toThrow(
-      "[evjs] createManifestRenderCoordinator() manifest.server.renderers must be an object.",
+      "[evjs] createFrameworkRenderCoordinator() runtime.server.renderers must be an object.",
     );
     expect(() =>
-      createManifestRenderCoordinator({
-        manifest,
+      createFrameworkRenderCoordinator({
+        runtime: manifest,
         loadModule: "load",
       } as never),
     ).toThrow(
-      "[evjs] createManifestRenderCoordinator() loadModule must be a function.",
+      "[evjs] createFrameworkRenderCoordinator() loadModule must be a function.",
     );
     expect(() =>
-      createManifestRenderCoordinator({
-        manifest,
+      createFrameworkRenderCoordinator({
+        runtime: manifest,
         loadModule: async () => ({}),
         fallback: "render",
       } as never),
     ).toThrow(
-      "[evjs] createManifestRenderCoordinator() fallback must be a render function or coordinator object.",
+      "[evjs] createFrameworkRenderCoordinator() fallback must be a render function or coordinator object.",
     );
   });
 
-  it("loads renderer modules from manifest assets", async () => {
+  it("loads renderer modules from runtime assets", async () => {
     const manifest = createManifest();
     manifest.server = {
-      entry: "server.js",
-      assets: { js: ["server.js"], css: [] },
       renderers: {
         "dashboard-server": {
           kind: "page-server",
           owner: { pageId: "dashboard" },
-          module: "./src/pages/Dashboard.tsx",
           assets: { js: ["dashboard-server.js"], css: [] },
         },
       },
-      functions: {},
-      routes: [],
     };
     const app = createApp({
       framework: {
-        manifest,
-        render: createManifestRenderCoordinator({
-          manifest,
+        runtime: manifest,
+        render: createFrameworkRenderCoordinator({
+          runtime: manifest,
           async loadModule(asset) {
             expect(asset).toBe("dashboard-server.js");
             return {
@@ -3234,23 +3033,18 @@ describe("createApp", () => {
     expect(await res.text()).toBe("<h1>dashboard:manifest</h1>");
   });
 
-  it("creates an explicit React framework server from runtime manifest globals", async () => {
+  it("creates an explicit React framework server from runtime runtime globals", async () => {
     const manifest = createManifest();
     manifest.server = {
-      entry: "server.js",
-      assets: { js: ["server.js"], css: [] },
       renderers: {
         "dashboard-server": {
           kind: "page-server",
           owner: { pageId: "dashboard" },
-          module: "./src/pages/Dashboard.tsx",
           assets: { js: ["dashboard-server.js"], css: [] },
         },
       },
-      functions: {},
-      routes: [],
     };
-    vi.stubGlobal("__EVJS_MANIFEST__", manifest);
+    vi.stubGlobal("__EVJS_FRAMEWORK_RUNTIME__", manifest);
     vi.stubGlobal("__EVJS_SERVER_MODULE_LOADER__", async (asset: string) => {
       expect(asset).toBe("dashboard-server.js");
       return {
@@ -3272,7 +3066,7 @@ describe("createApp", () => {
 
   it("reports missing React framework module loaders as plain text", async () => {
     const manifest = createManifest();
-    vi.stubGlobal("__EVJS_MANIFEST__", manifest);
+    vi.stubGlobal("__EVJS_FRAMEWORK_RUNTIME__", manifest);
 
     const framework = createReactFrameworkServer();
     if (!framework) throw new Error("Expected framework options");
@@ -3294,41 +3088,37 @@ describe("createApp", () => {
       "[evjs] createReactFrameworkServer() options must be an object.",
     );
     expect(() =>
-      createReactFrameworkServer({ manifest: null as never }),
-    ).toThrow(
-      "[evjs] createReactFrameworkServer() manifest must be an object.",
-    );
+      createReactFrameworkServer({ runtime: null as never }),
+    ).toThrow("[evjs] createReactFrameworkServer() runtime must be an object.");
     expect(() =>
       createReactFrameworkServer({
-        manifest: { ...manifest, runtime: null } as never,
+        runtime: { ...manifest, runtime: null } as never,
       }),
     ).toThrow(
-      "[evjs] createReactFrameworkServer() manifest.runtime must be an object.",
+      "[evjs] createReactFrameworkServer() runtime.runtime must be an object.",
     );
     expect(() =>
       createReactFrameworkServer({
-        manifest: { ...manifest, version: 2 } as never,
+        runtime: { ...manifest, version: 2 } as never,
+      }),
+    ).toThrow("[evjs] createReactFrameworkServer() runtime.version must be 1.");
+    expect(() =>
+      createReactFrameworkServer({
+        runtime: { ...manifest, pages: null } as never,
       }),
     ).toThrow(
-      "[evjs] createReactFrameworkServer() manifest.version must be 1.",
+      "[evjs] createReactFrameworkServer() runtime.pages must be an object.",
     );
     expect(() =>
       createReactFrameworkServer({
-        manifest: { ...manifest, pages: null } as never,
+        runtime: { ...manifest, routes: {} } as never,
       }),
     ).toThrow(
-      "[evjs] createReactFrameworkServer() manifest.pages must be an object.",
+      "[evjs] createReactFrameworkServer() runtime.routes must be an array.",
     );
     expect(() =>
       createReactFrameworkServer({
-        manifest: { ...manifest, routes: {} } as never,
-      }),
-    ).toThrow(
-      "[evjs] createReactFrameworkServer() manifest.routes must be an array.",
-    );
-    expect(() =>
-      createReactFrameworkServer({
-        manifest: {
+        runtime: {
           ...manifest,
           runtime: {
             ...manifest.runtime,
@@ -3337,49 +3127,58 @@ describe("createApp", () => {
         } as never,
       }),
     ).toThrow(
-      "[evjs] createReactFrameworkServer() manifest.runtime.transport.baseUrl must not contain leading or trailing whitespace.",
+      "[evjs] createReactFrameworkServer() runtime.runtime.transport.baseUrl must not contain leading or trailing whitespace.",
     );
     expect(() =>
       createReactFrameworkServer({
-        manifest: {
+        runtime: {
           ...manifest,
           server: { renderers: [] },
         } as never,
       }),
     ).toThrow(
-      "[evjs] createReactFrameworkServer() manifest.server.renderers must be an object.",
+      "[evjs] createReactFrameworkServer() runtime.server.renderers must be an object.",
     );
     expect(() =>
       createReactFrameworkServer({
-        manifest: { ...manifest, rsc: "rsc" } as never,
+        runtime: { ...manifest, rsc: "rsc" } as never,
       }),
     ).toThrow(
-      "[evjs] createReactFrameworkServer() manifest.rsc must be an object.",
+      "[evjs] createReactFrameworkServer() runtime.rsc must be an object.",
     );
     expect(() =>
-      createReactFrameworkServer({ manifest, loadModule: "load" } as never),
+      createReactFrameworkServer({
+        runtime: manifest,
+        loadModule: "load",
+      } as never),
     ).toThrow(
       "[evjs] createReactFrameworkServer() loadModule must be a function.",
     );
     expect(() =>
-      createReactFrameworkServer({ manifest, renderModule: "render" } as never),
+      createReactFrameworkServer({
+        runtime: manifest,
+        renderModule: "render",
+      } as never),
     ).toThrow(
       "[evjs] createReactFrameworkServer() renderModule must be a function.",
     );
     expect(() =>
-      createReactFrameworkServer({ manifest, react: null as never }),
+      createReactFrameworkServer({ runtime: manifest, react: null as never }),
     ).toThrow("[evjs] createReactFrameworkServer() react must be an object.");
     expect(() =>
-      createReactFrameworkServer({ manifest, rsc: [] as never }),
+      createReactFrameworkServer({ runtime: manifest, rsc: [] as never }),
     ).toThrow("[evjs] createReactFrameworkServer() rsc must be an object.");
     expect(() =>
-      createReactFrameworkServer({ manifest, fallback: "render" } as never),
+      createReactFrameworkServer({
+        runtime: manifest,
+        fallback: "render",
+      } as never),
     ).toThrow(
       "[evjs] createReactFrameworkServer() fallback must be a render function or coordinator object.",
     );
     expect(() =>
       createReactFrameworkServer({
-        manifest,
+        runtime: manifest,
         rscCoordinator: { match: () => true } as never,
       }),
     ).toThrow(
@@ -3390,20 +3189,15 @@ describe("createApp", () => {
   it("can restrict React framework page rendering to dev proxy requests", async () => {
     const manifest = createManifest();
     manifest.server = {
-      entry: "server.js",
-      assets: { js: ["server.js"], css: [] },
       renderers: {
         "dashboard-server": {
           kind: "page-server",
           owner: { pageId: "dashboard" },
-          module: "./src/pages/Dashboard.tsx",
           assets: { js: ["dashboard-server.js"], css: [] },
         },
       },
-      functions: {},
-      routes: [],
     };
-    vi.stubGlobal("__EVJS_MANIFEST__", manifest);
+    vi.stubGlobal("__EVJS_FRAMEWORK_RUNTIME__", manifest);
     vi.stubGlobal(
       "__EVJS_DEV_PAGE_RENDER_PROXY_HEADER__",
       "x-evjs-dev-page-render",
@@ -3435,7 +3229,7 @@ describe("createApp", () => {
     configureRscManifest(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         rsc(ctx) {
           const pageUrl = ctx.pageUrl ? new URL(ctx.pageUrl) : undefined;
           return new Response(
@@ -3458,37 +3252,32 @@ describe("createApp", () => {
     expect(await res.text()).toBe("/dashboard?tab=stats");
   });
 
-  it("mounts RSC flight handling from the RSC manifest endpoint", async () => {
+  it("does not mount RSC flight handling without a server runtime endpoint", async () => {
     const manifest = createManifest();
     configureRscManifest(manifest);
     if (manifest.runtime.server) {
       delete manifest.runtime.server.rsc;
     }
-    if (!manifest.rsc) {
-      throw new Error("Expected RSC manifest metadata");
-    }
-    manifest.rsc.endpoint = "/__custom/rsc";
+    const rsc = vi.fn(
+      () =>
+        new Response("flight", {
+          headers: { "Content-Type": "text/x-component" },
+        }),
+    );
 
     const app = createApp({
       framework: {
-        manifest,
-        rsc() {
-          return new Response("manifest-endpoint-flight", {
-            headers: { "Content-Type": "text/x-component" },
-          });
-        },
+        runtime: manifest,
+        rsc,
       },
     });
 
     const frameworkEndpoint = await app.request("/__evjs/rsc?page=dashboard");
-    const manifestEndpoint = await app.request("/__custom/rsc?page=dashboard");
+    const customEndpoint = await app.request("/__custom/rsc?page=dashboard");
 
     expect(frameworkEndpoint.status).toBe(404);
-    expect(manifestEndpoint.status).toBe(200);
-    expect(manifestEndpoint.headers.get("Content-Type")).toBe(
-      "text/x-component",
-    );
-    expect(await manifestEndpoint.text()).toBe("manifest-endpoint-flight");
+    expect(customEndpoint.status).toBe(404);
+    expect(rsc).not.toHaveBeenCalled();
   });
 
   it("serves RSC flight HEAD requests without a response body", async () => {
@@ -3496,7 +3285,7 @@ describe("createApp", () => {
     configureRscManifest(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         rsc() {
           return new Response("flight", {
             headers: {
@@ -3524,7 +3313,7 @@ describe("createApp", () => {
     configureRscManifest(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         rsc() {
           return new Response("flight", {
             headers: {
@@ -3549,7 +3338,7 @@ describe("createApp", () => {
     configureRscManifest(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         rsc() {
           return new Response("flight", {
             headers: { "Content-Type": "text/x-component" },
@@ -3572,7 +3361,7 @@ describe("createApp", () => {
     configureRscManifest(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         rsc: {
           match(ctx) {
             return new URL(ctx.request.url).searchParams.get("flight") === "1";
@@ -3599,7 +3388,7 @@ describe("createApp", () => {
     configureRscManifest(manifest);
     const invalidMatchApp = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         rsc: {
           match() {
             return "yes" as never;
@@ -3622,7 +3411,7 @@ describe("createApp", () => {
 
     const throwingMatchApp = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         rsc: {
           match() {
             throw new Error("match exploded");
@@ -3649,7 +3438,7 @@ describe("createApp", () => {
     configureRscManifest(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         rsc() {
           return null as never;
         },
@@ -3669,7 +3458,7 @@ describe("createApp", () => {
     configureRscManifest(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         rsc() {
           return new Response("not ready", {
             status: 404,
@@ -3691,7 +3480,7 @@ describe("createApp", () => {
     configureRscManifest(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         rsc() {
           return new Response(JSON.stringify({ ok: true }), {
             headers: { "Content-Type": "application/json" },
@@ -3713,7 +3502,7 @@ describe("createApp", () => {
     configureRscManifest(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         rsc() {
           return new Response(null);
         },
@@ -3733,7 +3522,7 @@ describe("createApp", () => {
     configureRscManifest(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         rsc() {
           return new Response("flight", {
             headers: { "Content-Type": "text/x-component" },
@@ -3763,7 +3552,7 @@ describe("createApp", () => {
     const unknownPage = await app.request("/__evjs/rsc?page=unknown");
     expect(unknownPage.status).toBe(404);
     await expect(unknownPage.text()).resolves.toContain(
-      'RSC page "unknown" is not in the manifest',
+      'RSC page "unknown" is not in the runtime',
     );
 
     manifest.pages.dashboard.render = "ssr";
@@ -3780,7 +3569,7 @@ describe("createApp", () => {
     configureRscManifest(manifest);
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         rsc() {
           return new Response("flight", {
             headers: { "Content-Type": "text/x-component" },
@@ -3821,11 +3610,10 @@ describe("createApp", () => {
       pageId: "settings",
       path: "/settings",
       renderer: "settings-rsc",
-      module: "./src/pages/Settings.tsx",
     });
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         rsc() {
           return new Response("flight", {
             headers: { "Content-Type": "text/x-component" },
@@ -3849,11 +3637,10 @@ describe("createApp", () => {
       pageId: "user",
       path: "/users/$userId",
       renderer: "user-rsc",
-      module: "./src/pages/User.tsx",
     });
     const app = createApp({
       framework: {
-        manifest,
+        runtime: manifest,
         rsc(ctx) {
           const pageUrl = ctx.pageUrl ? new URL(ctx.pageUrl) : undefined;
           return new Response(pageUrl?.pathname ?? "missing-url", {
@@ -3871,39 +3658,32 @@ describe("createApp", () => {
     await expect(res.text()).resolves.toBe("/users/42");
   });
 
-  it("creates a default RSC coordinator from a React framework manifest", async () => {
+  it("creates a default RSC coordinator from a React framework runtime", async () => {
     const manifest = createManifest();
     configureRscPage(manifest);
     manifest.rsc = {
-      endpoint: "/__evjs/rsc",
       pages: {
         dashboard: {
           renderer: "dashboard-rsc",
           assets: { js: ["dashboard-rsc.js"], css: [] },
-          component: "./src/pages/Dashboard.tsx",
         },
       },
     };
     manifest.server = {
-      assets: { js: ["server.js"], css: [] },
-      functions: {},
-      routes: [],
       renderers: {
         "dashboard-rsc": {
           kind: "rsc-page",
           owner: { pageId: "dashboard" },
-          module: "./src/pages/Dashboard.tsx",
           assets: { js: ["dashboard-rsc.js"], css: [] },
         },
         "dashboard-server": {
           kind: "page-server",
           owner: { pageId: "dashboard" },
-          module: "./src/pages/Dashboard.tsx",
           assets: { js: ["dashboard-server.js"], css: [] },
         },
       },
     };
-    vi.stubGlobal("__EVJS_MANIFEST__", manifest);
+    vi.stubGlobal("__EVJS_FRAMEWORK_RUNTIME__", manifest);
     vi.stubGlobal("__EVJS_SERVER_MODULE_LOADER__", async () => ({
       renderFlight(ctx: { pageId?: string }) {
         return new Response(`flight:${ctx.pageId}`, {
@@ -3925,42 +3705,35 @@ describe("createApp", () => {
     await expect(res.text()).resolves.toBe("flight:dashboard");
   });
 
-  it("creates a default RSC coordinator from the RSC manifest endpoint", async () => {
+  it("does not create a default RSC coordinator without a server runtime endpoint", async () => {
     const manifest = createManifest();
     configureRscPage(manifest);
     if (manifest.runtime.server) {
       delete manifest.runtime.server.rsc;
     }
     manifest.rsc = {
-      endpoint: "/__custom/rsc",
       pages: {
         dashboard: {
           renderer: "dashboard-rsc",
           assets: { js: ["dashboard-rsc.js"], css: [] },
-          component: "./src/pages/Dashboard.tsx",
         },
       },
     };
     manifest.server = {
-      assets: { js: ["server.js"], css: [] },
-      functions: {},
-      routes: [],
       renderers: {
         "dashboard-rsc": {
           kind: "rsc-page",
           owner: { pageId: "dashboard" },
-          module: "./src/pages/Dashboard.tsx",
           assets: { js: ["dashboard-rsc.js"], css: [] },
         },
         "dashboard-server": {
           kind: "page-server",
           owner: { pageId: "dashboard" },
-          module: "./src/pages/Dashboard.tsx",
           assets: { js: ["dashboard-server.js"], css: [] },
         },
       },
     };
-    vi.stubGlobal("__EVJS_MANIFEST__", manifest);
+    vi.stubGlobal("__EVJS_FRAMEWORK_RUNTIME__", manifest);
     vi.stubGlobal("__EVJS_SERVER_MODULE_LOADER__", async () => ({
       renderFlight(ctx: { pageId?: string }) {
         return new Response(`manifest-flight:${ctx.pageId}`, {
@@ -3973,27 +3746,21 @@ describe("createApp", () => {
 
     const framework = createReactFrameworkServer();
     if (!framework) throw new Error("Expected framework options");
+    expect(framework.rsc).toBeUndefined();
     const app = createApp({ framework });
 
     const staleEndpoint = await app.request("/__evjs/rsc?page=dashboard");
-    const manifestEndpoint = await app.request("/__custom/rsc?page=dashboard");
+    const customEndpoint = await app.request("/__custom/rsc?page=dashboard");
 
     expect(staleEndpoint.status).toBe(404);
-    expect(manifestEndpoint.status).toBe(200);
-    expect(manifestEndpoint.headers.get("Content-Type")).toContain(
-      "text/x-component",
-    );
-    await expect(manifestEndpoint.text()).resolves.toBe(
-      "manifest-flight:dashboard",
-    );
+    expect(customEndpoint.status).toBe(404);
   });
 });
 
-function createManifest(): BuildOutput {
+function createManifest(): FrameworkRuntime {
   return {
     version: 1,
     buildId: "test",
-    distDir: "dist",
     publicPath: "/",
     runtime: {
       server: {
@@ -4002,8 +3769,6 @@ function createManifest(): BuildOutput {
         rsc: "/__evjs/rsc",
       },
     },
-    assets: {},
-    apps: {},
     pages: {
       dashboard: {
         assets: { js: [], css: [] },
@@ -4024,14 +3789,10 @@ function createManifest(): BuildOutput {
       },
     ],
     server: {
-      assets: { js: ["server.js"], css: [] },
-      functions: {},
-      routes: [],
       renderers: {
         "dashboard-server": {
           kind: "page-server",
           owner: { pageId: "dashboard" },
-          module: "./src/pages/Dashboard.tsx",
           assets: { js: ["dashboard-server.js"], css: [] },
         },
       },
@@ -4039,10 +3800,9 @@ function createManifest(): BuildOutput {
   };
 }
 
-function configureRscManifest(manifest: BuildOutput): void {
+function configureRscManifest(manifest: FrameworkRuntime): void {
   configureRscPage(manifest);
   manifest.rsc = {
-    endpoint: "/__evjs/rsc",
     pages: {
       dashboard: {
         renderer: "dashboard-rsc",
@@ -4051,20 +3811,15 @@ function configureRscManifest(manifest: BuildOutput): void {
     },
   };
   manifest.server = {
-    assets: { js: ["server.js"], css: [] },
-    functions: {},
-    routes: [],
     renderers: {
       "dashboard-rsc": {
         kind: "rsc-page",
         owner: { pageId: "dashboard" },
-        module: "./src/pages/Dashboard.tsx",
         assets: { js: ["dashboard-rsc.js"], css: [] },
       },
       "dashboard-server": {
         kind: "page-server",
         owner: { pageId: "dashboard" },
-        module: "./src/pages/Dashboard.tsx",
         assets: { js: ["dashboard-server.js"], css: [] },
       },
     },
@@ -4072,12 +3827,11 @@ function configureRscManifest(manifest: BuildOutput): void {
 }
 
 function addRscManifestPage(
-  manifest: BuildOutput,
+  manifest: FrameworkRuntime,
   options: {
     pageId: string;
     path: string;
     renderer: string;
-    module: string;
   },
 ): void {
   const rscPages = manifest.rsc?.pages;
@@ -4110,18 +3864,16 @@ function addRscManifestPage(
   serverRenderers[options.renderer] = {
     kind: "rsc-page",
     owner: { pageId: options.pageId },
-    module: options.module,
     assets: rendererAssets,
   };
   serverRenderers[`${options.pageId}-server`] = {
     kind: "page-server",
     owner: { pageId: options.pageId },
-    module: options.module,
     assets: { js: [`${options.pageId}-server.js`], css: [] },
   };
 }
 
-function configureRscPage(manifest: BuildOutput): void {
+function configureRscPage(manifest: FrameworkRuntime): void {
   manifest.pages.dashboard.render = "ssr";
   manifest.pages.dashboard.componentModel = "rsc";
   manifest.pages.dashboard.rendering = {
@@ -4132,7 +3884,7 @@ function configureRscPage(manifest: BuildOutput): void {
   };
 }
 
-function configurePprRendering(manifest: BuildOutput): void {
+function configurePprRendering(manifest: FrameworkRuntime): void {
   const delivery = manifest.pages.dashboard.ppr?.delivery ?? "merge";
   manifest.pages.dashboard.rendering = {
     component: "server",

--- a/packages/server/tests/context.test.ts
+++ b/packages/server/tests/context.test.ts
@@ -1,4 +1,3 @@
-import type { BuildOutput } from "@evjs/shared/manifest";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createApp } from "../src/app.js";
 import {
@@ -10,6 +9,7 @@ import {
   setCookie,
   waitUntil,
 } from "../src/context.js";
+import type { FrameworkRuntime } from "../src/framework.js";
 import {
   registerServerReference,
   registry,
@@ -130,7 +130,7 @@ describe("Server Request Context", () => {
       ],
       routes: [route],
       framework: {
-        manifest: createFrameworkManifest(),
+        runtime: createFrameworkManifest(),
         render(ctx) {
           observed.push(
             `framework-render:${headers().get("x-context-test")}:${ctx.pageId}`,
@@ -176,7 +176,7 @@ describe("Server Request Context", () => {
     configurePprManifest(pprManifest);
     const pprApp = createApp({
       framework: {
-        manifest: pprManifest,
+        runtime: pprManifest,
         render(ctx) {
           if (ctx.regionId) {
             observed.push(`ppr-region:${headers().get("x-context-test")}`);
@@ -196,7 +196,7 @@ describe("Server Request Context", () => {
     configureRscManifest(rscManifest);
     const rscApp = createApp({
       framework: {
-        manifest: rscManifest,
+        runtime: rscManifest,
         rsc(ctx) {
           observed.push(
             `rsc-flight:${headers().get("x-context-test")}:${ctx.pageId}`,
@@ -225,11 +225,10 @@ describe("Server Request Context", () => {
   });
 });
 
-function createFrameworkManifest(): BuildOutput {
+function createFrameworkManifest(): FrameworkRuntime {
   return {
     version: 1,
     buildId: "test",
-    distDir: "dist",
     publicPath: "/",
     runtime: {
       server: {
@@ -238,8 +237,6 @@ function createFrameworkManifest(): BuildOutput {
         rsc: "/__evjs/rsc",
       },
     },
-    assets: {},
-    apps: {},
     pages: {
       dashboard: {
         assets: { js: [], css: [] },
@@ -260,14 +257,10 @@ function createFrameworkManifest(): BuildOutput {
       },
     ],
     server: {
-      assets: { js: ["server.js"], css: [] },
-      functions: {},
-      routes: [],
       renderers: {
         "dashboard-server": {
           kind: "page-server",
           owner: { pageId: "dashboard" },
-          module: "./src/pages/Dashboard.tsx",
           assets: { js: ["dashboard-server.js"], css: [] },
         },
       },
@@ -275,8 +268,7 @@ function createFrameworkManifest(): BuildOutput {
   };
 }
 
-function configurePprManifest(manifest: BuildOutput): void {
-  manifest.pages.dashboard.prerender = { partial: true, delivery: "merge" };
+function configurePprManifest(manifest: FrameworkRuntime): void {
   manifest.pages.dashboard.ppr = {
     delivery: "merge",
     shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -284,7 +276,6 @@ function configurePprManifest(manifest: BuildOutput): void {
       hero: {
         id: "hero",
         assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
-        component: "./src/pages/Hero.region.tsx",
       },
     },
   };
@@ -297,7 +288,7 @@ function configurePprManifest(manifest: BuildOutput): void {
   };
 }
 
-function configureRscManifest(manifest: BuildOutput): void {
+function configureRscManifest(manifest: FrameworkRuntime): void {
   manifest.pages.dashboard.componentModel = "rsc";
   manifest.pages.dashboard.rendering = {
     component: "rsc",
@@ -306,7 +297,6 @@ function configureRscManifest(manifest: BuildOutput): void {
     hydrate: "none",
   };
   manifest.rsc = {
-    endpoint: "/__evjs/rsc",
     pages: {
       dashboard: {
         renderer: "dashboard-rsc",
@@ -324,7 +314,6 @@ function configureRscManifest(manifest: BuildOutput): void {
   renderers["dashboard-rsc"] = {
     kind: "rsc-page",
     owner: { pageId: "dashboard" },
-    module: "./src/pages/Dashboard.tsx",
     assets: { js: ["dashboard-rsc.js"], css: [] },
   };
 }

--- a/packages/server/tests/react-renderer.test.ts
+++ b/packages/server/tests/react-renderer.test.ts
@@ -1,8 +1,4 @@
 import {
-  assertFrameworkManifestShape,
-  type BuildOutput,
-} from "@evjs/shared/manifest";
-import {
   createContext,
   createElement,
   lazy,
@@ -11,6 +7,10 @@ import {
   useContext,
 } from "react";
 import { describe, expect, it } from "vitest";
+import {
+  assertFrameworkRuntime,
+  type FrameworkRuntime,
+} from "../src/framework.js";
 import {
   createReactRscFlightAdapter,
   createReactServerRenderAdapter,
@@ -78,7 +78,7 @@ describe("createReactServerRenderAdapter", () => {
       },
       {
         request: new Request("https://example.com/dashboard"),
-        manifest: createManifest(),
+        runtime: createManifest(),
         pageId: "dashboard",
         page: {
           assets: { js: ["dashboard.js"], css: ["dashboard.css"] },
@@ -104,7 +104,7 @@ describe("createReactServerRenderAdapter", () => {
         "<body>",
         '<div id="root"><h1>Page <!-- -->dashboard</h1></div>',
         '<script id="__EVJS_PAGE_PROPS__" type="application/json">',
-        '{"manifest":{"buildId":"test"},"pageId":"dashboard"}',
+        '{"runtime":{"buildId":"test"},"pageId":"dashboard"}',
         "</script>",
         '<script defer src="/assets/dashboard.js"></script>',
         "</body>",
@@ -123,7 +123,7 @@ describe("createReactServerRenderAdapter", () => {
       },
       {
         request: new Request("https://example.com/dashboard"),
-        manifest: {
+        runtime: {
           ...createManifest(),
           publicPath: "auto",
         },
@@ -177,7 +177,7 @@ describe("createReactServerRenderAdapter", () => {
       },
       {
         request: new Request("https://example.com/dashboard"),
-        manifest: createManifest(),
+        runtime: createManifest(),
         pageId: "dashboard",
         page: {
           assets: { js: ["dashboard.js"], css: [] },
@@ -201,7 +201,7 @@ describe("createReactServerRenderAdapter", () => {
     expect(result.html).not.toContain("loading");
   });
 
-  it("does not embed framework manifest internals in default hydration props", async () => {
+  it("does not embed framework runtime internals in default hydration props", async () => {
     const adapter = createReactServerRenderAdapter();
     const manifest = createManifest();
     manifest.pages.dashboard = {
@@ -213,13 +213,11 @@ describe("createReactServerRenderAdapter", () => {
         streaming: false,
         hydrate: "load",
       },
-      component: "./src/pages/Dashboard.tsx",
     };
     manifest.routes.push({
       id: "dashboard",
       path: "/dashboard",
       pageId: "dashboard",
-      module: "./src/pages/Dashboard.tsx",
     });
 
     const result = await adapter(
@@ -230,7 +228,7 @@ describe("createReactServerRenderAdapter", () => {
       },
       {
         request: new Request("https://example.com/dashboard"),
-        manifest,
+        runtime: manifest,
         pageId: "dashboard",
         page: manifest.pages.dashboard,
         route: manifest.routes[0],
@@ -242,7 +240,7 @@ describe("createReactServerRenderAdapter", () => {
     }
 
     expect(result.html).toContain(
-      '<script id="__EVJS_PAGE_PROPS__" type="application/json">{"manifest":{"buildId":"test"},"route":{"id":"dashboard","path":"/dashboard"},"pageId":"dashboard"}</script>',
+      '<script id="__EVJS_PAGE_PROPS__" type="application/json">{"runtime":{"buildId":"test"},"route":{"id":"dashboard","path":"/dashboard"},"pageId":"dashboard"}</script>',
     );
     expect(result.html).not.toContain("Dashboard.tsx");
     expect(result.html).not.toContain('"assets"');
@@ -266,7 +264,7 @@ describe("createReactServerRenderAdapter", () => {
         },
         {
           request: new Request("https://example.com/dashboard"),
-          manifest: createManifest(),
+          runtime: createManifest(),
           pageId: "dashboard",
         },
       ),
@@ -287,13 +285,11 @@ describe("createReactServerRenderAdapter", () => {
         streaming: false,
         hydrate: "load",
       },
-      component: "./src/pages/posts/$postId.tsx",
     };
     manifest.routes.push({
       id: "post",
       path: "/posts/$postId",
       pageId: "post",
-      module: "./src/pages/posts/$postId.tsx",
     });
     let renderedProps: Record<string, unknown> | undefined;
     function PostPage(props: Record<string, unknown>) {
@@ -316,7 +312,7 @@ describe("createReactServerRenderAdapter", () => {
         request: new Request(
           "https://example.com/posts/42?tab=comments&tag=a&tag=b",
         ),
-        manifest,
+        runtime: manifest,
         pageId: "post",
         page: manifest.pages.post,
         route: manifest.routes[0],
@@ -329,13 +325,13 @@ describe("createReactServerRenderAdapter", () => {
 
     expect(result.html).toContain("<h1>42:comments:a,b</h1>");
     expect(renderedProps).toEqual({
-      manifest: { buildId: "test" },
+      runtime: { buildId: "test" },
       route: { id: "post", path: "/posts/$postId" },
       pageId: "post",
     });
   });
 
-  it("uses the most specific manifest route for server page hooks", async () => {
+  it("uses the most specific runtime route for server page hooks", async () => {
     const adapter = createReactServerRenderAdapter();
     const manifest = createManifest();
     manifest.pages.profile = {
@@ -347,20 +343,17 @@ describe("createReactServerRenderAdapter", () => {
         streaming: false,
         hydrate: "load",
       },
-      component: "./src/pages/Profile.tsx",
     };
     manifest.routes.push(
       {
         id: "user",
         path: "/users/$userId",
         pageId: "profile",
-        module: "./src/pages/Profile.tsx",
       },
       {
         id: "settings",
         path: "/users/settings",
         pageId: "profile",
-        module: "./src/pages/Profile.tsx",
       },
     );
     function ProfilePage() {
@@ -380,7 +373,7 @@ describe("createReactServerRenderAdapter", () => {
       },
       {
         request: new Request("https://example.com/users/settings?tab=account"),
-        manifest,
+        runtime: manifest,
         pageId: "profile",
         page: manifest.pages.profile,
       },
@@ -405,13 +398,11 @@ describe("createReactServerRenderAdapter", () => {
         streaming: false,
         hydrate: "load",
       },
-      component: "./src/pages/posts/[postId].tsx",
     };
     manifest.routes.push({
       id: "post",
       path: "/posts/:postId",
       pageId: "post",
-      module: "./src/pages/posts/[postId].tsx",
     });
     function PostPage() {
       const { postId } = usePageParams<{ postId: string }>();
@@ -425,7 +416,7 @@ describe("createReactServerRenderAdapter", () => {
       },
       {
         request: new Request("https://example.com/posts/42"),
-        manifest,
+        runtime: manifest,
         pageId: "post",
         page: manifest.pages.post,
         route: manifest.routes[0],
@@ -451,13 +442,11 @@ describe("createReactServerRenderAdapter", () => {
         streaming: false,
         hydrate: "load",
       },
-      component: "./src/pages/docs.tsx",
     };
     manifest.routes.push({
       id: "docs-fallback",
       path: "/docs/*",
       pageId: "docs",
-      module: "./src/pages/docs.tsx",
     });
     function DocsPage() {
       const { _splat } = usePageParams<{ _splat: string }>();
@@ -471,7 +460,7 @@ describe("createReactServerRenderAdapter", () => {
       },
       {
         request: new Request("https://example.com/docs/guides/install"),
-        manifest,
+        runtime: manifest,
         pageId: "docs",
         page: manifest.pages.docs,
         route: manifest.routes[0],
@@ -518,7 +507,7 @@ describe("createReactServerRenderAdapter", () => {
       },
       {
         request: new Request("https://example.com/posts/42?tab=ignored"),
-        manifest: createManifest(),
+        runtime: createManifest(),
         pageId: "post",
       },
     );
@@ -536,12 +525,10 @@ describe("createReactServerRenderAdapter", () => {
       rsc: "/__evjs/rsc",
     };
     manifest.rsc = {
-      endpoint: "/__evjs/rsc",
       pages: {
         insights: {
           renderer: "insights-rsc",
           assets: { js: ["insights-rsc.js"], css: [] },
-          component: "./src/pages/Insights.tsx",
         },
       },
     };
@@ -555,7 +542,6 @@ describe("createReactServerRenderAdapter", () => {
         streaming: true,
         hydrate: "none",
       },
-      component: "./src/pages/Insights.tsx",
       mount: "#app",
     };
     assertRendererTestManifestShape(manifest);
@@ -568,7 +554,7 @@ describe("createReactServerRenderAdapter", () => {
       },
       {
         request: new Request("https://example.com/insights"),
-        manifest,
+        runtime: manifest,
         pageId: "insights",
         page: manifest.pages.insights,
       },
@@ -602,7 +588,7 @@ describe("createReactServerRenderAdapter", () => {
         { value: "not a component" },
         {
           request: new Request("https://example.com/dashboard"),
-          manifest: createManifest(),
+          runtime: createManifest(),
         },
       ),
     ).resolves.toBeUndefined();
@@ -614,7 +600,7 @@ describe("createReactServerRenderAdapter", () => {
     await expect(
       adapter(null as never, {
         request: new Request("https://example.com/dashboard"),
-        manifest: createManifest(),
+        runtime: createManifest(),
       }),
     ).rejects.toThrow(
       "[evjs] createReactServerRenderAdapter() module must be a renderer module object.",
@@ -642,7 +628,7 @@ describe("createReactServerRenderAdapter", () => {
       },
       {
         request: new Request("https://example.com/dashboard"),
-        manifest: createManifest(),
+        runtime: createManifest(),
         pageId: "dashboard",
       },
     );
@@ -669,7 +655,7 @@ describe("createReactServerRenderAdapter", () => {
         },
         {
           request: new Request("https://example.com/dashboard"),
-          manifest: createManifest(),
+          runtime: createManifest(),
           pageId: "dashboard",
         },
       ),
@@ -694,7 +680,7 @@ describe("createReactServerRenderAdapter", () => {
         },
         {
           request: new Request("https://example.com/dashboard"),
-          manifest: createManifest(),
+          runtime: createManifest(),
           pageId: "dashboard",
         },
       ),
@@ -719,7 +705,7 @@ describe("createReactServerRenderAdapter", () => {
         },
         {
           request: new Request("https://example.com/dashboard"),
-          manifest: createManifest(),
+          runtime: createManifest(),
           pageId: "dashboard",
         },
       ),
@@ -780,30 +766,19 @@ describe("createReactRscFlightAdapter", () => {
       },
     };
     manifest.server = {
-      assets: { js: ["server.js"], css: [] },
-      functions: {},
-      routes: [],
       renderers: {
         "dashboard-rsc": {
           kind: "rsc-page",
           owner: { pageId: "dashboard" },
-          module: "./src/pages/Dashboard.tsx",
           assets: { js: ["dashboard-rsc.js"], css: [] },
         },
       },
     };
     manifest.rsc = {
-      endpoint: "/__evjs/rsc",
       pages: {
         dashboard: {
           renderer: "dashboard-rsc",
           assets: { js: ["dashboard-rsc.js"], css: [] },
-        },
-      },
-      clientReferences: {
-        "src/Client.tsx#default": {
-          module: "src/Client.tsx",
-          exportName: "default",
         },
       },
     };
@@ -826,7 +801,7 @@ describe("createReactRscFlightAdapter", () => {
 
     const response = await adapter.renderFlight({
       request: new Request("https://example.com/__evjs/rsc?page=dashboard"),
-      manifest,
+      runtime: manifest,
       pageId: "dashboard",
       page: manifest.pages.dashboard,
       rscPage: manifest.rsc.pages?.dashboard,
@@ -849,7 +824,7 @@ describe("createReactRscFlightAdapter", () => {
 
     const response = await adapter.renderFlight({
       request: new Request("https://example.com/__evjs/rsc?page=dashboard"),
-      manifest,
+      runtime: manifest,
       pageId: "dashboard",
     });
 
@@ -875,7 +850,7 @@ describe("createReactRscFlightAdapter", () => {
 
     const response = await adapter.renderFlight({
       request: new Request("https://example.com/__evjs/rsc?page=dashboard"),
-      manifest,
+      runtime: manifest,
       pageId: "dashboard",
     });
 
@@ -893,7 +868,7 @@ describe("createReactRscFlightAdapter", () => {
 
     const response = await adapter.renderFlight({
       request: new Request("https://example.com/__evjs/rsc?page=dashboard"),
-      manifest,
+      runtime: manifest,
       pageId: "dashboard",
     });
 
@@ -917,7 +892,7 @@ describe("createReactRscFlightAdapter", () => {
 
     const response = await adapter.renderFlight({
       request: new Request("https://example.com/__evjs/rsc?page=dashboard"),
-      manifest,
+      runtime: manifest,
       pageId: "dashboard",
     });
 
@@ -936,7 +911,7 @@ describe("createReactRscFlightAdapter", () => {
 
     const lookalikeResponse = await lookalikeAdapter.renderFlight({
       request: new Request("https://example.com/__evjs/rsc?page=dashboard"),
-      manifest,
+      runtime: manifest,
       pageId: "dashboard",
     });
 
@@ -956,7 +931,7 @@ describe("createReactRscFlightAdapter", () => {
 
     const response = await adapter.renderFlight({
       request: new Request("https://example.com/__evjs/rsc?page=dashboard"),
-      manifest,
+      runtime: manifest,
       pageId: "dashboard",
     });
 
@@ -981,7 +956,7 @@ describe("createReactRscFlightAdapter", () => {
 
     const response = await adapter.renderFlight({
       request: new Request("https://example.com/__evjs/rsc?page=dashboard"),
-      manifest,
+      runtime: manifest,
       pageId: "dashboard",
     });
 
@@ -995,7 +970,6 @@ describe("createReactRscFlightAdapter", () => {
     const renderer = {
       kind: "rsc-page" as const,
       owner: { pageId: "dashboard" },
-      module: "./src/pages/Dashboard.tsx",
       assets: { js: ["dashboard-rsc.js"], css: [] },
     };
     const adapter = createReactRscFlightAdapter({
@@ -1013,7 +987,7 @@ describe("createReactRscFlightAdapter", () => {
 
     const response = await adapter.renderFlight({
       request: new Request("https://example.com/__evjs/rsc?page=dashboard"),
-      manifest,
+      runtime: manifest,
       pageId: "dashboard",
       rscPage: {
         renderer: "dashboard-rsc",
@@ -1033,7 +1007,6 @@ describe("createReactRscFlightAdapter", () => {
     const renderer = {
       kind: "rsc-page" as const,
       owner: { pageId: "dashboard" },
-      module: "./src/pages/Dashboard.tsx",
       assets: { js: ["dashboard-rsc.js"], css: [] },
     };
     const adapter = createReactRscFlightAdapter({
@@ -1044,7 +1017,7 @@ describe("createReactRscFlightAdapter", () => {
 
     const response = await adapter.renderFlight({
       request: new Request("https://example.com/__evjs/rsc?page=dashboard"),
-      manifest,
+      runtime: manifest,
       pageId: "dashboard",
       rscPage: {
         renderer: "dashboard-rsc",
@@ -1071,7 +1044,7 @@ describe("createReactRscFlightAdapter", () => {
 
     const response = await adapter.renderFlight({
       request: new Request("https://example.com/__evjs/rsc?page=dashboard"),
-      manifest,
+      runtime: manifest,
       pageId: "dashboard",
     });
     const text = await response.text();
@@ -1106,7 +1079,7 @@ describe("createReactRscFlightAdapter", () => {
 
     const response = await adapter.renderFlight({
       request: new Request("https://example.com/__evjs/rsc?page=dashboard"),
-      manifest,
+      runtime: manifest,
       pageId: "dashboard",
     });
     const text = await response.text();
@@ -1121,11 +1094,10 @@ describe("createReactRscFlightAdapter", () => {
   });
 });
 
-function createManifest(): BuildOutput {
+function createManifest(): FrameworkRuntime {
   return {
     version: 1,
     buildId: "test",
-    distDir: "dist",
     publicPath: "/assets/",
     runtime: {
       server: {
@@ -1133,24 +1105,12 @@ function createManifest(): BuildOutput {
         fn: "/__evjs/fn",
       },
     },
-    assets: {},
-    apps: {},
     pages: {},
     routes: [],
-    server: {
-      entry: "server.js",
-      assets: { js: ["server.js"], css: [] },
-      functions: {},
-      routes: [],
-    },
+    server: {},
   };
 }
 
-function assertRendererTestManifestShape(manifest: BuildOutput): void {
-  assertFrameworkManifestShape(manifest, "react renderer test manifest", {
-    serverFunctionModules: "optional",
-    pageRendererReferences: "optional",
-    pprRendererReferences: "optional",
-    rscRendererReferences: "optional",
-  });
+function assertRendererTestManifestShape(manifest: FrameworkRuntime): void {
+  assertFrameworkRuntime(manifest, "react renderer test runtime");
 }

--- a/packages/shared/src/manifest/index.ts
+++ b/packages/shared/src/manifest/index.ts
@@ -324,10 +324,23 @@ export interface BuildOutput {
 }
 
 export interface FrameworkManifestValidationOptions {
+  server?: "required" | "optional";
   serverFunctionModules?: "required" | "optional";
   pageRendererReferences?: "required" | "optional";
   pprRendererReferences?: "required" | "optional";
   rscRendererReferences?: "required" | "optional";
+}
+
+export interface PublicManifestOutput {
+  version: 1;
+  buildId: string;
+  publicPath: PublicPathOutput;
+  runtime: RuntimeOutput;
+  assets?: Record<string, AssetGroup>;
+  apps: Record<string, PublicAppOutput>;
+  pages: Record<string, PublicPageOutput>;
+  routes: PublicRouteOutput[];
+  rsc?: PublicRscOutput;
 }
 
 export interface BuildOutputPaths {
@@ -360,6 +373,10 @@ export interface AppOutput {
   module?: RuntimeModuleOutput;
 }
 
+export interface PublicAppOutput extends Omit<AppOutput, "entry" | "module"> {
+  module?: PublicRuntimeModuleOutput;
+}
+
 export interface PageOutput {
   assets: AssetGroup;
   document?: HtmlDocumentOutput;
@@ -376,6 +393,12 @@ export interface PageOutput {
   prerender?: PrerenderConfig;
   module?: RuntimeModuleOutput;
   ppr?: PprPageOutput;
+}
+
+export interface PublicPageOutput
+  extends Omit<PageOutput, "entry" | "component" | "app" | "module" | "ppr"> {
+  module?: PublicRuntimeModuleOutput;
+  ppr?: PublicPprPageOutput;
 }
 
 export interface HtmlDocumentOutput {
@@ -401,6 +424,10 @@ export interface PprPageOutput {
   regions: Record<string, PprRegionOutput>;
 }
 
+export interface PublicPprPageOutput extends Omit<PprPageOutput, "regions"> {
+  regions: Record<string, PublicPprRegionOutput>;
+}
+
 export interface PprRegionOutput {
   id: string;
   assets: AssetGroup;
@@ -410,11 +437,18 @@ export interface PprRegionOutput {
   hydrate?: HydrationMode;
 }
 
+export type PublicPprRegionOutput = Omit<
+  PprRegionOutput,
+  "component" | "fallback"
+>;
+
 export interface RuntimeModuleOutput {
   type: "entry" | "lifecycle" | "react-component";
   href?: string;
   source?: string;
 }
+
+export type PublicRuntimeModuleOutput = Omit<RuntimeModuleOutput, "source">;
 
 export interface RouteOutput {
   id: string;
@@ -428,6 +462,8 @@ export interface RouteOutput {
   hydrate?: HydrationMode;
   runtime?: ServerRuntime;
 }
+
+export type PublicRouteOutput = Omit<RouteOutput, "module">;
 
 export interface ServerOutput {
   entry?: string;
@@ -465,12 +501,19 @@ export interface RscOutput {
   serverConsumerManifest?: Record<string, unknown>;
 }
 
+export interface PublicRscOutput {
+  endpoint?: string;
+  pages?: Record<string, PublicRscPageOutput>;
+}
+
 export interface RscPageOutput {
   renderer: string;
   assets: AssetGroup;
   component?: string;
   routeId?: string;
 }
+
+export type PublicRscPageOutput = Omit<RscPageOutput, "component">;
 
 export interface RscReferenceOutput {
   module: string;
@@ -665,8 +708,24 @@ function joinPaths(parent: string, child: string): string {
 export function assertFrameworkManifestShape(
   value: unknown,
   source: string,
+  options?: FrameworkManifestValidationOptions & { server?: "required" },
+): asserts value is BuildOutput;
+export function assertFrameworkManifestShape(
+  value: unknown,
+  source: string,
+  options: FrameworkManifestValidationOptions & { server: "optional" },
+): asserts value is PublicManifestOutput;
+export function assertFrameworkManifestShape(
+  value: unknown,
+  source: string,
+  options?: FrameworkManifestValidationOptions,
+): asserts value is BuildOutput | PublicManifestOutput;
+export function assertFrameworkManifestShape(
+  value: unknown,
+  source: string,
   options: FrameworkManifestValidationOptions = {},
-): asserts value is BuildOutput {
+): asserts value is BuildOutput | PublicManifestOutput {
+  const requireServer = options.server !== "optional";
   const requireServerFunctionModules =
     options.serverFunctionModules !== "optional";
   const requirePageRendererReferences =
@@ -680,14 +739,22 @@ export function assertFrameworkManifestShape(
     throw new Error(`[evjs] ${source}.version must be 1.`);
   }
   assertManifestBuildId(value.buildId, `${source}.buildId`);
-  assertManifestString(value.distDir, `${source}.distDir`);
+  if (value.distDir === undefined) {
+    if (requireServer) {
+      throw new Error(`[evjs] ${source}.distDir must be a non-empty string.`);
+    }
+  } else {
+    assertManifestString(value.distDir, `${source}.distDir`);
+  }
   assertPublicPathOutput(value.publicPath, `${source}.publicPath`);
   if (value.paths !== undefined) {
     assertBuildOutputPaths(value.paths, `${source}.paths`);
   }
   assertObject(value.runtime, `${source}.runtime`);
-  assertObject(value.assets, `${source}.assets`);
-  assertAssetGroupRecord(value.assets, `${source}.assets`);
+  if (value.assets !== undefined) {
+    assertObject(value.assets, `${source}.assets`);
+    assertAssetGroupRecord(value.assets, `${source}.assets`);
+  }
   assertObject(value.apps, `${source}.apps`);
   assertAppOutputs(value.apps, `${source}.apps`);
   assertObject(value.pages, `${source}.pages`);
@@ -723,41 +790,48 @@ export function assertFrameworkManifestShape(
       `${source}.runtime.transport.baseUrl`,
     );
   }
-  assertObject(value.server, `${source}.server`);
-  if (value.server.entry !== undefined) {
-    assertManifestString(value.server.entry, `${source}.server.entry`);
-  }
-  if (value.server.renderers !== undefined) {
-    assertObject(value.server.renderers, `${source}.server.renderers`);
-    assertServerRendererOutputs(
-      value.server.renderers,
-      `${source}.server.renderers`,
-      value.pages,
-      value.routes,
+  if (value.server === undefined) {
+    if (requireServer) {
+      throw new Error(`[evjs] ${source}.server must be an object.`);
+    }
+  } else {
+    assertObject(value.server, `${source}.server`);
+    if (value.server.entry !== undefined) {
+      assertManifestString(value.server.entry, `${source}.server.entry`);
+    }
+    if (value.server.renderers !== undefined) {
+      assertObject(value.server.renderers, `${source}.server.renderers`);
+      assertServerRendererOutputs(
+        value.server.renderers,
+        `${source}.server.renderers`,
+        value.pages,
+        value.routes,
+      );
+    }
+    assertAssetGroup(value.server.assets, `${source}.server.assets`);
+    assertObject(value.server.functions, `${source}.server.functions`);
+    assertServerFunctionOutputs(
+      value.server.functions,
+      `${source}.server.functions`,
+      requireServerFunctionModules,
     );
+    if (!Array.isArray(value.server.routes)) {
+      throw new Error(`[evjs] ${source}.server.routes must be an array.`);
+    }
+    assertServerRouteOutputs(value.server.routes, `${source}.server.routes`);
   }
-  assertAssetGroup(value.server.assets, `${source}.server.assets`);
-  assertObject(value.server.functions, `${source}.server.functions`);
-  assertServerFunctionOutputs(
-    value.server.functions,
-    `${source}.server.functions`,
-    requireServerFunctionModules,
-  );
-  if (!Array.isArray(value.server.routes)) {
-    throw new Error(`[evjs] ${source}.server.routes must be an array.`);
-  }
-  assertServerRouteOutputs(value.server.routes, `${source}.server.routes`);
+  const serverRenderers = getServerRendererOutputs(value.server);
   assertPageServerRendererReferences(
     value.pages,
     `${source}.pages`,
-    getServerRendererOutputs(value.server),
+    serverRenderers,
     value.routes,
     requirePageRendererReferences,
   );
   assertPprPageOutputReferences(
     value.pages,
     `${source}.pages`,
-    getServerRendererOutputs(value.server),
+    serverRenderers,
     requirePprRendererReferences,
   );
   if (value.rsc !== undefined) {
@@ -765,7 +839,7 @@ export function assertFrameworkManifestShape(
       value.rsc,
       `${source}.rsc`,
       value.pages,
-      getServerRendererOutputs(value.server),
+      serverRenderers,
       value.routes,
       requireRscRendererReferences,
     );
@@ -1919,7 +1993,7 @@ export {
   createPublicManifest,
   createServerManifest,
   linkBuildOutput,
-  type ServerManifestFnOutput,
+  type ServerManifestFunctionOutput,
   type ServerManifestOutput,
   type ServerManifestRouteOutput,
 } from "./linker.js";

--- a/packages/shared/src/manifest/index.ts
+++ b/packages/shared/src/manifest/index.ts
@@ -335,7 +335,6 @@ export interface PublicManifestOutput {
   version: 1;
   buildId: string;
   publicPath: PublicPathOutput;
-  runtime: RuntimeOutput;
   assets?: Record<string, AssetGroup>;
   apps: Record<string, PublicAppOutput>;
   pages: Record<string, PublicPageOutput>;
@@ -445,10 +444,9 @@ export type PublicPprRegionOutput = Omit<
 export interface RuntimeModuleOutput {
   type: "entry" | "lifecycle" | "react-component";
   href?: string;
-  source?: string;
 }
 
-export type PublicRuntimeModuleOutput = Omit<RuntimeModuleOutput, "source">;
+export type PublicRuntimeModuleOutput = RuntimeModuleOutput;
 
 export interface RouteOutput {
   id: string;
@@ -458,12 +456,12 @@ export interface RouteOutput {
   appId?: string;
   pageId?: string;
   module?: string;
-  render?: RenderMode;
-  hydrate?: HydrationMode;
-  runtime?: ServerRuntime;
 }
 
-export type PublicRouteOutput = Omit<RouteOutput, "module">;
+export type PublicRouteOutput = Pick<
+  RouteOutput,
+  "id" | "path" | "appId" | "pageId"
+>;
 
 export interface ServerOutput {
   entry?: string;
@@ -750,7 +748,13 @@ export function assertFrameworkManifestShape(
   if (value.paths !== undefined) {
     assertBuildOutputPaths(value.paths, `${source}.paths`);
   }
-  assertObject(value.runtime, `${source}.runtime`);
+  if (value.runtime === undefined) {
+    if (requireServer) {
+      throw new Error(`[evjs] ${source}.runtime must be an object.`);
+    }
+  } else {
+    assertObject(value.runtime, `${source}.runtime`);
+  }
   if (value.assets !== undefined) {
     assertObject(value.assets, `${source}.assets`);
     assertAssetGroupRecord(value.assets, `${source}.assets`);
@@ -764,31 +768,33 @@ export function assertFrameworkManifestShape(
   }
   assertRouteOutputs(value.routes, `${source}.routes`, value.pages, value.apps);
 
-  assertObject(value.runtime.server, `${source}.runtime.server`);
-  assertManifestPathname(
-    value.runtime.server.basePath,
-    `${source}.runtime.server.basePath`,
-    true,
-  );
-  assertManifestPathname(
-    value.runtime.server.fn,
-    `${source}.runtime.server.fn`,
-    true,
-  );
-  assertManifestPathname(
-    value.runtime.server.ppr,
-    `${source}.runtime.server.ppr`,
-  );
-  assertManifestPathname(
-    value.runtime.server.rsc,
-    `${source}.runtime.server.rsc`,
-  );
-  if (value.runtime.transport !== undefined) {
-    assertObject(value.runtime.transport, `${source}.runtime.transport`);
-    assertManifestTransportBaseUrl(
-      value.runtime.transport.baseUrl,
-      `${source}.runtime.transport.baseUrl`,
+  if (value.runtime !== undefined) {
+    assertObject(value.runtime.server, `${source}.runtime.server`);
+    assertManifestPathname(
+      value.runtime.server.basePath,
+      `${source}.runtime.server.basePath`,
+      true,
     );
+    assertManifestPathname(
+      value.runtime.server.fn,
+      `${source}.runtime.server.fn`,
+      true,
+    );
+    assertManifestPathname(
+      value.runtime.server.ppr,
+      `${source}.runtime.server.ppr`,
+    );
+    assertManifestPathname(
+      value.runtime.server.rsc,
+      `${source}.runtime.server.rsc`,
+    );
+    if (value.runtime.transport !== undefined) {
+      assertObject(value.runtime.transport, `${source}.runtime.transport`);
+      assertManifestTransportBaseUrl(
+        value.runtime.transport.baseUrl,
+        `${source}.runtime.transport.baseUrl`,
+      );
+    }
   }
   if (value.server === undefined) {
     if (requireServer) {
@@ -1127,9 +1133,6 @@ function assertRuntimeModuleOutput(value: unknown, source: string): void {
   assertObject(value, source);
   assertRuntimeModuleType(value.type, `${source}.type`);
   assertManifestString(value.href, `${source}.href`);
-  if (value.source !== undefined) {
-    assertManifestString(value.source, `${source}.source`);
-  }
 }
 
 function assertRuntimeModuleType(value: unknown, source: string): void {
@@ -1204,11 +1207,6 @@ function assertHydrationMode(value: unknown, source: string): void {
   throw new Error(
     `[evjs] ${source} must be "none", "load", "visible", or "idle".`,
   );
-}
-
-function assertServerRuntime(value: unknown, source: string): void {
-  if (value === "node" || value === "edge") return;
-  throw new Error(`[evjs] ${source} must be "node" or "edge".`);
 }
 
 function assertRscPageOutputContract(
@@ -1325,15 +1323,6 @@ function assertRouteOutputs(
     if (route.module !== undefined) {
       assertManifestString(route.module, `${routeSource}.module`);
     }
-    if (route.render !== undefined) {
-      assertRenderMode(route.render, `${routeSource}.render`);
-    }
-    if (route.hydrate !== undefined) {
-      assertHydrationMode(route.hydrate, `${routeSource}.hydrate`);
-    }
-    if (route.runtime !== undefined) {
-      assertServerRuntime(route.runtime, `${routeSource}.runtime`);
-    }
     if (page) {
       assertPageRouteOutputContract(route, page, routeSource);
     }
@@ -1352,11 +1341,6 @@ function assertPageRouteOutputContract(
   ) {
     throw new Error(
       `[evjs] ${routeSource}.path "${route.path as string}" must match manifest.pages.${route.pageId as string}.path "${page.path}".`,
-    );
-  }
-  if (route.render !== undefined && route.render !== page.render) {
-    throw new Error(
-      `[evjs] ${routeSource}.render must match manifest.pages.${route.pageId as string}.render "${page.render as string}".`,
     );
   }
 }

--- a/packages/shared/src/manifest/linker.ts
+++ b/packages/shared/src/manifest/linker.ts
@@ -11,6 +11,11 @@ import type {
   PageOutput,
   PageRenderingOutput,
   PprRegionOutput,
+  PublicAppOutput,
+  PublicManifestOutput,
+  PublicPageOutput,
+  PublicPprRegionOutput,
+  PublicRuntimeModuleOutput,
   RscReferenceOutput,
   RuntimeModuleOutput,
   ServerFunctionOutput,
@@ -49,11 +54,11 @@ export interface ServerManifestOutput {
   version: 1;
   entry?: string;
   assets: AssetGroup;
-  fns: Record<string, ServerManifestFnOutput>;
-  routes?: ServerManifestRouteOutput[];
+  functions: Record<string, ServerManifestFunctionOutput>;
+  routes: ServerManifestRouteOutput[];
 }
 
-export interface ServerManifestFnOutput {
+export interface ServerManifestFunctionOutput {
   assets: AssetGroup;
 }
 
@@ -387,13 +392,13 @@ function assertServerRuntimeEntry(
  * needs those facts. The public manifest must not expose that implementation
  * metadata.
  */
-export function createPublicManifest(output: BuildOutput): BuildOutput {
+export function createPublicManifest(
+  output: BuildOutput,
+): PublicManifestOutput {
   const publicAssetFiles = collectPublicAssetFiles(output);
   return pruneUndefined({
     version: output.version,
     buildId: output.buildId,
-    distDir: output.distDir,
-    paths: output.paths,
     publicPath: output.publicPath,
     runtime: output.runtime,
     assets: clonePublicAssetRecord(output.assets, publicAssetFiles),
@@ -420,25 +425,6 @@ export function createPublicManifest(output: BuildOutput): BuildOutput {
         runtime: route.runtime,
       }),
     ),
-    server: pruneUndefined({
-      assets: clonePublicAssets(output.server.assets, publicAssetFiles),
-      functions: Object.fromEntries(
-        Object.entries(output.server.functions).map(([id, fn]) => [
-          id,
-          pruneUndefined({
-            assets: clonePublicAssets(fn.assets, publicAssetFiles),
-            exportName: fn.exportName,
-          }),
-        ]),
-      ),
-      routes: output.server.routes.map((route) =>
-        pruneUndefined({
-          path: route.path,
-          methods: [...route.methods],
-          assets: clonePublicAssets(route.assets, publicAssetFiles),
-        }),
-      ),
-    }),
     rsc: output.rsc
       ? pruneUndefined({
           endpoint: output.rsc.endpoint,
@@ -456,10 +442,7 @@ export function createPublicManifest(output: BuildOutput): BuildOutput {
             : undefined,
         })
       : undefined,
-    deployment: output.deployment
-      ? sanitizePublicMetadata(output.deployment)
-      : undefined,
-  }) as BuildOutput;
+  }) as PublicManifestOutput;
 }
 
 export function createServerManifest(
@@ -475,13 +458,13 @@ export function createServerManifest(
     version: 1,
     ...(output.server.entry ? { entry: output.server.entry } : {}),
     assets: cloneAssets(output.server.assets),
-    fns: Object.fromEntries(
+    functions: Object.fromEntries(
       Object.entries(output.server.functions).map(([id, fn]) => [
         id,
         { assets: cloneAssets(fn.assets) },
       ]),
     ),
-    ...(routes.length > 0 ? { routes } : {}),
+    routes,
   };
 }
 
@@ -495,19 +478,19 @@ function createBuildOutputPaths(
   };
 }
 
-function sanitizeAppOutput(app: AppOutput): AppOutput {
+function sanitizeAppOutput(app: AppOutput): PublicAppOutput {
   return pruneUndefined({
     assets: cloneAssets(app.assets),
     document: cloneHtmlDocument(app.document),
     mount: app.mount,
     module: sanitizeRuntimeModule(app.module),
-  }) as AppOutput;
+  }) as PublicAppOutput;
 }
 
 function sanitizePageOutput(
   page: PageOutput,
   publicAssetFiles: Set<string>,
-): PageOutput {
+): PublicPageOutput {
   return pruneUndefined({
     assets: clonePublicAssets(page.assets, publicAssetFiles),
     document: cloneHtmlDocument(page.document),
@@ -532,7 +515,7 @@ function sanitizePageOutput(
           ),
         }
       : undefined,
-  }) as PageOutput;
+  }) as PublicPageOutput;
 }
 
 function createHtmlDocumentLookup(html: BuildPlan["html"]): {
@@ -563,23 +546,23 @@ function cloneHtmlDocument(
 function sanitizePprRegion(
   region: PprRegionOutput,
   publicAssetFiles: Set<string>,
-): PprRegionOutput {
+): PublicPprRegionOutput {
   return pruneUndefined({
     id: region.id,
     assets: clonePublicAssets(region.assets, publicAssetFiles),
     cache: region.cache,
     hydrate: region.hydrate,
-  }) as PprRegionOutput;
+  }) as PublicPprRegionOutput;
 }
 
 function sanitizeRuntimeModule(
   module: RuntimeModuleOutput | undefined,
-): RuntimeModuleOutput | undefined {
+): PublicRuntimeModuleOutput | undefined {
   if (!module) return undefined;
   return pruneUndefined({
     type: module.type,
     href: module.href,
-  }) as RuntimeModuleOutput;
+  }) as PublicRuntimeModuleOutput;
 }
 
 function clonePublicAssetRecord(
@@ -632,49 +615,6 @@ function mergeAssetGroups(...groups: AssetGroup[]): AssetGroup {
     js: [...new Set(groups.flatMap((group) => group.js))],
     css: [...new Set(groups.flatMap((group) => group.css))],
   };
-}
-
-function sanitizePublicMetadata(
-  value: unknown,
-  key = "",
-): Record<string, unknown> | undefined {
-  const sanitized = sanitizeMetadataValue(value, key);
-  return sanitized && typeof sanitized === "object" && !Array.isArray(sanitized)
-    ? (sanitized as Record<string, unknown>)
-    : undefined;
-}
-
-function sanitizeMetadataValue(value: unknown, key: string): unknown {
-  if (value === undefined || typeof value === "function") return undefined;
-  if (value === null) return null;
-  if (Array.isArray(value)) {
-    return value
-      .map((item) => sanitizeMetadataValue(item, key))
-      .filter((item) => item !== undefined);
-  }
-  if (typeof value === "object") {
-    return pruneUndefined(
-      Object.fromEntries(
-        Object.entries(value as Record<string, unknown>)
-          .map(([childKey, childValue]) => [
-            childKey,
-            sanitizeMetadataValue(childValue, childKey),
-          ])
-          .filter(([, childValue]) => childValue !== undefined),
-      ),
-    );
-  }
-  if (typeof value === "string" && isSourceLikeString(value, key)) {
-    return undefined;
-  }
-  return value;
-}
-
-function isSourceLikeString(value: string, key: string): boolean {
-  if (key === "href" || key === "manifest") return false;
-  if (/^file:\/\//.test(value)) return true;
-  if (/\.[cm]?tsx?(?:[?#]|$)/.test(value)) return true;
-  return /(?:^|\/)(?:Users|home|private|tmp)\//.test(value);
 }
 
 function pruneUndefined<T extends Record<string, unknown>>(value: T): T {

--- a/packages/shared/src/manifest/linker.ts
+++ b/packages/shared/src/manifest/linker.ts
@@ -17,7 +17,6 @@ import type {
   PublicPprRegionOutput,
   PublicRuntimeModuleOutput,
   RscReferenceOutput,
-  RuntimeModuleOutput,
   ServerFunctionOutput,
   ServerRouteOutput,
 } from "./index.js";
@@ -157,7 +156,6 @@ export function linkBuildOutput(input: BuildOutputLinkInput): BuildOutput {
             ? {
                 type: "entry" as const,
                 href,
-                source: app.entry,
               }
             : undefined,
         },
@@ -219,7 +217,6 @@ export function linkBuildOutput(input: BuildOutputLinkInput): BuildOutput {
                     ? ("lifecycle" as const)
                     : ("entry" as const),
                 href,
-                source: page.component ?? page.app ?? page.entry,
               }
             : undefined,
           ppr: isPartialPrerenderPage(page)
@@ -294,16 +291,15 @@ export function linkBuildOutput(input: BuildOutputLinkInput): BuildOutput {
     pages,
     routes: input.graph.routes
       .filter((route) => route.kind !== "layout")
-      .map((route) => ({
-        id: route.id,
-        path: route.path,
-        appId: route.appId,
-        pageId: route.pageId,
-        module: route.module,
-        render: route.render,
-        hydrate: route.hydrate,
-        runtime: route.runtime,
-      })),
+      .map((route) =>
+        pruneUndefined({
+          id: route.id,
+          path: route.path,
+          appId: route.appId,
+          pageId: route.pageId,
+          module: route.module,
+        }),
+      ),
     server: {
       entry: serverEntry,
       assets: serverAssets,
@@ -400,7 +396,6 @@ export function createPublicManifest(
     version: output.version,
     buildId: output.buildId,
     publicPath: output.publicPath,
-    runtime: output.runtime,
     assets: clonePublicAssetRecord(output.assets, publicAssetFiles),
     apps: Object.fromEntries(
       Object.entries(output.apps).map(([id, app]) => [
@@ -420,9 +415,6 @@ export function createPublicManifest(
         path: route.path,
         appId: route.appId,
         pageId: route.pageId,
-        render: route.render,
-        hydrate: route.hydrate,
-        runtime: route.runtime,
       }),
     ),
     rsc: output.rsc
@@ -556,7 +548,7 @@ function sanitizePprRegion(
 }
 
 function sanitizeRuntimeModule(
-  module: RuntimeModuleOutput | undefined,
+  module: PublicRuntimeModuleOutput | undefined,
 ): PublicRuntimeModuleOutput | undefined {
   if (!module) return undefined;
   return pruneUndefined({

--- a/packages/shared/tests/manifest.test.ts
+++ b/packages/shared/tests/manifest.test.ts
@@ -3418,6 +3418,7 @@ describe("createPublicManifest", () => {
 
     expect(() =>
       assertFrameworkManifestShape(manifest, "public manifest", {
+        server: "optional",
         serverFunctionModules: "optional",
         pageRendererReferences: "optional",
         pprRendererReferences: "optional",
@@ -3452,23 +3453,21 @@ describe("createPublicManifest", () => {
       assets: { js: [], css: [] },
       cache: "no-store",
     });
-    expect(manifest.server?.entry).toBeUndefined();
-    expect(manifest.server?.renderers).toBeUndefined();
-    expect(manifest.server?.functions["fn:refund"]).toEqual({
-      assets: { js: [], css: [] },
-      exportName: "refund",
-    });
-    expect(manifest.rsc?.clientReferenceManifest).toBeUndefined();
-    expect(manifest.rsc?.clientReferences).toBeUndefined();
+    expect("server" in manifest).toBe(false);
+    expect(
+      manifest.rsc ? "clientReferenceManifest" in manifest.rsc : false,
+    ).toBe(false);
+    expect(manifest.rsc ? "clientReferences" in manifest.rsc : false).toBe(
+      false,
+    );
     expect(manifest.rsc?.pages?.insights).toEqual({
       renderer: "insights-rsc",
       assets: { js: [], css: ["insights.css"] },
       routeId: "insights",
     });
-    expect(manifest.deployment).toEqual({
-      platform: "node",
-      publicAsset: "dashboard.js",
-    });
+    expect("distDir" in manifest).toBe(false);
+    expect("paths" in manifest).toBe(false);
+    expect("deployment" in manifest).toBe(false);
   });
 });
 
@@ -3508,7 +3507,7 @@ describe("createServerManifest", () => {
       version: 1,
       entry: "server.js",
       assets: { js: ["server.js"], css: ["server.css"] },
-      fns: {
+      functions: {
         "fn:getUser": {
           assets: { js: ["users.server.js"], css: [] },
         },
@@ -3528,7 +3527,8 @@ describe("createServerManifest", () => {
       version: 1,
       entry: "server.js",
       assets: { js: ["server.js"], css: [] },
-      fns: {},
+      functions: {},
+      routes: [],
     });
   });
 });

--- a/packages/shared/tests/manifest.test.ts
+++ b/packages/shared/tests/manifest.test.ts
@@ -362,27 +362,6 @@ describe("assertFrameworkManifestShape", () => {
           pages: {
             home: {
               assets: { js: [], css: [] },
-              module: {
-                type: "lifecycle",
-                href: "home.js",
-                source: "",
-              },
-            },
-          },
-        },
-        "manifest",
-      ),
-    ).toThrow(
-      "[evjs] manifest.pages.home.module.source must be a non-empty string.",
-    );
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
-          pages: {
-            home: {
-              assets: { js: [], css: [] },
               render: "spa",
               rendering: {
                 component: "client",
@@ -1304,40 +1283,6 @@ describe("assertFrameworkManifestShape", () => {
       assertFrameworkManifestShape(
         {
           ...createMinimalBuildOutput(),
-          routes: [{ id: "home", path: "/home", render: "spa" }],
-        },
-        "manifest",
-      ),
-    ).toThrow(
-      '[evjs] manifest.routes[0].render must be "csr", "ssr", or "ssg".',
-    );
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
-          routes: [{ id: "home", path: "/home", hydrate: "hover" }],
-        },
-        "manifest",
-      ),
-    ).toThrow(
-      '[evjs] manifest.routes[0].hydrate must be "none", "load", "visible", or "idle".',
-    );
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
-          routes: [{ id: "home", path: "/home", runtime: "worker" }],
-        },
-        "manifest",
-      ),
-    ).toThrow('[evjs] manifest.routes[0].runtime must be "node" or "edge".');
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
           pages: {
             home: {
               assets: { js: [], css: [] },
@@ -1357,33 +1302,6 @@ describe("assertFrameworkManifestShape", () => {
       ),
     ).toThrow(
       '[evjs] manifest.routes[0].path "/home" must match manifest.pages.home.path "/actual-home".',
-    );
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
-          pages: {
-            home: {
-              assets: { js: [], css: [] },
-              render: "csr",
-              rendering: {
-                component: "client",
-                html: "client",
-                streaming: false,
-                hydrate: "load",
-              },
-              path: "/home",
-            },
-          },
-          routes: [
-            { id: "home", path: "/home", pageId: "home", render: "ssr" },
-          ],
-        },
-        "manifest",
-      ),
-    ).toThrow(
-      '[evjs] manifest.routes[0].render must match manifest.pages.home.render "csr".',
     );
 
     expect(() =>
@@ -2706,7 +2624,6 @@ describe("linkBuildOutput", () => {
     expect(output.apps.admin.module).toEqual({
       type: "entry",
       href: "admin.js",
-      source: "./src/main.tsx",
     });
     expect(output.apps.admin.document).toEqual({ fileName: "admin.html" });
 
@@ -3295,7 +3212,6 @@ describe("createPublicManifest", () => {
           module: {
             type: "entry",
             href: "admin.js",
-            source: "./src/main.tsx",
           },
         },
       },
@@ -3317,7 +3233,6 @@ describe("createPublicManifest", () => {
           module: {
             type: "react-component",
             href: "evjs-rsc-client.js",
-            source: "./src/pages/Insights.tsx",
           },
         },
         campaign: {
@@ -3355,7 +3270,6 @@ describe("createPublicManifest", () => {
           path: "/insights",
           pageId: "insights",
           module: "./src/pages/Insights.tsx",
-          render: "ssr",
         },
       ],
       server: {
@@ -3437,6 +3351,15 @@ describe("createPublicManifest", () => {
       type: "react-component",
       href: "evjs-rsc-client.js",
     });
+    expect("runtime" in manifest).toBe(false);
+    expect(manifest.routes).toContainEqual({
+      id: "insights",
+      path: "/insights",
+      pageId: "insights",
+    });
+    expect(manifest.routes.flatMap((route) => Object.keys(route))).not.toEqual(
+      expect.arrayContaining(["module", "render", "hydrate", "runtime"]),
+    );
     expect(manifest.apps.admin.document).toEqual({ fileName: "admin.html" });
     expect(manifest.pages.insights.document).toEqual({
       fileName: "insights.html",


### PR DESCRIPTION
## Summary
- Tighten generated runtime contracts so runtime packages no longer depend on manifest/build-output shapes.
- Reduce redundant metadata in `BuildOutput`, public client manifest, and deployment artifacts.
- Clarify that client/server manifests are deployment/tooling metadata, not runtime inputs.

## Changes
- Generate `ClientRuntime` directly from `BuildOutput` with only boot/navigation fields: build id, transport/RSC endpoint, app/page module targets, mounts, and route lookup data.
- Remove public manifest `runtime`, route behavior fields, and runtime module `source`; public routes now only expose URL-to-app/page indexing.
- Remove duplicated route `render/hydrate/runtime` from `BuildOutput.routes`; page behavior stays under `pages`.
- Move deployment artifact runtime endpoint/transport data under `server` instead of duplicating the raw runtime object.
- Update shared/ev/bundler tests and docs to lock the reduced shapes.

## Validation
- `npm run check-types`
- `npm run lint`
- `npm test`
- `git diff --check`
- `npm --workspace @evjs/shared test -- tests/manifest.test.ts --testTimeout=10000`
- `npm --workspace @evjs/ev test -- tests/commands.test.ts tests/deployment.test.ts --testTimeout=10000`
- `npm --workspace @evjs/bundler-utoopack test -- tests/manifest-generator.test.ts tests/adapter.test.ts --testTimeout=20000`
- `npm --workspace @evjs/bundler-webpack test -- tests/adapter.test.ts --testTimeout=20000`
- Residual scans for runtime manifest/build-output references in `packages/client` and `packages/server`

## Risk / rollout
- Medium surface area because generated metadata contracts and deployment helper output shapes changed.
- Runtime behavior risk is constrained by keeping `ClientRuntime` and `FrameworkRuntime` explicit and covered by focused assertions.
- Deployment adapters consuming removed route/root runtime fields should switch to `pages` and `server` fields.

## Reviewer notes
- Please focus on whether the retained `ClientRuntime` and `FrameworkRuntime` fields are the right public runtime contract.
- Check deployment artifact consumers for assumptions about root `runtime` or route-level render/runtime fields.
- Follow-up work can further review private source module retention in full `BuildOutput` if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `runtime.json` as a generated browser runtime configuration alongside existing build outputs.
  * Updated client page startup, routing/activation, and RSC/Flight flows to consume generated runtime configuration.
* **Bug Fixes**
  * Improved build/deploy/server startup so the correct runtime metadata is injected and used for rendering and endpoints.
  * Tightened runtime/output validation to reduce missing or mismatched route/renderer data.
* **Documentation**
  * Clarified the runtime/build contract, artifact responsibilities, and deployment loading behavior (including Chinese docs).
* **Refactor / Tests**
  * Migrated client/server rendering, adapters, and E2E/tests to runtime-based inputs and updated assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->