### PR TITLE
refactor(manifest): tighten build output contract

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,8 +21,9 @@ src/pages + src/apis + src/middleware.ts + ev.config.ts
   -> AppGraph
   -> BuildPlan
   -> selected bundler adapter
-  -> BuildOutput / dist/client/manifest.json / dist/server/manifest.json
-  -> ClientRuntime / FrameworkRuntime contracts / deployment adapters
+  -> in-memory BuildOutput
+  -> ClientRuntime / FrameworkRuntime contracts
+  -> DeploymentMetadata / lightweight manifests / deployment adapters
 ```
 
 Framework semantics are owned by `@evjs/ev` and `@evjs/shared/manifest`.
@@ -157,8 +158,8 @@ the bundler dev instance.
   rendering, PPR region rendering, and RSC Flight endpoint routing
 
 deployment adapters
-  translate BuildOutput to platform artifacts and injected FrameworkRuntime
-  bootstraps
+  translate BuildOutput/DeploymentMetadata to platform artifacts and injected
+  FrameworkRuntime bootstraps
 ```
 
 TanStack Router is available through the `@evjs/client` standalone CSR surface
@@ -168,28 +169,35 @@ and navigation helpers instead of constructing route trees directly.
 
 ## Manifest
 
-The framework output contract is `BuildOutput`. Builds serialize the complete
-private contract to:
+The framework output contract is the in-memory `BuildOutput`. Builds serialize
+the canonical deployment projection to:
 
 ```txt
 dist/build-output.json
 ```
 
-They also emit deployment-focused client/server manifests to `output.client`
-and `output.server`, plus a generated browser `runtime.json`. Deployment
-plugins and platform adapters should consume `BuildOutput`; generated runtimes
-consume minimal `ClientRuntime` and injected `FrameworkRuntime` contracts.
-Routes in these artifacts are URL-to-app/page indexes. Page behavior stays
-under page records, and framework endpoint data stays under runtime/server
-projections instead of being repeated on every route.
+They also emit compatibility deployment manifests to `output.client` and
+`output.server`. The client manifest keeps public assets and SPA/MPA routing
+only. The server manifest keeps only the server entry field for existing
+deployment integrations. Generated HTML embeds `ClientRuntime`, and raw server
+bundles read `dist/server/framework-runtime.json`; deployment adapters embed the
+same FrameworkRuntime data into their bootstrap code.
+
+Deployment plugins and platform adapters should consume
+`deploymentMetadata`/`createDeploymentArtifact()` for post-build routing and
+assets. Plugins that need the complete graph can still inspect the in-memory
+`BuildOutput`. Generated runtimes consume minimal `ClientRuntime` and
+`FrameworkRuntime` contracts rather than manifest or build-output files.
 
 ## Deployment
 
 `@evjs/ev` exposes platform-neutral deployment artifact helpers plus
-`nodeDeploymentAdapter()`. The Node adapter emits a production `dist/server.mjs`
-that imports only Node built-ins, `@evjs/server/node`, and the generated server
-bundle. Platform-specific adapters should consume `BuildOutput` instead of
-reading bundler config or stats.
+`nodeDeploymentAdapter()`, `staticDeploymentAdapter()`, and
+`edgeDeploymentAdapter()`. The Node adapter emits a production
+`dist/server.mjs` that imports only Node built-ins, `@evjs/server/node`, and
+the generated server bundle. Platform-specific adapters should derive platform
+routes from `DeploymentMetadata` and the in-memory `BuildOutput` instead of
+reading bundler config, stats, manifests, or runtime contracts.
 
 ## Programmatic Preparation
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -180,9 +180,9 @@ They also emit compatibility deployment manifests to `output.client` and
 `output.server`. The client manifest keeps public assets for SPA builds and
 page-level assets plus routing for MPA builds. The server manifest keeps the
 server entry and a lightweight projection of server-handled routes for existing
-deployment integrations. Generated HTML embeds `ClientRuntime`, and raw server
-bundles read `dist/server/framework-runtime.json`; deployment adapters embed the
-same FrameworkRuntime data into their bootstrap code.
+deployment integrations. Generated HTML embeds `ClientRuntime`, and runtime-only
+`FrameworkRuntime` data is injected into dev or deployment adapter bootstraps
+instead of being emitted as a default JSON artifact.
 
 Deployment plugins and platform adapters should consume
 `deploymentMetadata`/`createDeploymentArtifact()` for post-build routing and

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -177,8 +177,9 @@ dist/build-output.json
 ```
 
 They also emit compatibility deployment manifests to `output.client` and
-`output.server`. The client manifest keeps public assets and SPA/MPA routing
-only. The server manifest keeps only the server entry field for existing
+`output.server`. The client manifest keeps public assets for SPA builds and
+page-level assets plus routing for MPA builds. The server manifest keeps the
+server entry and a lightweight projection of server-handled routes for existing
 deployment integrations. Generated HTML embeds `ClientRuntime`, and raw server
 bundles read `dist/server/framework-runtime.json`; deployment adapters embed the
 same FrameworkRuntime data into their bootstrap code.

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -174,16 +174,18 @@ or an equivalent value embedded by a deployment adapter. Deployed server
 runtimes do not read `dist/build-output.json` or manifest files at startup.
 The browser runtime projection is intentionally smaller than the public
 manifest: it keeps only the build id, transport base URL, RSC endpoint,
-app/page module targets, mount selectors, and route lookup data needed to boot
-or navigate. Asset indexes, deployment metadata, source references, and
+app/page module targets, mount selectors, and the routing metadata needed to
+boot or navigate. Asset indexes, deployment metadata, source references, and
 renderer bundle metadata stay in manifests or `BuildOutput`; React Flight
 client reference data stays in the explicit `FrameworkRuntime` projection.
 Public manifests, deployment artifacts, and client runtime projections expose a
 single SPA app as `app`, not an `apps.default` map. `BuildOutput.apps` remains
-the complete private/plugin view for named build graph app nodes. In
-`BuildOutput` and public manifests, client routes are URL-to-target indexes.
-Page rendering, hydration, and component model metadata stay under `pages`, and
-framework endpoints stay under runtime/server projections.
+the complete private/plugin view for named build graph app nodes. `BuildOutput`
+keeps the complete private `pages` and `routes` graph. Public manifests and
+runtime projections group client routing under `routing`: SPA uses
+`{ kind: "spa", routes }`, while MPA/page outputs use
+`{ kind: "mpa", pages }` with page route metadata on each page entry.
+Framework endpoints stay under runtime/server projections.
 
 TanStack Router is available through the `@evjs/client` standalone CSR surface
 for manual browser applications. In framework-managed apps, `@evjs/ev` owns
@@ -410,7 +412,9 @@ Full BuildOutput manifests retain deployment-facing route, asset, server
 function, server route, renderer, and RSC page metadata without publishing
 source module paths or bundler chunk maps.
 Client/server manifests are deployment metadata; generated browser and server
-runtimes consume minimal ClientRuntime and FrameworkRuntime contracts.
+runtimes consume minimal ClientRuntime and FrameworkRuntime contracts. Those
+runtime contracts use `routing.kind` to distinguish SPA routes from MPA/page
+targets instead of serializing empty top-level `pages` or `routes` fields.
 Deployment artifacts group framework endpoint and transport data under their
 server section instead of duplicating the raw runtime object.
 

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -164,28 +164,25 @@ sequenceDiagram
   EV->>Plugins: buildEnd({ output, frameworkRuntime, isRebuild })
 ```
 
-Builds emit the private deployment handoff artifact at
-`dist/build-output.json`. Its output locations are grouped under
-`BuildOutput.paths`; there is no separate top-level `distDir`. The client and
-server manifest files are deployment/tooling metadata. Browser bootstraps
-consume a generated client `runtime.json` projection, and server bootstraps
-consume an explicit `FrameworkRuntime` projection from `dist/server/runtime.json`
-or an equivalent value embedded by a deployment adapter. Deployed server
-runtimes do not read `dist/build-output.json` or manifest files at startup.
-The browser runtime projection is intentionally smaller than the public
-manifest: it keeps only the build id, transport base URL, RSC endpoint,
-app/page module targets, mount selectors, and the routing metadata needed to
-boot or navigate. Asset indexes, deployment metadata, source references, and
-renderer bundle metadata stay in manifests or `BuildOutput`; React Flight
-client reference data stays in the explicit `FrameworkRuntime` projection.
-Public manifests, deployment artifacts, and client runtime projections expose a
-single SPA app as `app`, not an `apps.default` map. `BuildOutput.apps` remains
-the complete private/plugin view for named build graph app nodes. `BuildOutput`
-keeps the complete private `pages` and `routes` graph. Public manifests and
-runtime projections group client routing under `routing`: SPA uses
-`{ kind: "spa", routes }`, while MPA/page outputs use
-`{ kind: "mpa", pages }` with page route metadata on each page entry.
-Framework endpoints stay under runtime/server projections.
+Builds emit canonical deployment metadata at `dist/build-output.json`. The
+internal `BuildOutput` remains an in-memory plugin/build contract and is not
+serialized wholesale. Client and server manifest files are compatibility
+projections for deployment tooling: `client/manifest.json` keeps public assets
+and SPA/MPA routing, while `server/manifest.json` only keeps the server entry.
+Generated HTML embeds the browser `ClientRuntime`; CLI builds no longer write
+`client/runtime.json` by default. Raw server bundles consume the explicit
+`FrameworkRuntime` sidecar at `dist/server/framework-runtime.json`, while
+deployment adapters embed the same runtime contract in their bootstrap code.
+Deployed runtimes do not read `dist/build-output.json` or manifest files at
+startup.
+
+Runtime-required data is intentionally separated from deployment metadata.
+ClientRuntime keeps only the build id, transport base URL, RSC endpoint,
+app/page module targets, mount selectors, and routing metadata needed to boot or
+navigate. FrameworkRuntime keeps SSR/PPR/RSC render coordination and React
+Flight client reference data. Deployment metadata keeps public assets, HTML
+documents, server entry, and deployable route rows such as static documents,
+page-server routes, server routes, and framework endpoints.
 
 TanStack Router is available through the `@evjs/client` standalone CSR surface
 for manual browser applications. In framework-managed apps, `@evjs/ev` owns
@@ -205,7 +202,7 @@ sequenceDiagram
   participant FrameworkRuntime as "FrameworkRuntime"
 
   Browser->>Runtime: page/app boot
-  Runtime->>ClientRuntime: load embedded or /runtime.json
+  Runtime->>ClientRuntime: read embedded JSON or configured runtime URL
   Runtime->>Shell: create internal shell
   Shell->>ClientRuntime: resolve app/page target
   Shell->>Browser: import JS/CSS module assets
@@ -331,10 +328,10 @@ through static exports such as `render`, `hydrate`, `rsc`, and `prerender`.
 When graph creation sees SSR, RSC, or partial prerender metadata, it derives the
 required server renderers, PPR regions, assets, and manifest output from that
 page module.
-Full BuildOutput manifests keep those renderer relationships explicit: SSR, SSG, and
-RSC document pages resolve through a `page-server` renderer owned by the page id
-or by one of that page's route ids. PPR pages resolve through `ppr-shell` and
-`ppr-region` entries instead.
+The in-memory BuildOutput keeps those renderer relationships explicit: SSR,
+SSG, and RSC document pages resolve through a `page-server` renderer owned by
+the page id or by one of that page's route ids. PPR pages resolve through
+`ppr-shell` and `ppr-region` entries instead.
 
 `pages.*` remains the explicit lower-level page API. It is useful when a page
 does not map cleanly to the `src/pages` file tree. Rendering metadata still
@@ -380,9 +377,9 @@ The RSC output rules are strict:
 - The manifest linker rejects RSC page output when `runtime.server.rsc` is
   missing.
 
-For full BuildOutput manifests, each RSC page renderer reference must resolve
-to an `rsc-page` renderer whose `owner.pageId` matches the RSC page id. Public
-manifests may omit that server-only renderer metadata.
+For in-memory BuildOutput validation, each RSC page renderer reference must
+resolve to an `rsc-page` renderer whose `owner.pageId` matches the RSC page id.
+Public manifests may omit that server-only renderer metadata.
 
 After ignoring type-only and ambient declarations, a `"use client"` module must
 still expose at least one runtime client reference. Bare runtime
@@ -395,7 +392,9 @@ file path and parser message before the bundler transform runs.
 
 ## Deployment
 
-Deployment adapters consume `BuildOutput`. `@evjs/ev` provides:
+Deployment adapters consume the in-memory `BuildOutput` during the build and can
+emit platform-specific files from the canonical `DeploymentMetadata` projection.
+`@evjs/ev` provides:
 
 - `createDeploymentArtifact(output)` for platform-neutral routing/assets/server metadata;
 - `nodeDeploymentAdapter()` for a concrete Node production target that emits
@@ -404,19 +403,17 @@ Deployment adapters consume `BuildOutput`. `@evjs/ev` provides:
 - `edgeDeploymentAdapter()` for edge-worker style runtime bootstraps that call the
   framework server bundle and an asset binding.
 
-Platform-specific adapters should derive their routing, framework endpoint, SSR,
-PPR, RSC, and asset metadata from `BuildOutput` instead of reading bundler stats.
-Build-pipeline adapters receive that object in memory; post-build tools can read
-`dist/build-output.json`.
-Full BuildOutput manifests retain deployment-facing route, asset, server
-function, server route, renderer, and RSC page metadata without publishing
-source module paths or bundler chunk maps.
+Platform-specific adapters should derive routing, framework endpoints, SSR, PPR,
+RSC, and asset metadata from `BuildOutput` in memory instead of reading bundler
+stats. Post-build tools should read `dist/build-output.json`, whose routes table
+uses explicit kinds such as `static-document`, `page-server`,
+`framework-function`, `framework-ppr`, `framework-rsc`, and `server-route`.
 Client/server manifests are deployment metadata; generated browser and server
 runtimes consume minimal ClientRuntime and FrameworkRuntime contracts. Those
 runtime contracts use `routing.kind` to distinguish SPA routes from MPA/page
 targets instead of serializing empty top-level `pages` or `routes` fields.
-Deployment artifacts group framework endpoint and transport data under their
-server section instead of duplicating the raw runtime object.
+Deployment metadata expresses framework endpoints as route rows instead of
+duplicating the raw runtime object or per-function ids.
 
 The deployment model is capability-driven:
 
@@ -435,9 +432,9 @@ edge + origin/FaaS split
   origin/FaaS resolves functions, routes, SSR/RSC, and PPR regions
 ```
 
-Adapters should classify `BuildOutput` first, then emit platform routes. Static
-hosting must not claim support for SSR, PPR, RSC, server functions, or server
-routes unless a server-capable runtime is attached.
+Adapters should classify `deploymentMetadata.routes` first, then emit platform
+routes. Static hosting must not claim support for SSR, PPR, RSC, server
+functions, or server routes unless a server-capable runtime is attached.
 
 ## Dev Updates
 

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -182,7 +182,8 @@ app/page module targets, mount selectors, and routing metadata needed to boot or
 navigate. FrameworkRuntime keeps SSR/PPR/RSC render coordination and React
 Flight client reference data. Deployment metadata keeps public assets, HTML
 documents, server entry, and deployable route rows such as static documents,
-page-server routes, server routes, and framework endpoints.
+server-rendered page routes, API routes, server functions, PPR endpoints, and
+RSC endpoints.
 
 TanStack Router is available through the `@evjs/client` standalone CSR surface
 for manual browser applications. In framework-managed apps, `@evjs/ev` owns
@@ -405,9 +406,11 @@ emit platform-specific files from the canonical `DeploymentMetadata` projection.
 
 Platform-specific adapters should derive routing, framework endpoints, SSR, PPR,
 RSC, and asset metadata from `BuildOutput` in memory instead of reading bundler
-stats. Post-build tools should read `dist/build-output.json`, whose routes table
-uses explicit kinds such as `static-document`, `page-server`,
-`framework-function`, `framework-ppr`, `framework-rsc`, and `server-route`.
+stats. Post-build tools should read `dist/build-output.json`, whose documents
+table carries app shell fallback metadata and whose routes table uses explicit
+kinds such as `static-page`, `server-page`, `server-function`, `ppr-endpoint`,
+`rsc-endpoint`, and `api-route`. Page route rows carry `render` metadata such
+as `csr`, `ssg`, `ssr`, `ppr`, or `rsc` separately from the deployment kind.
 Client/server manifests are deployment metadata; generated browser and server
 runtimes consume minimal ClientRuntime and FrameworkRuntime contracts. Those
 runtime contracts use `routing.kind` to distinguish SPA routes from MPA/page

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -178,7 +178,10 @@ app/page module targets, mount selectors, and route lookup data needed to boot
 or navigate. Asset indexes, deployment metadata, source references, and
 renderer bundle metadata stay in manifests or `BuildOutput`; React Flight
 client reference data stays in the explicit `FrameworkRuntime` projection.
-In `BuildOutput` and public manifests, client routes are URL-to-target indexes.
+Public manifests, deployment artifacts, and client runtime projections expose a
+single SPA app as `app`, not an `apps.default` map. `BuildOutput.apps` remains
+the complete private/plugin view for named build graph app nodes. In
+`BuildOutput` and public manifests, client routes are URL-to-target indexes.
 Page rendering, hydration, and component model metadata stay under `pages`, and
 framework endpoints stay under runtime/server projections.
 

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -161,21 +161,23 @@ sequenceDiagram
   loop each HTML document
     EV->>Plugins: transformHtml(doc, htmlContext)
   end
-  EV->>Plugins: buildEnd({ output, isRebuild })
+  EV->>Plugins: buildEnd({ output, frameworkRuntime, isRebuild })
 ```
 
-Builds emit the complete private `BuildOutput` handoff artifact at
-`dist/build-output.json`. The client and server manifest paths come from
-`output.client` and `output.server`; those files are deployment/tooling
-metadata. Browser bootstraps consume a generated `runtime.json` projection, and
-deployment adapters embed equivalent `FrameworkRuntime` data into platform
-server files, so deployed server runtimes do not read `dist/build-output.json`
-or manifest files at startup.
+Builds emit the private deployment handoff artifact at
+`dist/build-output.json`. Its output locations are grouped under
+`BuildOutput.paths`; there is no separate top-level `distDir`. The client and
+server manifest files are deployment/tooling metadata. Browser bootstraps
+consume a generated client `runtime.json` projection, and server bootstraps
+consume an explicit `FrameworkRuntime` projection from `dist/server/runtime.json`
+or an equivalent value embedded by a deployment adapter. Deployed server
+runtimes do not read `dist/build-output.json` or manifest files at startup.
 The browser runtime projection is intentionally smaller than the public
 manifest: it keeps only the build id, transport base URL, RSC endpoint,
 app/page module targets, mount selectors, and route lookup data needed to boot
 or navigate. Asset indexes, deployment metadata, source references, and
-renderer bundle metadata stay in manifests or `BuildOutput`.
+renderer bundle metadata stay in manifests or `BuildOutput`; React Flight
+client reference data stays in the explicit `FrameworkRuntime` projection.
 In `BuildOutput` and public manifests, client routes are URL-to-target indexes.
 Page rendering, hydration, and component model metadata stay under `pages`, and
 framework endpoints stay under runtime/server projections.
@@ -347,7 +349,8 @@ belongs in the referenced page module, not in `ev.config.ts`.
 The public config exposes `server.basePath`; the function endpoint is derived from that base path.
 
 RSC `use client` reference extraction preserves these names in
-`BuildOutput.rsc`:
+RSC reference extraction records these export names for the bundler transform
+and React Flight manifest generation:
 
 - default exports;
 - identifier exports;
@@ -360,16 +363,15 @@ Type-only exports are ignored. The client reference transform emits internal
 bindings with export specifiers, so reserved words and string-literal aliases
 stay valid JavaScript.
 
-The RSC manifest rules are strict:
+The RSC output rules are strict:
 
-- `BuildOutput.rsc.clientReferences` and `BuildOutput.rsc.serverReferences` use
-  the extracted reference id as a trimmed string key.
-- Reference ids may contain file paths, URL syntax, `#`, or `:`.
-- The value object carries the trimmed `module` and optional trimmed
-  `exportName`.
-- Reference-only RSC output can omit `BuildOutput.rsc.endpoint`.
-- RSC page output cannot omit `BuildOutput.rsc.endpoint`, because Flight
-  requests need a concrete endpoint.
+- `BuildOutput.rsc` does not publish extracted source reference ids or source
+  modules.
+- RSC page output carries renderer ids and emitted assets.
+- React Flight client reference manifests stay out of `BuildOutput` and
+  client/server manifests; the generated `FrameworkRuntime` carries the runtime
+  client reference data needed by the RSC endpoint.
+- The Flight endpoint is expressed once as `BuildOutput.runtime.server.rsc`.
 - The manifest linker rejects RSC page output when `runtime.server.rsc` is
   missing.
 
@@ -401,7 +403,9 @@ Platform-specific adapters should derive their routing, framework endpoint, SSR,
 PPR, RSC, and asset metadata from `BuildOutput` instead of reading bundler stats.
 Build-pipeline adapters receive that object in memory; post-build tools can read
 `dist/build-output.json`.
-Full BuildOutput manifests retain source modules and server renderer references.
+Full BuildOutput manifests retain deployment-facing route, asset, server
+function, server route, renderer, and RSC page metadata without publishing
+source module paths or bundler chunk maps.
 Client/server manifests are deployment metadata; generated browser and server
 runtimes consume minimal ClientRuntime and FrameworkRuntime contracts.
 Deployment artifacts group framework endpoint and transport data under their

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -167,8 +167,9 @@ sequenceDiagram
 Builds emit canonical deployment metadata at `dist/build-output.json`. The
 internal `BuildOutput` remains an in-memory plugin/build contract and is not
 serialized wholesale. Client and server manifest files are compatibility
-projections for deployment tooling: `client/manifest.json` keeps public assets
-and SPA/MPA routing, while `server/manifest.json` only keeps the server entry.
+projections for deployment tooling: `client/manifest.json` keeps SPA public
+assets or MPA page-level assets plus routing, while `server/manifest.json`
+keeps the server entry and lightweight server route projection.
 Generated HTML embeds the browser `ClientRuntime`; CLI builds no longer write
 `client/runtime.json` by default. Raw server bundles consume the explicit
 `FrameworkRuntime` sidecar at `dist/server/framework-runtime.json`, while

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -171,11 +171,10 @@ projections for deployment tooling: `client/manifest.json` keeps SPA public
 assets or MPA page-level assets plus routing, while `server/manifest.json`
 keeps the server entry and lightweight server route projection.
 Generated HTML embeds the browser `ClientRuntime`; CLI builds no longer write
-`client/runtime.json` by default. Raw server bundles consume the explicit
-`FrameworkRuntime` sidecar at `dist/server/framework-runtime.json`, while
-deployment adapters embed the same runtime contract in their bootstrap code.
-Deployed runtimes do not read `dist/build-output.json` or manifest files at
-startup.
+`client/runtime.json` by default. Runtime-only `FrameworkRuntime` data is kept
+in memory for plugins and injected into dev or deployment adapter bootstraps
+instead of being emitted as a default JSON artifact. Deployed runtimes do not
+read `dist/build-output.json` or manifest files at startup.
 
 Runtime-required data is intentionally separated from deployment metadata.
 ClientRuntime keeps only the build id, transport base URL, RSC endpoint,

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -329,10 +329,12 @@ through static exports such as `render`, `hydrate`, `rsc`, and `prerender`.
 When graph creation sees SSR, RSC, or partial prerender metadata, it derives the
 required server renderers, PPR regions, assets, and manifest output from that
 page module.
-The in-memory BuildOutput keeps those renderer relationships explicit: SSR,
-SSG, and RSC document pages resolve through a `page-server` renderer owned by
-the page id or by one of that page's route ids. PPR pages resolve through
-`ppr-shell` and `ppr-region` entries instead.
+The in-memory BuildOutput keeps those renderer relationships explicit: SSR and
+RSC document pages resolve through a `page-server` renderer owned by the page id
+or by one of that page's route ids. SSG pages use a `page-server` renderer during
+the production build to emit static HTML, then deployment metadata exposes them
+as `static-page` routes. PPR pages resolve through `ppr-shell` and `ppr-region`
+entries instead.
 
 `pages.*` remains the explicit lower-level page API. It is useful when a page
 does not map cleanly to the `src/pages` file tree. Rendering metadata still
@@ -409,9 +411,13 @@ RSC, and asset metadata from `BuildOutput` in memory instead of reading bundler
 stats. Post-build tools should read `dist/build-output.json`, whose documents
 table carries app shell fallback metadata and whose routes table uses explicit
 kinds such as `static-page`, `server-page`, `server-function`, `ppr-endpoint`,
-`rsc-endpoint`, and `api-route`. Page route rows carry `render` metadata such
-as `csr`, `ssg`, `ssr`, `ppr`, or `rsc` separately from the deployment kind.
-Client/server manifests are deployment metadata; generated browser and server
+`rsc-endpoint`, and `api-route`. Static page route rows point at emitted HTML
+documents and carry `render: "csr" | "ssg"`; server page route rows describe
+server-handled pages and carry `render: "ssr"`. Server page rows add
+`prerender: "full" | "partial"` for full prerender or PPR behavior, and
+`rsc: true` for RSC pages, so derived capabilities do not masquerade as source
+`render` values. Client/server manifests are
+deployment metadata; generated browser and server
 runtimes consume minimal ClientRuntime and FrameworkRuntime contracts. Those
 runtime contracts use `routing.kind` to distinguish SPA routes from MPA/page
 targets instead of serializing empty top-level `pages` or `routes` fields.

--- a/docs/docs/build.md
+++ b/docs/docs/build.md
@@ -68,9 +68,10 @@ dist-server/
 ```
 
 Generated HTML embeds the `ClientRuntime` needed by the browser bootstrap.
-`client/manifest.json` is lightweight deployment metadata with public assets and
-SPA/MPA route information. `server/manifest.json` only preserves the server
-entry filename. `server/framework-runtime.json` is runtime-required data for raw
+`client/manifest.json` is lightweight deployment metadata: SPA manifests keep
+top-level public assets, while MPA manifests keep assets on each routing page.
+`server/manifest.json` preserves the server entry filename plus the server route
+projection. `server/framework-runtime.json` is runtime-required data for raw
 server bundles, and `build-output.json` is canonical deployment metadata.
 Application code should not import or edit deployment metadata files.
 

--- a/docs/docs/build.md
+++ b/docs/docs/build.md
@@ -30,11 +30,12 @@ dist/
 │   ├── index.html
 │   ├── main.[hash].js
 │   ├── [chunk].[hash].js
+│   └── manifest.json
+├── server/
+│   ├── main.[hash].js
 │   ├── manifest.json
-│   └── runtime.json
-└── server/
-    ├── main.[hash].js
-    └── manifest.json
+│   └── framework-runtime.json
+└── build-output.json
 ```
 
 Use `output.client` and `output.server` when your host expects public files in a
@@ -59,19 +60,19 @@ dist/
 ├── index.html
 ├── main.[hash].js
 ├── [chunk].[hash].js
-├── manifest.json
-└── runtime.json
+└── manifest.json
 dist-server/
 ├── main.[hash].js
-└── manifest.json
+├── manifest.json
+└── framework-runtime.json
 ```
 
-`runtime.json` is generated browser runtime configuration with only boot,
-navigation, transport, and RSC endpoint data. `manifest.json` files and
-`build-output.json` are generated deployment/tooling metadata. Client route
-entries are URL-to-app/page indexes; page rendering behavior stays on page
-records, and runtime endpoints stay out of the public client manifest.
-Application code should not import or edit these files.
+Generated HTML embeds the `ClientRuntime` needed by the browser bootstrap.
+`client/manifest.json` is lightweight deployment metadata with public assets and
+SPA/MPA route information. `server/manifest.json` only preserves the server
+entry filename. `server/framework-runtime.json` is runtime-required data for raw
+server bundles, and `build-output.json` is canonical deployment metadata.
+Application code should not import or edit deployment metadata files.
 
 ## Page Output
 

--- a/docs/docs/build.md
+++ b/docs/docs/build.md
@@ -95,7 +95,10 @@ export default function ProductPage() {
 }
 ```
 
-For static pages, use `render = "ssg"`. For partial prerendering, use
+For build-time static generation, use `render = "ssg"` on a statically
+addressable page. `ev build` renders that page into an emitted HTML document
+such as `dist/client/report.html`, and deployment metadata represents it as a
+`static-page` route. For server pages with partial prerendering, use
 `render = "ssr"` with `prerender = { partial: true }`.
 
 ```tsx

--- a/docs/docs/build.md
+++ b/docs/docs/build.md
@@ -33,8 +33,7 @@ dist/
 │   └── manifest.json
 ├── server/
 │   ├── main.[hash].js
-│   ├── manifest.json
-│   └── framework-runtime.json
+│   └── manifest.json
 └── build-output.json
 ```
 
@@ -63,17 +62,17 @@ dist/
 └── manifest.json
 dist-server/
 ├── main.[hash].js
-├── manifest.json
-└── framework-runtime.json
+└── manifest.json
 ```
 
 Generated HTML embeds the `ClientRuntime` needed by the browser bootstrap.
 `client/manifest.json` is lightweight deployment metadata: SPA manifests keep
 top-level public assets, while MPA manifests keep assets on each routing page.
 `server/manifest.json` preserves the server entry filename plus the server route
-projection. `server/framework-runtime.json` is runtime-required data for raw
-server bundles, and `build-output.json` is canonical deployment metadata.
-Application code should not import or edit deployment metadata files.
+projection. Runtime-only `FrameworkRuntime` data is injected into dev and
+deployment bootstraps instead of being emitted as JSON. `build-output.json` is
+canonical deployment metadata. Application code should not import or edit
+deployment metadata files.
 
 ## Page Output
 

--- a/docs/docs/client-routes.md
+++ b/docs/docs/client-routes.md
@@ -132,11 +132,11 @@ export default defineConfig({
 ```
 
 In MPA mode every discovered CSR page is emitted as an independent HTML document
-and client entry. File-route pages that export `render = "ssg"` emit an
-independent static HTML document and a server renderer for static generation; by
-default they do not create a browser page entry. No client router setup is
-added. A file-route page can use a page-specific HTML template by placing an
-`.html` file with the same basename beside the page module, such as
+and client entry. File-route pages that export `render = "ssg"` are rendered
+during `ev build` into independent static HTML documents; by default they do
+not create a browser page entry. No client router setup is added. A file-route
+page can use a page-specific HTML template by placing an `.html` file with the
+same basename beside the page module, such as
 `src/pages/about.html` for `src/pages/about.tsx` or
 `src/pages/product/index.html` for `src/pages/product/index.tsx`; routes
 without one use the global `index.html` template by default.

--- a/docs/docs/deploy.md
+++ b/docs/docs/deploy.md
@@ -35,8 +35,8 @@ Important paths:
   deployment tooling.
 - `dist/server/`: server bundle and server metadata when the app uses server
   functions, server file routes, SSR, PPR, or RSC.
-- `dist/server/manifest.json`: entry-only server manifest for deployment
-  compatibility.
+- `dist/server/manifest.json`: lightweight server manifest with the server
+  entry and server-handled route projection for deployment compatibility.
 - `dist/server/framework-runtime.json`: runtime-required framework data for raw
   server bundle startup.
 - `dist/build-output.json`: canonical deployment metadata for tooling and

--- a/docs/docs/deploy.md
+++ b/docs/docs/deploy.md
@@ -20,10 +20,10 @@ Typical output:
 dist/
 ├── client/
 │   ├── manifest.json
-│   ├── runtime.json
 │   └── ...
 ├── server/
 │   ├── manifest.json
+│   ├── framework-runtime.json
 │   └── ...
 └── build-output.json
 ```
@@ -33,16 +33,18 @@ Important paths:
 - `dist/client/`: browser assets and generated HTML.
 - `dist/client/manifest.json`: browser-safe route and asset metadata for
   deployment tooling.
-- `dist/client/runtime.json`: minimal browser runtime configuration loaded by
-  generated page bootstraps when it is not embedded in HTML.
 - `dist/server/`: server bundle and server metadata when the app uses server
   functions, server file routes, SSR, PPR, or RSC.
-- `dist/build-output.json`: complete build metadata for tooling and deployment
-  adapters. Application code should not import or edit it.
+- `dist/server/manifest.json`: entry-only server manifest for deployment
+  compatibility.
+- `dist/server/framework-runtime.json`: runtime-required framework data for raw
+  server bundle startup.
+- `dist/build-output.json`: canonical deployment metadata for tooling and
+  deployment adapters. Application code should not import or edit it.
 
-If page HTML does not embed the runtime config, the browser runtime fetches it
-from the configured runtime URL or `/runtime.json`. Serve that response as JSON
-with `Content-Type: application/json`.
+Generated HTML embeds the browser `ClientRuntime`. The manual `@evjs/client`
+runtime URL APIs still support loading JSON from a configured URL, but CLI
+builds no longer emit `dist/client/runtime.json` by default.
 
 ## Choose A Target
 
@@ -210,21 +212,21 @@ CMD ["node", "dist/server.mjs"]
 
 ## Custom Deployment Plugins
 
-Deployment plugins can use `buildEnd({ output })` to emit platform files. For a
-portable metadata shape, start from `createDeploymentArtifact()`:
+Deployment plugins can use `buildEnd({ deploymentMetadata })` to emit platform
+files. For platform-specific compatibility fields, wrap that metadata before
+writing files:
 
 ```ts
-import { createDeploymentArtifact } from "@evjs/ev";
-
 export function deployAdapter() {
   return {
     name: "deploy-adapter",
     setup() {
       return {
-        buildEnd({ output }) {
-          const artifact = createDeploymentArtifact(output, {
+        buildEnd({ deploymentMetadata }) {
+          const artifact = {
+            ...deploymentMetadata,
             platform: "custom",
-          });
+          };
 
           emitPlatformFiles(artifact);
         },

--- a/docs/docs/deploy.md
+++ b/docs/docs/deploy.md
@@ -23,7 +23,6 @@ dist/
 │   └── ...
 ├── server/
 │   ├── manifest.json
-│   ├── framework-runtime.json
 │   └── ...
 └── build-output.json
 ```
@@ -37,14 +36,15 @@ Important paths:
   functions, server file routes, SSR, PPR, or RSC.
 - `dist/server/manifest.json`: lightweight server manifest with the server
   entry and server-handled route projection for deployment compatibility.
-- `dist/server/framework-runtime.json`: runtime-required framework data for raw
-  server bundle startup.
 - `dist/build-output.json`: canonical deployment metadata for tooling and
   deployment adapters. Application code should not import or edit it.
 
 Generated HTML embeds the browser `ClientRuntime`. The manual `@evjs/client`
 runtime URL APIs still support loading JSON from a configured URL, but CLI
 builds no longer emit `dist/client/runtime.json` by default.
+Runtime-only `FrameworkRuntime` data is passed through build/plugin results and
+injected into dev or deployment adapter bootstraps; it is not emitted as a
+default JSON artifact.
 
 ## Choose A Target
 

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -172,30 +172,37 @@ import type { HtmlDocument } from "@evjs/ev";
 
 ## Build Result
 
-`buildEnd()` receives the final build output plus narrower client and server
-manifest views:
+`buildEnd()` receives the final build output plus narrower client/server
+manifest and deployment metadata views:
 
 ```ts
 setup() {
   return {
-    buildEnd({ output, clientManifest, serverManifest, isRebuild }) {
+    buildEnd({
+      output,
+      clientManifest,
+      serverManifest,
+      deploymentMetadata,
+      isRebuild,
+    }) {
       console.log("Apps:", Object.keys(output.apps));
       console.log("Pages:", Object.keys(output.pages));
-      console.log("Client JS:", clientManifest.assets.js);
+      console.log("Client asset groups:", Object.keys(clientManifest.assets ?? {}));
       console.log("Server entry:", serverManifest.entry);
+      console.log("Deploy routes:", deploymentMetadata.routes.length);
       console.log("Rebuild:", isRebuild);
     },
   };
 }
 ```
 
-Deployment plugins should read routes, functions, assets, and runtime paths from
-`output`. Plugins that only need the client bundle summary can use
-`clientManifest`: check `clientManifest.kind` before reading SPA `routes` or
-MPA `pages`. Plugins that only need the server entry, function ids, or route
-method summary can use `serverManifest`. HTML hooks receive the same result
-fields plus document-specific fields such as `ctx.kind`, `ctx.fileName`, and
-`ctx.assets`.
+Deployment plugins should prefer `deploymentMetadata` for routes, documents,
+assets, and the server entry. Plugins that need the complete internal build graph
+can still inspect `output` in memory. Plugins that only need the client bundle
+summary can use `clientManifest`: check `clientManifest.routing.kind` before
+reading SPA `routes` or MPA `pages`. `serverManifest` is entry-only. HTML hooks
+receive the same result fields plus document-specific fields such as `ctx.kind`,
+`ctx.fileName`, and `ctx.assets`.
 
 ## Bundler Config
 

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -190,10 +190,11 @@ setup() {
 ```
 
 Deployment plugins should read routes, functions, assets, and runtime paths from
-`output`. Plugins that only need client or server bundle summaries can use
-`clientManifest` and `serverManifest`. HTML hooks receive the same result fields
-plus document-specific fields such as `ctx.kind`, `ctx.fileName`, and
-`ctx.assets`.
+`output`. Plugins that only need the client bundle summary can use
+`clientManifest`; plugins that only need the server entry, function ids, or
+route method summary can use `serverManifest`. HTML hooks receive the same
+result fields plus document-specific fields such as `ctx.kind`, `ctx.fileName`,
+and `ctx.assets`.
 
 ## Bundler Config
 

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -189,6 +189,7 @@ setup() {
       console.log("Pages:", Object.keys(output.pages));
       console.log("Client asset groups:", Object.keys(clientManifest.assets ?? {}));
       console.log("Server entry:", serverManifest.entry);
+      console.log("Server routes:", serverManifest.routes.length);
       console.log("Deploy routes:", deploymentMetadata.routes.length);
       console.log("Rebuild:", isRebuild);
     },
@@ -200,8 +201,10 @@ Deployment plugins should prefer `deploymentMetadata` for routes, documents,
 assets, and the server entry. Plugins that need the complete internal build graph
 can still inspect `output` in memory. Plugins that only need the client bundle
 summary can use `clientManifest`: check `clientManifest.routing.kind` before
-reading SPA `routes` or MPA `pages`. `serverManifest` is entry-only. HTML hooks
-receive the same result fields plus document-specific fields such as `ctx.kind`,
+reading SPA `routes` or MPA `pages`. Plugins that only need the server entry and
+server-handled route summary can use `serverManifest.routes`; full deployment
+planning should still use `deploymentMetadata.routes`. HTML hooks receive the
+same result fields plus document-specific fields such as `ctx.kind`,
 `ctx.fileName`, and `ctx.assets`.
 
 ## Bundler Config

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -191,10 +191,11 @@ setup() {
 
 Deployment plugins should read routes, functions, assets, and runtime paths from
 `output`. Plugins that only need the client bundle summary can use
-`clientManifest`; plugins that only need the server entry, function ids, or
-route method summary can use `serverManifest`. HTML hooks receive the same
-result fields plus document-specific fields such as `ctx.kind`, `ctx.fileName`,
-and `ctx.assets`.
+`clientManifest`: check `clientManifest.kind` before reading SPA `routes` or
+MPA `pages`. Plugins that only need the server entry, function ids, or route
+method summary can use `serverManifest`. HTML hooks receive the same result
+fields plus document-specific fields such as `ctx.kind`, `ctx.fileName`, and
+`ctx.assets`.
 
 ## Bundler Config
 

--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -15,10 +15,10 @@
 - `ev inspect` CLI preflight for explaining page route discovery, server
   declarations, render metadata, runtime paths, planned entries, and diagnostics
   without running a bundler or writing `dist`.
-- Configurable framework manifest directories through `output.client` and
-  `output.server`, plus the complete private `dist/build-output.json` handoff.
-- Manifest-driven app/page activation through the public
-  `@evjs/client` runtime package.
+- Configurable framework metadata directories through `output.client` and
+  `output.server`, plus canonical deployment metadata at `dist/build-output.json`.
+- ClientRuntime-driven app/page activation through the public
+  `@evjs/client` runtime package and generated framework bootstraps.
 - Framework-owned SPA page routes and router-free page runtime for MPA.
 - Webpack adapter for framework validation while Utoopack lower-layer APIs catch up.
 - Focused render-mode and deployment-adapter examples plus end-to-end coverage for apps,

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
@@ -163,14 +163,15 @@ sequenceDiagram
 内嵌的等价数据。因此已部署的 server runtime 不会在启动时读取 `dist/build-output.json`
 或 manifest 文件。
 浏览器运行时投影刻意小于 public manifest：只保留启动和导航需要的 build id、
-transport base URL、RSC endpoint、app/page module target、mount selector 和 route
-lookup 数据。资源索引、部署元信息、源码引用和 renderer bundle 元信息留在 manifest 或
+transport base URL、RSC endpoint、app/page module target、mount selector 和必要的
+routing 元信息。资源索引、部署元信息、源码引用和 renderer bundle 元信息留在 manifest 或
 `BuildOutput` 中；React Flight client reference 数据留在显式 `FrameworkRuntime` 投影中。
 public manifest、deployment artifact 和 client runtime 投影会把单 SPA app 表达成
 `app` 字段，而不是 `apps.default` 映射。`BuildOutput.apps` 仍然保留完整的私有/plugin
-视图，用于命名 build graph app 节点。在 `BuildOutput` 和公开 manifest 中，client route
-是 URL 到目标的索引。页面渲染、hydrate 和 component model 元信息留在 `pages` 下，
-framework endpoint 留在 runtime/server 投影下。
+视图，用于命名 build graph app 节点。`BuildOutput` 保留完整的私有 `pages`/`routes`
+图；public manifest 和 runtime 投影把客户端路由统一放到 `routing` 下：SPA 使用
+`{ kind: "spa", routes }`，MPA/page output 使用 `{ kind: "mpa", pages }`，每个 page
+entry 自带 route 元信息。framework endpoint 留在 runtime/server 投影下。
 
 ## 运行时流程
 
@@ -370,7 +371,8 @@ Deployment adapter 消费 `BuildOutput`。`@evjs/ev` 提供：
 完整 BuildOutput manifest 会保留面向部署的 route、asset、server function、server
 route、renderer 和 RSC page metadata，但不发布源码 module path 或 bundler chunk map。client/server manifest
 是部署元信息；生成的浏览器和服务端运行时消费最小化的 ClientRuntime 和 FrameworkRuntime
-contract。
+contract。这些 runtime contract 使用 `routing.kind` 区分 SPA routes 和 MPA/page targets，
+不再序列化空的顶层 `pages` 或 `routes` 字段。
 Deployment artifact 会把 framework endpoint 和 transport 数据归到 server 分组下，而不是
 重复携带原始 runtime 对象。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
@@ -153,18 +153,19 @@ sequenceDiagram
   loop each HTML document
     EV->>Plugins: transformHtml(doc, htmlContext)
   end
-  EV->>Plugins: buildEnd({ output, isRebuild })
+  EV->>Plugins: buildEnd({ output, frameworkRuntime, isRebuild })
 ```
 
-构建会在 `dist/build-output.json` 输出完整私有 `BuildOutput` handoff artifact。
-client/server manifest 路径来自 `output.client` 和 `output.server`；这些文件是部署/工具
-元信息。浏览器 bootstrap 消费生成的 `runtime.json` 投影，Deployment adapter 会把等价的
-`FrameworkRuntime` 数据内嵌进平台服务端产物，因此已部署的 server runtime 不会在启动时读取
-`dist/build-output.json` 或 manifest 文件。
+构建会在 `dist/build-output.json` 输出私有部署 handoff artifact。输出位置统一放在
+`BuildOutput.paths` 下，不再有单独的顶层 `distDir`。client/server manifest 文件是部署/工具
+元信息。浏览器 bootstrap 消费生成的 client `runtime.json` 投影，服务端 bootstrap 消费
+`dist/server/runtime.json` 中的显式 `FrameworkRuntime` 投影，或消费 Deployment adapter
+内嵌的等价数据。因此已部署的 server runtime 不会在启动时读取 `dist/build-output.json`
+或 manifest 文件。
 浏览器运行时投影刻意小于 public manifest：只保留启动和导航需要的 build id、
 transport base URL、RSC endpoint、app/page module target、mount selector 和 route
 lookup 数据。资源索引、部署元信息、源码引用和 renderer bundle 元信息留在 manifest 或
-`BuildOutput` 中。
+`BuildOutput` 中；React Flight client reference 数据留在显式 `FrameworkRuntime` 投影中。
 在 `BuildOutput` 和公开 manifest 中，client route 是 URL 到目标的索引。页面渲染、
 hydrate 和 component model 元信息留在 `pages` 下，framework endpoint 留在 runtime/server
 投影下。
@@ -317,7 +318,8 @@ entry 解析。
 
 公开配置只暴露 `server.basePath`；函数 endpoint 从这个 base path 派生。
 
-RSC `use client` reference extraction 会在 `BuildOutput.rsc` 中保留这些名称：
+RSC `use client` reference extraction 会为 bundler transform 和 React Flight
+manifest 生成记录这些导出名称：
 
 - default export；
 - identifier export；
@@ -329,15 +331,13 @@ RSC `use client` reference extraction 会在 `BuildOutput.rsc` 中保留这些�
 type-only export 会被忽略。client reference transform 会生成内部 binding，并通过
 export specifier 导出，因此 reserved word 和字符串字面量 alias 仍是合法 JavaScript。
 
-RSC manifest 规则保持严格：
+RSC output 规则保持严格：
 
-- `BuildOutput.rsc.clientReferences` 和 `BuildOutput.rsc.serverReferences` 使用提取出的
-  reference id 作为无首尾空白的字符串 key。
-- reference id 可以包含文件路径、URL 语法、`#` 或 `:`。
-- value object 携带无首尾空白的 `module` 和可选 `exportName`。
-- 只有 reference metadata 的 RSC output 可以省略 `BuildOutput.rsc.endpoint`。
-- 包含 RSC page output 时不能省略 `BuildOutput.rsc.endpoint`，因为 Flight 请求需要明确的
-  endpoint。
+- `BuildOutput.rsc` 不发布提取出的源码 reference id 或源码 module。
+- RSC page output 携带 renderer id 和构建出的 assets。
+- React Flight client reference manifest 不进入 `BuildOutput` 和 client/server manifest；
+  生成的 `FrameworkRuntime` 携带 RSC endpoint 运行时需要的 client reference 数据。
+- Flight endpoint 只通过 `BuildOutput.runtime.server.rsc` 表达一次。
 - 缺少 `runtime.server.rsc` 时，manifest linker 会拒绝 RSC page output。
 
 在完整 BuildOutput manifest 中，每个 RSC page renderer reference 必须解析到
@@ -365,9 +365,10 @@ Deployment adapter 消费 `BuildOutput`。`@evjs/ev` 提供：
 
 平台专属 adapter 应从 `BuildOutput` 派生 routing、framework endpoint、SSR、PPR、RSC 和 asset metadata，而不是读取 bundler stats。
 构建流水线中的 adapter 会在内存里收到这个对象；构建后的工具可以读取 `dist/build-output.json`。
-完整 BuildOutput manifest 会保留源码 module 和 server renderer reference。client/server
-manifest 是部署元信息；生成的浏览器和服务端运行时消费最小化的 ClientRuntime 和
-FrameworkRuntime contract。
+完整 BuildOutput manifest 会保留面向部署的 route、asset、server function、server
+route、renderer 和 RSC page metadata，但不发布源码 module path 或 bundler chunk map。client/server manifest
+是部署元信息；生成的浏览器和服务端运行时消费最小化的 ClientRuntime 和 FrameworkRuntime
+contract。
 Deployment artifact 会把 framework endpoint 和 transport 数据归到 server 分组下，而不是
 重复携带原始 runtime 对象。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
@@ -170,8 +170,8 @@ Runtime-required 数据刻意和 deployment metadata 分离。ClientRuntime 只�
 需要的 build id、transport base URL、RSC endpoint、app/page module target、mount
 selector 和必要 routing 元信息。FrameworkRuntime 保留 SSR/PPR/RSC 渲染协调和 React
 Flight client reference 数据。Deployment metadata 保留 public assets、HTML documents、
-server entry，以及 static document、page-server、server route、framework endpoint 等
-可部署 route row。
+server entry，以及 static document、server-rendered page route、API route、
+server function、PPR endpoint、RSC endpoint 等可部署 route row。
 
 ## 运行时流程
 
@@ -368,11 +368,13 @@ Deployment adapter 在构建过程中消费内存中的 `BuildOutput`，并可�
 
 平台专属 adapter 应从内存 `BuildOutput` 派生 routing、framework endpoint、SSR、PPR、RSC
 和 asset metadata，而不是读取 bundler stats。构建后的工具应读取 `dist/build-output.json`；
-其中 route table 使用 `static-document`、`page-server`、`framework-function`、
-`framework-ppr`、`framework-rsc` 和 `server-route` 等显式 kind。client/server manifest
-是部署元信息；生成的浏览器和服务端运行时消费最小化的 ClientRuntime 和 FrameworkRuntime
-contract。Deployment metadata 把 framework endpoint 表达成 route row，不重复携带原始
-runtime object，也不按单个 server function id 暴露给部署平台。
+其中 documents table 携带 app shell fallback 元信息，route table 使用
+`static-page`、`server-page`、`server-function`、`ppr-endpoint`、`rsc-endpoint`
+和 `api-route` 等显式 kind。页面 route row 通过 `render` 单独表达 `csr`、`ssg`、
+`ssr`、`ppr` 或 `rsc` 等渲染策略，和部署 kind 分离。client/server manifest 是部署元信息；
+生成的浏览器和服务端运行时消费最小化的 ClientRuntime 和 FrameworkRuntime contract。
+Deployment metadata 把 framework endpoint 表达成 route row，不重复携带原始 runtime object，
+也不按单个 server function id 暴露给部署平台。
 
 部署模型由能力分类驱动：
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
@@ -162,10 +162,9 @@ sequenceDiagram
 routing；`server/manifest.json` 保留 server entry 和轻量 server route projection。
 
 生成的 HTML 会内嵌浏览器 `ClientRuntime`，CLI build 默认不再写
-`client/runtime.json`。raw server bundle 消费显式的
-`dist/server/framework-runtime.json`，Node/Edge deployment adapter 则把同一份
-`FrameworkRuntime` contract 内嵌到 bootstrap 中。因此已部署 runtime 不会在启动时读取
-`dist/build-output.json` 或 manifest 文件。
+`client/runtime.json`。Runtime-only 的 `FrameworkRuntime` 数据保留在内存中的 plugin/build
+result，并注入 dev 或 deployment adapter bootstrap，不再作为默认 JSON artifact 输出。因此
+已部署 runtime 不会在启动时读取 `dist/build-output.json` 或 manifest 文件。
 
 Runtime-required 数据刻意和 deployment metadata 分离。ClientRuntime 只保留启动和导航
 需要的 build id、transport base URL、RSC endpoint、app/page module target、mount

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
@@ -166,9 +166,11 @@ sequenceDiagram
 transport base URL、RSC endpoint、app/page module target、mount selector 和 route
 lookup 数据。资源索引、部署元信息、源码引用和 renderer bundle 元信息留在 manifest 或
 `BuildOutput` 中；React Flight client reference 数据留在显式 `FrameworkRuntime` 投影中。
-在 `BuildOutput` 和公开 manifest 中，client route 是 URL 到目标的索引。页面渲染、
-hydrate 和 component model 元信息留在 `pages` 下，framework endpoint 留在 runtime/server
-投影下。
+public manifest、deployment artifact 和 client runtime 投影会把单 SPA app 表达成
+`app` 字段，而不是 `apps.default` 映射。`BuildOutput.apps` 仍然保留完整的私有/plugin
+视图，用于命名 build graph app 节点。在 `BuildOutput` 和公开 manifest 中，client route
+是 URL 到目标的索引。页面渲染、hydrate 和 component model 元信息留在 `pages` 下，
+framework endpoint 留在 runtime/server 投影下。
 
 ## 运行时流程
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
@@ -156,22 +156,23 @@ sequenceDiagram
   EV->>Plugins: buildEnd({ output, frameworkRuntime, isRebuild })
 ```
 
-构建会在 `dist/build-output.json` 输出私有部署 handoff artifact。输出位置统一放在
-`BuildOutput.paths` 下，不再有单独的顶层 `distDir`。client/server manifest 文件是部署/工具
-元信息。浏览器 bootstrap 消费生成的 client `runtime.json` 投影，服务端 bootstrap 消费
-`dist/server/runtime.json` 中的显式 `FrameworkRuntime` 投影，或消费 Deployment adapter
-内嵌的等价数据。因此已部署的 server runtime 不会在启动时读取 `dist/build-output.json`
-或 manifest 文件。
-浏览器运行时投影刻意小于 public manifest：只保留启动和导航需要的 build id、
-transport base URL、RSC endpoint、app/page module target、mount selector 和必要的
-routing 元信息。资源索引、部署元信息、源码引用和 renderer bundle 元信息留在 manifest 或
-`BuildOutput` 中；React Flight client reference 数据留在显式 `FrameworkRuntime` 投影中。
-public manifest、deployment artifact 和 client runtime 投影会把单 SPA app 表达成
-`app` 字段，而不是 `apps.default` 映射。`BuildOutput.apps` 仍然保留完整的私有/plugin
-视图，用于命名 build graph app 节点。`BuildOutput` 保留完整的私有 `pages`/`routes`
-图；public manifest 和 runtime 投影把客户端路由统一放到 `routing` 下：SPA 使用
-`{ kind: "spa", routes }`，MPA/page output 使用 `{ kind: "mpa", pages }`，每个 page
-entry 自带 route 元信息。framework endpoint 留在 runtime/server 投影下。
+构建会在 `dist/build-output.json` 输出 canonical deployment metadata。内部 `BuildOutput`
+仍是内存中的 plugin/build contract，不再完整序列化落盘。client/server manifest 是部署工具
+兼容投影：`client/manifest.json` 只保留公开 assets 和 SPA/MPA routing，
+`server/manifest.json` 只保留 server entry。
+
+生成的 HTML 会内嵌浏览器 `ClientRuntime`，CLI build 默认不再写
+`client/runtime.json`。raw server bundle 消费显式的
+`dist/server/framework-runtime.json`，Node/Edge deployment adapter 则把同一份
+`FrameworkRuntime` contract 内嵌到 bootstrap 中。因此已部署 runtime 不会在启动时读取
+`dist/build-output.json` 或 manifest 文件。
+
+Runtime-required 数据刻意和 deployment metadata 分离。ClientRuntime 只保留启动和导航
+需要的 build id、transport base URL、RSC endpoint、app/page module target、mount
+selector 和必要 routing 元信息。FrameworkRuntime 保留 SSR/PPR/RSC 渲染协调和 React
+Flight client reference 数据。Deployment metadata 保留 public assets、HTML documents、
+server entry，以及 static document、page-server、server route、framework endpoint 等
+可部署 route row。
 
 ## 运行时流程
 
@@ -185,7 +186,7 @@ sequenceDiagram
   participant FrameworkRuntime as "FrameworkRuntime"
 
   Browser->>Runtime: page/app boot
-  Runtime->>ClientRuntime: load embedded or /runtime.json
+  Runtime->>ClientRuntime: read embedded JSON or configured runtime URL
   Runtime->>Shell: create internal shell
   Shell->>ClientRuntime: resolve app/page target
   Shell->>Browser: import JS/CSS module assets
@@ -300,10 +301,9 @@ Page modules 通过文件名拥有 path-to-component wiring，并通过 `render`
 `rsc`、`prerender` 等静态导出拥有渲染元信息。当 graph creation 发现 SSR、RSC
 或 partial prerender metadata 时，会从该页面模块派生所需的 server renderers、
 PPR regions、assets 和 manifest output。
-完整 BuildOutput manifest 会显式保留这些 renderer 关系：SSR、SSG 和 RSC document page
+内存中的 BuildOutput 会显式保留这些 renderer 关系：SSR、SSG 和 RSC document page
 通过由 page id 拥有的 `page-server` renderer 解析，或通过该 page 的某个 route id
-拥有的 `page-server` renderer 解析。PPR 页面改由 `ppr-shell` 和 `ppr-region`
-entry 解析。
+拥有的 `page-server` renderer 解析。PPR 页面改由 `ppr-shell` 和 `ppr-region` entry 解析。
 
 `pages.*` 保留为显式底层页面 API。它适合页面无法自然映射到 `src/pages` 文件树的场景。
 渲染元信息仍属于被引用的 page module，而不是 `ev.config.ts`。
@@ -343,7 +343,7 @@ RSC output 规则保持严格：
 - Flight endpoint 只通过 `BuildOutput.runtime.server.rsc` 表达一次。
 - 缺少 `runtime.server.rsc` 时，manifest linker 会拒绝 RSC page output。
 
-在完整 BuildOutput manifest 中，每个 RSC page renderer reference 必须解析到
+在内存 BuildOutput 校验中，每个 RSC page renderer reference 必须解析到
 `owner.pageId` 匹配该 RSC page id 的 `rsc-page` renderer。公开 manifest 可以省略这些
 server-only renderer metadata。
 
@@ -357,7 +357,8 @@ message，再进入 bundler transform 前即可定位问题。
 
 ## 部署
 
-Deployment adapter 消费 `BuildOutput`。`@evjs/ev` 提供：
+Deployment adapter 在构建过程中消费内存中的 `BuildOutput`，并可从 canonical
+`DeploymentMetadata` 投影生成平台文件。`@evjs/ev` 提供：
 
 - `createDeploymentArtifact(output)`：生成平台中立的路由、资源和服务端 metadata；
 - `nodeDeploymentAdapter()`：具体 Node 生产目标，输出 `dist/deployment.node.json`
@@ -366,15 +367,13 @@ Deployment adapter 消费 `BuildOutput`。`@evjs/ev` 提供：
 - `edgeDeploymentAdapter()`：输出 edge worker 入口，由 worker 调用框架服务端 bundle
   和静态资源 binding。
 
-平台专属 adapter 应从 `BuildOutput` 派生 routing、framework endpoint、SSR、PPR、RSC 和 asset metadata，而不是读取 bundler stats。
-构建流水线中的 adapter 会在内存里收到这个对象；构建后的工具可以读取 `dist/build-output.json`。
-完整 BuildOutput manifest 会保留面向部署的 route、asset、server function、server
-route、renderer 和 RSC page metadata，但不发布源码 module path 或 bundler chunk map。client/server manifest
+平台专属 adapter 应从内存 `BuildOutput` 派生 routing、framework endpoint、SSR、PPR、RSC
+和 asset metadata，而不是读取 bundler stats。构建后的工具应读取 `dist/build-output.json`；
+其中 route table 使用 `static-document`、`page-server`、`framework-function`、
+`framework-ppr`、`framework-rsc` 和 `server-route` 等显式 kind。client/server manifest
 是部署元信息；生成的浏览器和服务端运行时消费最小化的 ClientRuntime 和 FrameworkRuntime
-contract。这些 runtime contract 使用 `routing.kind` 区分 SPA routes 和 MPA/page targets，
-不再序列化空的顶层 `pages` 或 `routes` 字段。
-Deployment artifact 会把 framework endpoint 和 transport 数据归到 server 分组下，而不是
-重复携带原始 runtime 对象。
+contract。Deployment metadata 把 framework endpoint 表达成 route row，不重复携带原始
+runtime object，也不按单个 server function id 暴露给部署平台。
 
 部署模型由能力分类驱动：
 
@@ -393,8 +392,8 @@ edge + origin/FaaS split
   origin/FaaS resolves functions, routes, SSR/RSC, and PPR regions
 ```
 
-Adapter 应先分类 `BuildOutput`，再输出平台路由。Static hosting 不应声明支持 SSR、
-PPR、RSC、server functions 或 server routes，除非同时接入具备服务端能力的 runtime。
+Adapter 应先分类 `deploymentMetadata.routes`，再输出平台路由。Static hosting 不应声明支持
+SSR、PPR、RSC、server functions 或 server routes，除非同时接入具备服务端能力的 runtime。
 
 ## Dev 更新
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
@@ -158,8 +158,8 @@ sequenceDiagram
 
 构建会在 `dist/build-output.json` 输出 canonical deployment metadata。内部 `BuildOutput`
 仍是内存中的 plugin/build contract，不再完整序列化落盘。client/server manifest 是部署工具
-兼容投影：`client/manifest.json` 只保留公开 assets 和 SPA/MPA routing，
-`server/manifest.json` 只保留 server entry。
+兼容投影：`client/manifest.json` 保留 SPA 公开 assets，或 MPA page 级 assets 与
+routing；`server/manifest.json` 保留 server entry 和轻量 server route projection。
 
 生成的 HTML 会内嵌浏览器 `ClientRuntime`，CLI build 默认不再写
 `client/runtime.json`。raw server bundle 消费显式的

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/architecture.md
@@ -300,9 +300,11 @@ Page modules 通过文件名拥有 path-to-component wiring，并通过 `render`
 `rsc`、`prerender` 等静态导出拥有渲染元信息。当 graph creation 发现 SSR、RSC
 或 partial prerender metadata 时，会从该页面模块派生所需的 server renderers、
 PPR regions、assets 和 manifest output。
-内存中的 BuildOutput 会显式保留这些 renderer 关系：SSR、SSG 和 RSC document page
+内存中的 BuildOutput 会显式保留这些 renderer 关系：SSR 和 RSC document page
 通过由 page id 拥有的 `page-server` renderer 解析，或通过该 page 的某个 route id
-拥有的 `page-server` renderer 解析。PPR 页面改由 `ppr-shell` 和 `ppr-region` entry 解析。
+拥有的 `page-server` renderer 解析。SSG 页面在 production build 阶段使用 `page-server`
+renderer 产出静态 HTML，随后部署元信息中表现为 `static-page` route。PPR 页面改由
+`ppr-shell` 和 `ppr-region` entry 解析。
 
 `pages.*` 保留为显式底层页面 API。它适合页面无法自然映射到 `src/pages` 文件树的场景。
 渲染元信息仍属于被引用的 page module，而不是 `ev.config.ts`。
@@ -370,9 +372,12 @@ Deployment adapter 在构建过程中消费内存中的 `BuildOutput`，并可�
 和 asset metadata，而不是读取 bundler stats。构建后的工具应读取 `dist/build-output.json`；
 其中 documents table 携带 app shell fallback 元信息，route table 使用
 `static-page`、`server-page`、`server-function`、`ppr-endpoint`、`rsc-endpoint`
-和 `api-route` 等显式 kind。页面 route row 通过 `render` 单独表达 `csr`、`ssg`、
-`ssr`、`ppr` 或 `rsc` 等渲染策略，和部署 kind 分离。client/server manifest 是部署元信息；
-生成的浏览器和服务端运行时消费最小化的 ClientRuntime 和 FrameworkRuntime contract。
+和 `api-route` 等显式 kind。Static page route row 指向已输出的 HTML document，并携带
+`render: "csr" | "ssg"`；server page route row 表达由 framework server 处理的页面，并携带
+`render: "ssr"`。server page row 用 `prerender: "full" | "partial"` 表达 full prerender
+或 PPR 行为，用 `rsc: true` 表达 RSC 页面，避免把派生能力伪装成源码里的 `render` 值。
+client/server manifest 是部署元信息；生成的浏览器和服务端运行时消费最小化的 ClientRuntime 和
+FrameworkRuntime contract。
 Deployment metadata 把 framework endpoint 表达成 route row，不重复携带原始 runtime object，
 也不按单个 server function id 暴露给部署平台。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
@@ -66,8 +66,9 @@ dist-server/
 ```
 
 生成的 HTML 会内嵌浏览器启动所需的 `ClientRuntime`。`client/manifest.json` 是轻量部署
-元信息，只包含公开资源和 SPA/MPA route 信息。`server/manifest.json` 只保留 server
-entry 文件名。`server/framework-runtime.json` 是 raw server bundle 启动所需的运行时数据，
+元信息：SPA manifest 保留顶层公开 assets，MPA manifest 把 assets 保留在每个 routing
+page 上。`server/manifest.json` 保留 server entry 文件名和 server route projection。
+`server/framework-runtime.json` 是 raw server bundle 启动所需的运行时数据，
 `build-output.json` 是 canonical deployment metadata。应用代码不应该导入或修改部署
 元信息文件。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
@@ -32,8 +32,7 @@ dist/
 │   └── manifest.json
 ├── server/
 │   ├── main.[hash].js
-│   ├── manifest.json
-│   └── framework-runtime.json
+│   └── manifest.json
 └── build-output.json
 ```
 
@@ -61,16 +60,15 @@ dist/
 └── manifest.json
 dist-server/
 ├── main.[hash].js
-├── manifest.json
-└── framework-runtime.json
+└── manifest.json
 ```
 
 生成的 HTML 会内嵌浏览器启动所需的 `ClientRuntime`。`client/manifest.json` 是轻量部署
 元信息：SPA manifest 保留顶层公开 assets，MPA manifest 把 assets 保留在每个 routing
 page 上。`server/manifest.json` 保留 server entry 文件名和 server route projection。
-`server/framework-runtime.json` 是 raw server bundle 启动所需的运行时数据，
-`build-output.json` 是 canonical deployment metadata。应用代码不应该导入或修改部署
-元信息文件。
+Runtime-only 的 `FrameworkRuntime` 数据会注入 dev 和 deployment bootstrap，不再作为
+JSON 文件输出。`build-output.json` 是 canonical deployment metadata。应用代码不应该导入或
+修改部署元信息文件。
 
 ## 页面输出
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
@@ -29,11 +29,12 @@ dist/
 │   ├── index.html
 │   ├── main.[hash].js
 │   ├── [chunk].[hash].js
+│   └── manifest.json
+├── server/
+│   ├── main.[hash].js
 │   ├── manifest.json
-│   └── runtime.json
-└── server/
-    ├── main.[hash].js
-    └── manifest.json
+│   └── framework-runtime.json
+└── build-output.json
 ```
 
 如果部署平台要求 public 文件在其他目录，可以配置 `output.client` 和
@@ -57,17 +58,18 @@ dist/
 ├── index.html
 ├── main.[hash].js
 ├── [chunk].[hash].js
-├── manifest.json
-└── runtime.json
+└── manifest.json
 dist-server/
 ├── main.[hash].js
-└── manifest.json
+├── manifest.json
+└── framework-runtime.json
 ```
 
-`runtime.json` 是只包含启动、导航、transport 和 RSC endpoint 数据的浏览器运行时配置。
-`manifest.json` 和 `build-output.json` 是部署/工具元信息。client route 条目只是
-URL 到 app/page 的索引；页面渲染行为保留在 page 记录上，runtime endpoint 不进入公开
-client manifest。应用代码不应该导入或修改这些文件。
+生成的 HTML 会内嵌浏览器启动所需的 `ClientRuntime`。`client/manifest.json` 是轻量部署
+元信息，只包含公开资源和 SPA/MPA route 信息。`server/manifest.json` 只保留 server
+entry 文件名。`server/framework-runtime.json` 是 raw server bundle 启动所需的运行时数据，
+`build-output.json` 是 canonical deployment metadata。应用代码不应该导入或修改部署
+元信息文件。
 
 ## 页面输出
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
@@ -90,7 +90,9 @@ export default function ProductPage() {
 }
 ```
 
-静态页面使用 `render = "ssg"`。Partial prerendering 使用 `render = "ssr"`
+构建期静态生成使用 `render = "ssg"`，并要求页面拥有静态可寻址路径。`ev build`
+会把该页面渲染成输出 HTML，例如 `dist/client/report.html`，部署元信息中表现为
+`static-page` route。服务端页面的 partial prerendering 使用 `render = "ssr"`
 加 `prerender = { partial: true }`。
 
 ```tsx

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/client-routes.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/client-routes.md
@@ -121,10 +121,9 @@ export default defineConfig({
 ```
 
 MPA 模式下，每个发现到的 CSR 页面都会生成独立 HTML 文档和客户端 entry。
-导出 `render = "ssg"` 的文件路由会输出独立 static HTML document，并获得用于
-static generation 的 server renderer；默认不创建 browser page entry。MPA 不会引入
-客户端路由器配置。文件路由可以通过旁边同 basename 的 `.html` 文件使用页面专属
-HTML 模板，例如 `src/pages/about.tsx` 对应 `src/pages/about.html`，
+导出 `render = "ssg"` 的文件路由会在 `ev build` 期间渲染成独立 static HTML
+document；默认不创建 browser page entry。MPA 不会引入客户端路由器配置。文件路由可以通过旁边同 basename
+的 `.html` 文件使用页面专属 HTML 模板，例如 `src/pages/about.tsx` 对应 `src/pages/about.html`，
 `src/pages/product/index.tsx` 对应 `src/pages/product/index.html`；没有 colocated
 模板的路由默认使用全局 `index.html` 模板。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deploy.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deploy.md
@@ -19,10 +19,10 @@ npm run build
 dist/
 ├── client/
 │   ├── manifest.json
-│   ├── runtime.json
 │   └── ...
 ├── server/
 │   ├── manifest.json
+│   ├── framework-runtime.json
 │   └── ...
 └── build-output.json
 ```
@@ -31,13 +31,12 @@ dist/
 
 - `dist/client/`：浏览器资源和生成的 HTML。
 - `dist/client/manifest.json`：给部署工具消费的浏览器安全路由和资源元信息。
-- `dist/client/runtime.json`：生成的页面 bootstrap 在 HTML 未内嵌配置时加载的最小浏览器运行时配置。
 - `dist/server/`：应用使用服务端函数、服务端文件路由、SSR、PPR 或 RSC 时生成的服务端 bundle 和服务端元信息。
-- `dist/build-output.json`：面向工具和部署 adapter 的完整构建元信息。应用代码不应导入或修改它。
+- `dist/server/manifest.json`：为了部署兼容保留的 entry-only server manifest。
+- `dist/server/framework-runtime.json`：raw server bundle 启动所需的框架运行时数据。
+- `dist/build-output.json`：面向工具和部署 adapter 的 canonical deployment metadata。应用代码不应导入或修改它。
 
-如果页面 HTML 没有内嵌 runtime config，浏览器 runtime 会从配置的 runtime URL 或
-`/runtime.json` 获取它。部署时应把该响应作为 JSON 返回，并设置
-`Content-Type: application/json`。
+生成的 HTML 会内嵌浏览器 `ClientRuntime`。手动使用 `@evjs/client` runtime URL API 时仍可从配置的 URL 加载 JSON，但 CLI build 默认不再输出 `dist/client/runtime.json`。
 
 ## 选择部署目标
 
@@ -193,21 +192,20 @@ CMD ["node", "dist/server.mjs"]
 
 ## 自定义部署插件
 
-部署插件可以使用 `buildEnd({ output })` 输出平台文件。需要可复用的元信息结构时，可以从
-`createDeploymentArtifact()` 开始：
+部署插件可以使用 `buildEnd({ deploymentMetadata })` 输出平台文件。需要平台专属兼容字段时，
+可以在写文件前包装这份 metadata：
 
 ```ts
-import { createDeploymentArtifact } from "@evjs/ev";
-
 export function deployAdapter() {
   return {
     name: "deploy-adapter",
     setup() {
       return {
-        buildEnd({ output }) {
-          const artifact = createDeploymentArtifact(output, {
+        buildEnd({ deploymentMetadata }) {
+          const artifact = {
+            ...deploymentMetadata,
             platform: "custom",
-          });
+          };
 
           emitPlatformFiles(artifact);
         },

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deploy.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deploy.md
@@ -22,7 +22,6 @@ dist/
 │   └── ...
 ├── server/
 │   ├── manifest.json
-│   ├── framework-runtime.json
 │   └── ...
 └── build-output.json
 ```
@@ -34,10 +33,11 @@ dist/
 - `dist/server/`：应用使用服务端函数、服务端文件路由、SSR、PPR 或 RSC 时生成的服务端 bundle 和服务端元信息。
 - `dist/server/manifest.json`：为了部署兼容保留的轻量 server manifest，包含 server entry
   和服务端处理的 route projection。
-- `dist/server/framework-runtime.json`：raw server bundle 启动所需的框架运行时数据。
 - `dist/build-output.json`：面向工具和部署 adapter 的 canonical deployment metadata。应用代码不应导入或修改它。
 
 生成的 HTML 会内嵌浏览器 `ClientRuntime`。手动使用 `@evjs/client` runtime URL API 时仍可从配置的 URL 加载 JSON，但 CLI build 默认不再输出 `dist/client/runtime.json`。
+Runtime-only 的 `FrameworkRuntime` 数据通过 build/plugin result 传递，并注入 dev 或 deployment
+adapter bootstrap，不再作为默认 JSON artifact 输出。
 
 ## 选择部署目标
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deploy.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deploy.md
@@ -32,7 +32,8 @@ dist/
 - `dist/client/`：浏览器资源和生成的 HTML。
 - `dist/client/manifest.json`：给部署工具消费的浏览器安全路由和资源元信息。
 - `dist/server/`：应用使用服务端函数、服务端文件路由、SSR、PPR 或 RSC 时生成的服务端 bundle 和服务端元信息。
-- `dist/server/manifest.json`：为了部署兼容保留的 entry-only server manifest。
+- `dist/server/manifest.json`：为了部署兼容保留的轻量 server manifest，包含 server entry
+  和服务端处理的 route projection。
 - `dist/server/framework-runtime.json`：raw server bundle 启动所需的框架运行时数据。
 - `dist/build-output.json`：面向工具和部署 adapter 的 canonical deployment metadata。应用代码不应导入或修改它。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugins.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugins.md
@@ -184,9 +184,10 @@ setup() {
 ```
 
 部署插件应该从 `output` 读取 routes、functions、assets 和 runtime paths。
-只需要客户端 bundle 摘要的插件可以使用 `clientManifest`；只需要 server entry、
-function ids 或 route method 摘要的插件可以使用 `serverManifest`。HTML hook 会收到
-同一组结果字段，并额外包含 `ctx.kind`、`ctx.fileName`、`ctx.assets` 等文档字段。
+只需要客户端 bundle 摘要的插件可以使用 `clientManifest`：读取 SPA `routes` 或 MPA
+`pages` 前先检查 `clientManifest.kind`。只需要 server entry、function ids 或 route
+method 摘要的插件可以使用 `serverManifest`。HTML hook 会收到同一组结果字段，并额外包含
+`ctx.kind`、`ctx.fileName`、`ctx.assets` 等文档字段。
 
 ## Bundler Config
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugins.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugins.md
@@ -183,6 +183,7 @@ setup() {
       console.log("Pages:", Object.keys(output.pages));
       console.log("Client asset groups:", Object.keys(clientManifest.assets ?? {}));
       console.log("Server entry:", serverManifest.entry);
+      console.log("Server routes:", serverManifest.routes.length);
       console.log("Deploy routes:", deploymentMetadata.routes.length);
       console.log("Rebuild:", isRebuild);
     },
@@ -193,8 +194,9 @@ setup() {
 部署插件应优先从 `deploymentMetadata` 读取 routes、documents、assets 和 server entry。
 需要完整内部构建图的插件仍可在内存中检查 `output`。只需要客户端 bundle 摘要的插件可以使用
 `clientManifest`：读取 SPA `routes` 或 MPA `pages` 前先检查
-`clientManifest.routing.kind`。`serverManifest` 只保留 entry。HTML hook 会收到同一组结果
-字段，并额外包含 `ctx.kind`、`ctx.fileName`、`ctx.assets` 等文档字段。
+`clientManifest.routing.kind`。只需要 server entry 和服务端处理 route 摘要的插件可以读取
+`serverManifest.routes`；完整部署规划仍应使用 `deploymentMetadata.routes`。HTML hook 会收到
+同一组结果字段，并额外包含 `ctx.kind`、`ctx.fileName`、`ctx.assets` 等文档字段。
 
 ## Bundler Config
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugins.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugins.md
@@ -167,27 +167,34 @@ import type { HtmlDocument } from "@evjs/ev";
 
 ## Build Result
 
-`buildEnd()` 接收最终构建输出，以及更聚焦的 client/server manifest 视图：
+`buildEnd()` 接收最终构建输出，以及更聚焦的 client/server manifest 和 deployment metadata 视图：
 
 ```ts
 setup() {
   return {
-    buildEnd({ output, clientManifest, serverManifest, isRebuild }) {
+    buildEnd({
+      output,
+      clientManifest,
+      serverManifest,
+      deploymentMetadata,
+      isRebuild,
+    }) {
       console.log("Apps:", Object.keys(output.apps));
       console.log("Pages:", Object.keys(output.pages));
-      console.log("Client JS:", clientManifest.assets.js);
+      console.log("Client asset groups:", Object.keys(clientManifest.assets ?? {}));
       console.log("Server entry:", serverManifest.entry);
+      console.log("Deploy routes:", deploymentMetadata.routes.length);
       console.log("Rebuild:", isRebuild);
     },
   };
 }
 ```
 
-部署插件应该从 `output` 读取 routes、functions、assets 和 runtime paths。
-只需要客户端 bundle 摘要的插件可以使用 `clientManifest`：读取 SPA `routes` 或 MPA
-`pages` 前先检查 `clientManifest.kind`。只需要 server entry、function ids 或 route
-method 摘要的插件可以使用 `serverManifest`。HTML hook 会收到同一组结果字段，并额外包含
-`ctx.kind`、`ctx.fileName`、`ctx.assets` 等文档字段。
+部署插件应优先从 `deploymentMetadata` 读取 routes、documents、assets 和 server entry。
+需要完整内部构建图的插件仍可在内存中检查 `output`。只需要客户端 bundle 摘要的插件可以使用
+`clientManifest`：读取 SPA `routes` 或 MPA `pages` 前先检查
+`clientManifest.routing.kind`。`serverManifest` 只保留 entry。HTML hook 会收到同一组结果
+字段，并额外包含 `ctx.kind`、`ctx.fileName`、`ctx.assets` 等文档字段。
 
 ## Bundler Config
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugins.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugins.md
@@ -184,9 +184,9 @@ setup() {
 ```
 
 部署插件应该从 `output` 读取 routes、functions、assets 和 runtime paths。
-只需要客户端或服务端 bundle 摘要的插件可以使用 `clientManifest` 和
-`serverManifest`。HTML hook 会收到同一组结果字段，并额外包含 `ctx.kind`、
-`ctx.fileName`、`ctx.assets` 等文档字段。
+只需要客户端 bundle 摘要的插件可以使用 `clientManifest`；只需要 server entry、
+function ids 或 route method 摘要的插件可以使用 `serverManifest`。HTML hook 会收到
+同一组结果字段，并额外包含 `ctx.kind`、`ctx.fileName`、`ctx.assets` 等文档字段。
 
 ## Bundler Config
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/roadmap.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/roadmap.md
@@ -15,9 +15,10 @@
 - `ev inspect` CLI preflight，可在不运行 bundler、不写入 `dist` 的情况下解释
   page route discovery、server declarations、render metadata、runtime paths、
   planned entries 和 diagnostics。
-- 通过 `output.client` 和 `output.server` 配置 framework manifest 目录，并保留完整私有
-  `dist/build-output.json` handoff。
-- 通过公开 `@evjs/client` runtime 包提供 manifest-driven app/page activation。
+- 通过 `output.client` 和 `output.server` 配置 framework metadata 目录，并在
+  `dist/build-output.json` 输出 canonical deployment metadata。
+- 通过公开 `@evjs/client` runtime 包和生成的 framework bootstrap 提供
+  ClientRuntime-driven app/page activation。
 - 框架托管 SPA 页面路由，并为 MPA 提供无路由器 page runtime。
 - Webpack adapter 用于在 Utoopack 下层 API 补齐前验证框架能力。
 - 聚焦 render mode 和 deployment adapter 的示例，并通过 e2e 覆盖 apps、组件页面、SSR/PPR/RSC 和 per-document HTML transform。

--- a/e2e/cases/deployment-adapters.ts
+++ b/e2e/cases/deployment-adapters.ts
@@ -92,7 +92,7 @@ test.describe("deployment-adapters", () => {
       }),
     );
     expect(manifest.deployment.deploymentAdaptersExample).toEqual({
-      apps: ["default"],
+      app: true,
       pages: [],
       rscPages: [],
       serverBasePath: "/__evjs",
@@ -113,7 +113,7 @@ test.describe("deployment-adapters", () => {
       serverDir: "dist/server",
     });
     expect(deployArtifactText).not.toContain('"chunks"');
-    expect(deployArtifact.apps.default).toEqual(
+    expect(deployArtifact.app).toEqual(
       expect.objectContaining({ mount: "#app" }),
     );
     expect(deployArtifact.server).toEqual(

--- a/e2e/cases/deployment-adapters.ts
+++ b/e2e/cases/deployment-adapters.ts
@@ -62,36 +62,38 @@ test.describe("deployment-adapters", () => {
       serverDir: "dist/server",
     });
     expect(manifestText).not.toContain('"chunks"');
-    expect(manifest.apps.default).toEqual(
-      expect.objectContaining({
-        mount: "#app",
-        module: expect.objectContaining({ type: "entry" }),
-      }),
-    );
-    expect(manifest.pages ?? {}).toEqual({});
-    expect(manifest.routes ?? []).toEqual([]);
-    expect(Object.values(manifest.server.functions)).toEqual(
+    expect("apps" in manifest).toBe(false);
+    expect("pages" in manifest).toBe(false);
+    expect("runtime" in manifest).toBe(false);
+    expect(manifest.documents).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          exportName: "getMerchantOperationsSnapshot",
+          kind: "app",
+          id: "default",
+          fileName: "index.html",
         }),
       ]),
     );
-    expect(manifest.server.routes).toEqual(
+    expect(manifest.routes).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
+        {
+          kind: "framework-function",
+          path: "/__evjs/fn",
+          methods: ["POST"],
+        },
+        {
+          kind: "server-route",
           path: "/api/deployment-adapters/health",
-          methods: expect.arrayContaining(["GET"]),
-        }),
+          methods: ["GET"],
+        },
       ]),
     );
-    expect(manifest.runtime.server).toEqual(
+    expect(manifest.server).toEqual(
       expect.objectContaining({
-        basePath: "/__evjs",
-        fn: "/__evjs/fn",
+        entry: expect.any(String),
       }),
     );
-    expect(manifest.deployment.deploymentAdaptersExample).toEqual({
+    expect(manifest.metadata.deploymentAdaptersExample).toEqual({
       app: true,
       pages: [],
       rscPages: [],
@@ -113,27 +115,33 @@ test.describe("deployment-adapters", () => {
       serverDir: "dist/server",
     });
     expect(deployArtifactText).not.toContain('"chunks"');
-    expect(deployArtifact.app).toEqual(
-      expect.objectContaining({ mount: "#app" }),
-    );
-    expect(deployArtifact.server).toEqual(
-      expect.objectContaining({
-        basePath: "/__evjs",
-        fn: "/__evjs/fn",
-      }),
-    );
-    expect(deployArtifact.server.functions).toHaveLength(1);
-    expect(deployArtifact.server.routes).toEqual(
+    expect("app" in deployArtifact).toBe(false);
+    expect(deployArtifact.documents).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          path: "/api/deployment-adapters/health",
+          kind: "app",
+          id: "default",
+          fileName: "index.html",
         }),
+      ]),
+    );
+    expect(deployArtifact.routes).toEqual(
+      expect.arrayContaining([
+        {
+          kind: "framework-function",
+          path: "/__evjs/fn",
+          methods: ["POST"],
+        },
+        {
+          kind: "server-route",
+          path: "/api/deployment-adapters/health",
+          methods: ["GET"],
+        },
       ]),
     );
     expect(deployArtifact.metadata).toEqual(
       expect.objectContaining({
-        deploymentAdaptersExample:
-          manifest.deployment.deploymentAdaptersExample,
+        deploymentAdaptersExample: manifest.metadata.deploymentAdaptersExample,
       }),
     );
 
@@ -147,7 +155,7 @@ test.describe("deployment-adapters", () => {
       expect.objectContaining({
         platform: "node",
         server: expect.objectContaining({
-          basePath: "/__evjs",
+          entry: expect.any(String),
         }),
       }),
     );

--- a/e2e/cases/deployment-adapters.ts
+++ b/e2e/cases/deployment-adapters.ts
@@ -53,7 +53,15 @@ test.describe("deployment-adapters", () => {
   test("emits manifest and deployment artifacts from BuildOutput", async () => {
     const manifestPath = path.join(exampleDir, "dist", "build-output.json");
     const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+    const manifestText = JSON.stringify(manifest);
 
+    expect("distDir" in manifest).toBe(false);
+    expect(manifest.paths).toEqual({
+      rootDir: "dist",
+      publicDir: "dist/client",
+      serverDir: "dist/server",
+    });
+    expect(manifestText).not.toContain('"chunks"');
     expect(manifest.apps.default).toEqual(
       expect.objectContaining({
         mount: "#app",
@@ -96,7 +104,15 @@ test.describe("deployment-adapters", () => {
         "utf-8",
       ),
     );
+    const deployArtifactText = JSON.stringify(deployArtifact);
     expect(deployArtifact.platform).toBe("deployment-adapters-example");
+    expect("distDir" in deployArtifact).toBe(false);
+    expect(deployArtifact.paths).toEqual({
+      rootDir: "dist",
+      publicDir: "dist/client",
+      serverDir: "dist/server",
+    });
+    expect(deployArtifactText).not.toContain('"chunks"');
     expect(deployArtifact.apps.default).toEqual(
       expect.objectContaining({ mount: "#app" }),
     );

--- a/e2e/cases/deployment-adapters.ts
+++ b/e2e/cases/deployment-adapters.ts
@@ -77,12 +77,12 @@ test.describe("deployment-adapters", () => {
     expect(manifest.routes).toEqual(
       expect.arrayContaining([
         {
-          kind: "framework-function",
+          kind: "server-function",
           path: "/__evjs/fn",
           methods: ["POST"],
         },
         {
-          kind: "server-route",
+          kind: "api-route",
           path: "/api/deployment-adapters/health",
           methods: ["GET"],
         },
@@ -128,12 +128,12 @@ test.describe("deployment-adapters", () => {
     expect(deployArtifact.routes).toEqual(
       expect.arrayContaining([
         {
-          kind: "framework-function",
+          kind: "server-function",
           path: "/__evjs/fn",
           methods: ["POST"],
         },
         {
-          kind: "server-route",
+          kind: "api-route",
           path: "/api/deployment-adapters/health",
           methods: ["GET"],
         },

--- a/e2e/cases/mpa.ts
+++ b/e2e/cases/mpa.ts
@@ -91,10 +91,16 @@ test.describe("mpa", () => {
   test("emits MPA pages in manifest", async () => {
     const manifestPath = path.join(exampleDir, "dist", "manifest.json");
     const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as {
-      pages?: Record<string, unknown>;
+      routing?: {
+        kind?: string;
+        pages?: Record<string, unknown>;
+      };
     };
 
-    expect(manifest.pages).toEqual({
+    expect(manifest).not.toHaveProperty("pages");
+    expect(manifest).not.toHaveProperty("routes");
+    expect(manifest.routing?.kind).toBe("mpa");
+    expect(manifest.routing?.pages).toEqual({
       about: expect.objectContaining({
         assets: expect.objectContaining({
           js: expect.arrayContaining([expect.stringMatching(/about.*\.js$/)]),

--- a/e2e/cases/mpa.ts
+++ b/e2e/cases/mpa.ts
@@ -109,6 +109,7 @@ test.describe("mpa", () => {
         }),
         document: { fileName: "about.html" },
         path: "/about",
+        render: "csr",
         routeId: "about",
       }),
       home: expect.objectContaining({
@@ -118,12 +119,12 @@ test.describe("mpa", () => {
         }),
         document: { fileName: "home.html" },
         path: "/home",
+        render: "csr",
         routeId: "home",
       }),
     });
     const publicManifestText = fs.readFileSync(manifestPath, "utf-8");
     expect(publicManifestText).not.toContain(".tsx");
-    expect(publicManifestText).not.toContain('"render"');
     expect(publicManifestText).not.toContain('"module"');
   });
 });

--- a/e2e/cases/mpa.ts
+++ b/e2e/cases/mpa.ts
@@ -99,6 +99,7 @@ test.describe("mpa", () => {
 
     expect(manifest).not.toHaveProperty("pages");
     expect(manifest).not.toHaveProperty("routes");
+    expect(manifest).not.toHaveProperty("assets");
     expect(manifest.routing?.kind).toBe("mpa");
     expect(manifest.routing?.pages).toEqual({
       about: expect.objectContaining({

--- a/e2e/cases/mpa.ts
+++ b/e2e/cases/mpa.ts
@@ -106,37 +106,23 @@ test.describe("mpa", () => {
           js: expect.arrayContaining([expect.stringMatching(/about.*\.js$/)]),
           css: expect.any(Array),
         }),
-        render: "csr",
-        hydrate: "load",
-        rendering: expect.objectContaining({
-          component: "client",
-          html: "client",
-          hydrate: "load",
-        }),
-        module: expect.objectContaining({
-          type: "react-component",
-          href: expect.stringMatching(/\.js$/),
-        }),
+        document: { fileName: "about.html" },
+        path: "/about",
+        routeId: "about",
       }),
       home: expect.objectContaining({
         assets: expect.objectContaining({
           js: expect.arrayContaining([expect.stringMatching(/home.*\.js$/)]),
           css: expect.any(Array),
         }),
-        render: "csr",
-        hydrate: "load",
-        rendering: expect.objectContaining({
-          component: "client",
-          html: "client",
-          hydrate: "load",
-        }),
-        module: expect.objectContaining({
-          type: "react-component",
-          href: expect.stringMatching(/\.js$/),
-        }),
+        document: { fileName: "home.html" },
+        path: "/home",
+        routeId: "home",
       }),
     });
     const publicManifestText = fs.readFileSync(manifestPath, "utf-8");
     expect(publicManifestText).not.toContain(".tsx");
+    expect(publicManifestText).not.toContain('"render"');
+    expect(publicManifestText).not.toContain('"module"');
   });
 });

--- a/e2e/cases/plugin-authoring.ts
+++ b/e2e/cases/plugin-authoring.ts
@@ -16,6 +16,7 @@ test.describe("plugin-authoring", () => {
   test("uses server endpoint configured by plugin config hook", async ({
     page,
     baseURL,
+    apiURL,
   }) => {
     const rpcResponsePromise = page.waitForResponse((res) => {
       const url = new URL(res.url());
@@ -41,7 +42,7 @@ test.describe("plugin-authoring", () => {
     await expect(page.getByText("Server mode: production")).toBeVisible();
 
     const defaultEndpointResponse = await page.request.post(
-      new URL("__evjs/fn", baseURL).toString(),
+      new URL("__evjs/fn", apiURL).toString(),
       {
         data: { fnId: "missing", args: [] },
       },

--- a/e2e/cases/render-modes.ts
+++ b/e2e/cases/render-modes.ts
@@ -110,7 +110,7 @@ test.describe("render-modes", () => {
     ).toBeVisible();
   });
 
-  test("serves a configured SSG page path through the framework server", async ({
+  test("serves a full-prerendered SSR page path through the framework server", async ({
     page,
     request,
     baseURL,
@@ -120,18 +120,18 @@ test.describe("render-modes", () => {
     expect(htmlResponse.status()).toBe(200);
     const html = await htmlResponse.text();
     expect(html).toContain("Settlement Readiness Report");
-    expect(html).toContain('data-render-mode="ssg"');
+    expect(html).toContain('data-render-mode="ssr"');
     expect(html).not.toContain("settlement.js");
 
     await page.goto(`${baseURL}/settlement-report`);
-    await expectRenderMode(page, "ssg", "SSG");
+    await expectRenderMode(page, "ssr", "Prerendered SSR");
     await expectBackLink(page);
 
     await expect(
       page.getByRole("heading", { name: "Settlement Readiness Report" }),
     ).toBeVisible({ timeout: 10_000 });
     await expect(page.getByTestId("settlement-render-mode")).toHaveText(
-      "static",
+      "full prerender",
     );
     await expect(page.getByTestId("settlement-hydration")).toHaveText("none");
     await expect(page.getByTestId("settlement-ready-count")).toHaveText("2");
@@ -355,10 +355,10 @@ test.describe("render-modes", () => {
     );
     expect(runtimePages.settlement).toEqual(
       expect.objectContaining({
-        render: "ssg",
+        render: "ssr",
         rendering: {
           component: "server",
-          html: "static",
+          html: "server",
           prerender: "full",
           streaming: false,
           hydrate: "none",
@@ -437,7 +437,8 @@ test.describe("render-modes", () => {
           kind: "server-page",
           path: "/settlement-report",
           pageId: "settlement",
-          render: "ssg",
+          render: "ssr",
+          prerender: "full",
           methods: ["GET", "HEAD"],
         },
         {
@@ -481,21 +482,24 @@ test.describe("render-modes", () => {
           kind: "server-page",
           path: "/settlement-report",
           pageId: "settlement",
-          render: "ssg",
+          render: "ssr",
+          prerender: "full",
           methods: ["GET", "HEAD"],
         },
         {
           kind: "server-page",
           path: "/campaign",
           pageId: "campaign",
-          render: "ppr",
+          render: "ssr",
+          prerender: "partial",
           methods: ["GET", "HEAD"],
         },
         {
           kind: "server-page",
           path: "/insights",
           pageId: "insights",
-          render: "rsc",
+          render: "ssr",
+          rsc: true,
           methods: ["GET", "HEAD"],
         },
         {

--- a/e2e/cases/render-modes.ts
+++ b/e2e/cases/render-modes.ts
@@ -427,34 +427,36 @@ test.describe("render-modes", () => {
     expect(deploymentMetadata.routes).toEqual(
       expect.arrayContaining([
         {
-          kind: "page-server",
+          kind: "server-page",
           path: "/dashboard",
           pageId: "dashboard",
+          render: "ssr",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "page-server",
+          kind: "server-page",
           path: "/settlement-report",
           pageId: "settlement",
+          render: "ssg",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "framework-function",
+          kind: "server-function",
           path: "/__evjs/fn",
           methods: ["POST"],
         },
         {
-          kind: "framework-ppr",
+          kind: "ppr-endpoint",
           path: "/__evjs/ppr/*",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "framework-rsc",
+          kind: "rsc-endpoint",
           path: "/__evjs/rsc",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "server-route",
+          kind: "api-route",
           path: "/api/render-modes/health",
           methods: ["GET"],
         },
@@ -469,46 +471,50 @@ test.describe("render-modes", () => {
     expect(serverManifest.routes).toEqual(
       expect.arrayContaining([
         {
-          kind: "page-server",
+          kind: "server-page",
           path: "/dashboard",
           pageId: "dashboard",
+          render: "ssr",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "page-server",
+          kind: "server-page",
           path: "/settlement-report",
           pageId: "settlement",
+          render: "ssg",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "page-server",
+          kind: "server-page",
           path: "/campaign",
           pageId: "campaign",
+          render: "ppr",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "page-server",
+          kind: "server-page",
           path: "/insights",
           pageId: "insights",
+          render: "rsc",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "framework-function",
+          kind: "server-function",
           path: "/__evjs/fn",
           methods: ["POST"],
         },
         {
-          kind: "framework-ppr",
+          kind: "ppr-endpoint",
           path: "/__evjs/ppr/*",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "framework-rsc",
+          kind: "rsc-endpoint",
           path: "/__evjs/rsc",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "server-route",
+          kind: "api-route",
           path: "/api/render-modes/health",
           methods: ["GET"],
         },
@@ -516,13 +522,12 @@ test.describe("render-modes", () => {
     );
     expect(
       serverManifest.routes.some(
-        (route: { kind: string }) =>
-          route.kind === "static-document" || route.kind === "spa-fallback",
+        (route: { kind: string }) => route.kind === "static-page",
       ),
     ).toBe(false);
     expect(serverManifestText).not.toContain('"assets"');
     expect(serverManifestText).not.toContain('"renderers"');
-    expect(serverManifestText).not.toContain('"rsc"');
+    expect(serverManifestText).not.toContain("insights-rsc");
     expect(serverManifestText).not.toContain("getMerchantOperationsSnapshot");
     expect("runtime" in deploymentMetadata).toBe(false);
     expect("rsc" in deploymentMetadata).toBe(false);

--- a/e2e/cases/render-modes.ts
+++ b/e2e/cases/render-modes.ts
@@ -255,7 +255,16 @@ test.describe("render-modes", () => {
     const manifestPath = getRenderModesPublicManifestPath();
     const manifest = readRenderModesPublicManifest();
     const buildOutput = readRenderModesBuildOutput();
+    const buildOutputText = JSON.stringify(buildOutput);
+    const frameworkRuntime = readRenderModesFrameworkRuntime();
 
+    expect("distDir" in buildOutput).toBe(false);
+    expect(buildOutput.paths).toEqual({
+      rootDir: "dist",
+      publicDir: "dist/client",
+      serverDir: "dist/server",
+    });
+    expect(buildOutputText).not.toContain('"chunks"');
     expect(manifest.apps.default).toEqual(
       expect.objectContaining({
         mount: "#app",
@@ -407,8 +416,21 @@ test.describe("render-modes", () => {
     expect(manifest.rsc.clientReferences).toBeUndefined();
     expect(manifest.rsc.clientReferenceManifest).toBeUndefined();
     expect(manifest.rsc.serverConsumerManifest).toBeUndefined();
+    expect(frameworkRuntime.rsc.clientReferenceManifest).toBeDefined();
+    expect(
+      fs.existsSync(
+        path.join(exampleDir, "dist/client/react-client-manifest.json"),
+      ),
+    ).toBe(false);
+    expect(
+      fs.existsSync(
+        path.join(exampleDir, "dist/client/react-ssr-manifest.json"),
+      ),
+    ).toBe(false);
 
     const publicManifestText = fs.readFileSync(manifestPath, "utf-8");
+    expect(publicManifestText).not.toContain('"distDir"');
+    expect(publicManifestText).not.toContain('"chunks"');
     expect(publicManifestText).not.toContain(".tsx");
     expect(publicManifestText).not.toContain("file://");
     expect(publicManifestText).not.toContain(exampleDir);
@@ -449,6 +471,12 @@ function readRenderModesBuildOutput() {
       path.join(exampleDir, "dist", "build-output.json"),
       "utf-8",
     ),
+  );
+}
+
+function readRenderModesFrameworkRuntime() {
+  return JSON.parse(
+    fs.readFileSync(path.join(exampleDir, "dist/server/runtime.json"), "utf-8"),
   );
 }
 

--- a/e2e/cases/render-modes.ts
+++ b/e2e/cases/render-modes.ts
@@ -266,6 +266,8 @@ test.describe("render-modes", () => {
   test("emits a manifest with app, page, route, and server data", async () => {
     const manifestPath = getRenderModesPublicManifestPath();
     const manifest = readRenderModesPublicManifest();
+    const serverManifest = readRenderModesServerManifest();
+    const serverManifestText = JSON.stringify(serverManifest);
     const deploymentMetadata = readRenderModesDeploymentMetadata();
     const deploymentMetadataText = JSON.stringify(deploymentMetadata);
     const frameworkRuntime = readRenderModesFrameworkRuntime();
@@ -288,6 +290,7 @@ test.describe("render-modes", () => {
     expect("app" in manifest).toBe(false);
     expect(manifest).not.toHaveProperty("pages");
     expect(manifest).not.toHaveProperty("routes");
+    expect(manifest).not.toHaveProperty("assets");
     expect(manifest.routing.kind).toBe("mpa");
     expect(publicPages.support).toEqual(
       expect.objectContaining({
@@ -460,6 +463,65 @@ test.describe("render-modes", () => {
         entry: expect.any(String),
       }),
     );
+    expect(serverManifest.entry).toEqual(expect.any(String));
+    expect(serverManifest.routes).toEqual(
+      expect.arrayContaining([
+        {
+          kind: "page-server",
+          path: "/dashboard",
+          pageId: "dashboard",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "page-server",
+          path: "/settlement-report",
+          pageId: "settlement",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "page-server",
+          path: "/campaign",
+          pageId: "campaign",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "page-server",
+          path: "/insights",
+          pageId: "insights",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "framework-function",
+          path: "/__evjs/fn",
+          methods: ["POST"],
+        },
+        {
+          kind: "framework-ppr",
+          path: "/__evjs/ppr/*",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "framework-rsc",
+          path: "/__evjs/rsc",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "server-route",
+          path: "/api/render-modes/health",
+          methods: ["GET"],
+        },
+      ]),
+    );
+    expect(
+      serverManifest.routes.some(
+        (route: { kind: string }) =>
+          route.kind === "static-document" || route.kind === "spa-fallback",
+      ),
+    ).toBe(false);
+    expect(serverManifestText).not.toContain('"assets"');
+    expect(serverManifestText).not.toContain('"renderers"');
+    expect(serverManifestText).not.toContain('"rsc"');
+    expect(serverManifestText).not.toContain("getMerchantOperationsSnapshot");
     expect("runtime" in deploymentMetadata).toBe(false);
     expect("rsc" in deploymentMetadata).toBe(false);
     expect(frameworkRuntime.runtime.server).toEqual(
@@ -526,6 +588,15 @@ function getRenderModesPublicManifestPath(): string {
 function readRenderModesPublicManifest() {
   return JSON.parse(
     fs.readFileSync(getRenderModesPublicManifestPath(), "utf-8"),
+  );
+}
+
+function readRenderModesServerManifest() {
+  return JSON.parse(
+    fs.readFileSync(
+      path.join(exampleDir, "dist", "server", "manifest.json"),
+      "utf-8",
+    ),
   );
 }
 

--- a/e2e/cases/render-modes.ts
+++ b/e2e/cases/render-modes.ts
@@ -144,6 +144,7 @@ test.describe("render-modes", () => {
     request,
     baseURL,
     apiURL,
+    frameworkRuntime,
   }) => {
     const browserRegionRequests: string[] = [];
     page.on("request", (browserRequest) => {
@@ -180,7 +181,7 @@ test.describe("render-modes", () => {
     expect(pageResponse.status()).toBe(200);
     expect(pageResponse.headers()["x-evjs-ppr"]).toBe("stream");
     const pageHtml = await pageResponse.text();
-    const runtimePages = getRenderModesRuntimePages();
+    const runtimePages = getRenderModesRuntimePages(frameworkRuntime);
     const campaignPpr = getRenderModesCampaignPpr(runtimePages);
     const { id: regionId } = getSinglePprRegion(campaignPpr.regions);
     expect(pageHtml).toContain(`data-evjs-ppr-stream-region="${regionId}"`);
@@ -263,14 +264,15 @@ test.describe("render-modes", () => {
     expect(flightText).toContain("Atlas Foods");
   });
 
-  test("emits a manifest with app, page, route, and server data", async () => {
+  test("emits a manifest with app, page, route, and server data", async ({
+    frameworkRuntime,
+  }) => {
     const manifestPath = getRenderModesPublicManifestPath();
     const manifest = readRenderModesPublicManifest();
     const serverManifest = readRenderModesServerManifest();
     const serverManifestText = JSON.stringify(serverManifest);
     const deploymentMetadata = readRenderModesDeploymentMetadata();
     const deploymentMetadataText = JSON.stringify(deploymentMetadata);
-    const frameworkRuntime = readRenderModesFrameworkRuntime();
     const publicPages = getRenderModesPublicPages(manifest);
     const runtimePages = getRenderModesRuntimePages(frameworkRuntime);
     const publicRoutes = Object.entries(publicPages).map(([pageId, page]) => ({
@@ -532,7 +534,9 @@ test.describe("render-modes", () => {
         rsc: "/__evjs/rsc",
       }),
     );
-    expect(frameworkRuntime.rsc.pages.insights).toEqual(
+    expect(frameworkRuntime.rsc).toBeDefined();
+    expect(frameworkRuntime.rsc?.pages).toBeDefined();
+    expect(frameworkRuntime.rsc?.pages?.insights).toEqual(
       expect.objectContaining({
         renderer: "insights-rsc",
         routeId: "insights",
@@ -542,7 +546,7 @@ test.describe("render-modes", () => {
       }),
     );
     expect("rsc" in manifest).toBe(false);
-    expect(frameworkRuntime.rsc.clientReferenceManifest).toBeDefined();
+    expect(frameworkRuntime.rsc?.clientReferenceManifest).toBeDefined();
     expect(
       fs.existsSync(
         path.join(exampleDir, "dist/client/react-client-manifest.json"),
@@ -607,11 +611,14 @@ function getRenderModesPublicPages(
   return manifest.routing.pages;
 }
 
-function getRenderModesRuntimePages(
-  frameworkRuntime = readRenderModesFrameworkRuntime(),
-): Record<string, RenderModesPublicPage> {
+function getRenderModesRuntimePages(frameworkRuntime: {
+  routing?: {
+    kind?: string;
+    pages?: Record<string, RenderModesPublicPage>;
+  };
+}): Record<string, RenderModesPublicPage> {
   expect(frameworkRuntime.routing?.kind).toBe("mpa");
-  return frameworkRuntime.routing.pages;
+  return frameworkRuntime.routing?.pages ?? {};
 }
 
 function getRenderModesCampaignPpr(
@@ -626,15 +633,6 @@ function readRenderModesDeploymentMetadata() {
   return JSON.parse(
     fs.readFileSync(
       path.join(exampleDir, "dist", "build-output.json"),
-      "utf-8",
-    ),
-  );
-}
-
-function readRenderModesFrameworkRuntime() {
-  return JSON.parse(
-    fs.readFileSync(
-      path.join(exampleDir, "dist/server/framework-runtime.json"),
       "utf-8",
     ),
   );

--- a/e2e/cases/render-modes.ts
+++ b/e2e/cases/render-modes.ts
@@ -292,15 +292,26 @@ test.describe("render-modes", () => {
     expect("app" in manifest).toBe(false);
     expect(manifest).not.toHaveProperty("pages");
     expect(manifest).not.toHaveProperty("routes");
-    expect(manifest).not.toHaveProperty("assets");
-    expect(manifest.routing.kind).toBe("mpa");
+    expect(manifest.assets).toEqual(
+      expect.objectContaining({
+        main: expect.objectContaining({
+          js: expect.arrayContaining([expect.stringMatching(/^main\..+\.js$/)]),
+        }),
+        support: expect.objectContaining({
+          js: expect.arrayContaining([
+            expect.stringMatching(/^support\..+\.js$/),
+          ]),
+        }),
+      }),
+    );
+    expect(manifest.routing.kind).toBe("spa");
     expect(publicPages.support).toEqual(
       expect.objectContaining({
         path: "/support",
         routeId: "support",
       }),
     );
-    expect("render" in publicPages.support).toBe(false);
+    expect(publicPages.support.render).toBe("csr");
     expect("rendering" in publicPages.support).toBe(false);
     expect("module" in publicPages.support).toBe(false);
     expect(publicPages.dashboard).toEqual(
@@ -524,11 +535,6 @@ test.describe("render-modes", () => {
         },
       ]),
     );
-    expect(
-      serverManifest.routes.some(
-        (route: { kind: string }) => route.kind === "static-page",
-      ),
-    ).toBe(false);
     expect(serverManifestText).not.toContain('"assets"');
     expect(serverManifestText).not.toContain('"renderers"');
     expect(serverManifestText).not.toContain("insights-rsc");
@@ -616,8 +622,32 @@ function readRenderModesServerManifest() {
 function getRenderModesPublicPages(
   manifest = readRenderModesPublicManifest(),
 ): Record<string, RenderModesPublicPage> {
-  expect(manifest.routing?.kind).toBe("mpa");
-  return manifest.routing.pages;
+  if (manifest.routing?.kind === "mpa") {
+    return manifest.routing.pages;
+  }
+  expect(manifest.routing?.kind).toBe("spa");
+  return Object.fromEntries(
+    manifest.routing.routes.flatMap(
+      (route: {
+        id: string;
+        pageId?: string;
+        path: string;
+        render?: string;
+      }) =>
+        route.pageId
+          ? [
+              [
+                route.pageId,
+                {
+                  path: route.path,
+                  render: route.render,
+                  routeId: route.id,
+                },
+              ],
+            ]
+          : [],
+    ),
+  );
 }
 
 function getRenderModesRuntimePages(frameworkRuntime: {
@@ -625,9 +655,13 @@ function getRenderModesRuntimePages(frameworkRuntime: {
     kind?: string;
     pages?: Record<string, RenderModesPublicPage>;
   };
+  pages?: Record<string, RenderModesPublicPage>;
 }): Record<string, RenderModesPublicPage> {
-  expect(frameworkRuntime.routing?.kind).toBe("mpa");
-  return frameworkRuntime.routing?.pages ?? {};
+  if (frameworkRuntime.routing?.kind === "mpa") {
+    return frameworkRuntime.routing.pages ?? {};
+  }
+  expect(frameworkRuntime.routing?.kind).toBe("spa");
+  return frameworkRuntime.pages ?? {};
 }
 
 function getRenderModesCampaignPpr(

--- a/e2e/cases/render-modes.ts
+++ b/e2e/cases/render-modes.ts
@@ -12,6 +12,18 @@ const exampleDir = path.resolve(
 
 const test = createExampleTest("render-modes");
 
+interface RenderModesPublicPage {
+  document?: unknown;
+  module?: unknown;
+  path?: string;
+  routeId?: string;
+  ppr?: {
+    delivery?: string;
+    regions: Record<string, { id?: string; cache?: unknown }>;
+  };
+  [key: string]: unknown;
+}
+
 test.describe("render-modes", () => {
   test("runs the merchant operations console with server function and REST route", async ({
     page,
@@ -168,9 +180,9 @@ test.describe("render-modes", () => {
     expect(pageResponse.status()).toBe(200);
     expect(pageResponse.headers()["x-evjs-ppr"]).toBe("stream");
     const pageHtml = await pageResponse.text();
-    const { id: regionId } = getSinglePprRegion(
-      readRenderModesPublicManifest().pages.campaign.ppr.regions,
-    );
+    const publicPages = getRenderModesPublicPages();
+    const campaignPpr = getRenderModesCampaignPpr(publicPages);
+    const { id: regionId } = getSinglePprRegion(campaignPpr.regions);
     expect(pageHtml).toContain(`data-evjs-ppr-stream-region="${regionId}"`);
     expect(pageHtml).toContain("Dynamic PPR region rendered on demand");
 
@@ -257,6 +269,12 @@ test.describe("render-modes", () => {
     const buildOutput = readRenderModesBuildOutput();
     const buildOutputText = JSON.stringify(buildOutput);
     const frameworkRuntime = readRenderModesFrameworkRuntime();
+    const publicPages = getRenderModesPublicPages(manifest);
+    const publicRoutes = Object.entries(publicPages).map(([pageId, page]) => ({
+      id: page.routeId,
+      path: page.path,
+      pageId,
+    }));
 
     expect("distDir" in buildOutput).toBe(false);
     expect(buildOutput.paths).toEqual({
@@ -271,7 +289,10 @@ test.describe("render-modes", () => {
         module: expect.objectContaining({ type: "entry" }),
       }),
     );
-    expect(manifest.pages.support).toEqual(
+    expect(manifest).not.toHaveProperty("pages");
+    expect(manifest).not.toHaveProperty("routes");
+    expect(manifest.routing.kind).toBe("mpa");
+    expect(publicPages.support).toEqual(
       expect.objectContaining({
         render: "csr",
         rendering: {
@@ -283,7 +304,7 @@ test.describe("render-modes", () => {
         module: expect.objectContaining({ type: "react-component" }),
       }),
     );
-    expect(manifest.pages.dashboard).toEqual(
+    expect(publicPages.dashboard).toEqual(
       expect.objectContaining({
         path: "/dashboard",
         render: "ssr",
@@ -296,7 +317,7 @@ test.describe("render-modes", () => {
         routeId: "dashboard",
       }),
     );
-    expect(manifest.pages.settlement).toEqual(
+    expect(publicPages.settlement).toEqual(
       expect.objectContaining({
         path: "/settlement-report",
         render: "ssg",
@@ -310,9 +331,9 @@ test.describe("render-modes", () => {
         routeId: "settlement",
       }),
     );
-    expect(manifest.pages.settlement.document).toBeUndefined();
-    expect(manifest.pages.settlement.module).toBeUndefined();
-    expect(manifest.pages.insights).toEqual(
+    expect(publicPages.settlement.document).toBeUndefined();
+    expect(publicPages.settlement.module).toBeUndefined();
+    expect(publicPages.insights).toEqual(
       expect.objectContaining({
         path: "/insights",
         render: "ssr",
@@ -326,7 +347,7 @@ test.describe("render-modes", () => {
         routeId: "insights",
       }),
     );
-    expect(manifest.pages.campaign).toEqual(
+    expect(publicPages.campaign).toEqual(
       expect.objectContaining({
         path: "/campaign",
         render: "ssr",
@@ -343,8 +364,9 @@ test.describe("render-modes", () => {
         },
       }),
     );
+    const campaignPpr = getRenderModesCampaignPpr(publicPages);
     const { id: campaignRegionId, region: campaignRegion } = getSinglePprRegion(
-      manifest.pages.campaign.ppr.regions,
+      campaignPpr.regions,
     );
     expect(campaignRegion).toEqual(
       expect.objectContaining({
@@ -352,8 +374,8 @@ test.describe("render-modes", () => {
         cache: { revalidate: 30 },
       }),
     );
-    expect(manifest.pages.campaign.ppr.delivery).toBe("stream");
-    expect(manifest.routes).toEqual(
+    expect(campaignPpr.delivery).toBe("stream");
+    expect(publicRoutes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           id: "dashboard",
@@ -459,6 +481,21 @@ function readRenderModesPublicManifest() {
   return JSON.parse(
     fs.readFileSync(getRenderModesPublicManifestPath(), "utf-8"),
   );
+}
+
+function getRenderModesPublicPages(
+  manifest = readRenderModesPublicManifest(),
+): Record<string, RenderModesPublicPage> {
+  expect(manifest.routing?.kind).toBe("mpa");
+  return manifest.routing.pages;
+}
+
+function getRenderModesCampaignPpr(
+  pages: Record<string, RenderModesPublicPage>,
+): NonNullable<RenderModesPublicPage["ppr"]> {
+  const ppr = pages.campaign?.ppr;
+  expect(ppr).toBeDefined();
+  return ppr as NonNullable<RenderModesPublicPage["ppr"]>;
 }
 
 function readRenderModesBuildOutput() {

--- a/e2e/cases/render-modes.ts
+++ b/e2e/cases/render-modes.ts
@@ -180,8 +180,8 @@ test.describe("render-modes", () => {
     expect(pageResponse.status()).toBe(200);
     expect(pageResponse.headers()["x-evjs-ppr"]).toBe("stream");
     const pageHtml = await pageResponse.text();
-    const publicPages = getRenderModesPublicPages();
-    const campaignPpr = getRenderModesCampaignPpr(publicPages);
+    const runtimePages = getRenderModesRuntimePages();
+    const campaignPpr = getRenderModesCampaignPpr(runtimePages);
     const { id: regionId } = getSinglePprRegion(campaignPpr.regions);
     expect(pageHtml).toContain(`data-evjs-ppr-stream-region="${regionId}"`);
     expect(pageHtml).toContain("Dynamic PPR region rendered on demand");
@@ -266,68 +266,47 @@ test.describe("render-modes", () => {
   test("emits a manifest with app, page, route, and server data", async () => {
     const manifestPath = getRenderModesPublicManifestPath();
     const manifest = readRenderModesPublicManifest();
-    const buildOutput = readRenderModesBuildOutput();
-    const buildOutputText = JSON.stringify(buildOutput);
+    const deploymentMetadata = readRenderModesDeploymentMetadata();
+    const deploymentMetadataText = JSON.stringify(deploymentMetadata);
     const frameworkRuntime = readRenderModesFrameworkRuntime();
     const publicPages = getRenderModesPublicPages(manifest);
+    const runtimePages = getRenderModesRuntimePages(frameworkRuntime);
     const publicRoutes = Object.entries(publicPages).map(([pageId, page]) => ({
       id: page.routeId,
       path: page.path,
       pageId,
     }));
 
-    expect("distDir" in buildOutput).toBe(false);
-    expect(buildOutput.paths).toEqual({
+    expect("distDir" in deploymentMetadata).toBe(false);
+    expect(deploymentMetadata.paths).toEqual({
       rootDir: "dist",
       publicDir: "dist/client",
       serverDir: "dist/server",
     });
-    expect(buildOutputText).not.toContain('"chunks"');
-    expect(manifest.app).toEqual(
-      expect.objectContaining({
-        mount: "#app",
-        module: expect.objectContaining({ type: "entry" }),
-      }),
-    );
+    expect(deploymentMetadataText).not.toContain('"chunks"');
+    expect(deploymentMetadataText).not.toContain('"renderers"');
+    expect("app" in manifest).toBe(false);
     expect(manifest).not.toHaveProperty("pages");
     expect(manifest).not.toHaveProperty("routes");
     expect(manifest.routing.kind).toBe("mpa");
     expect(publicPages.support).toEqual(
       expect.objectContaining({
-        render: "csr",
-        rendering: {
-          component: "client",
-          html: "client",
-          streaming: false,
-          hydrate: "load",
-        },
-        module: expect.objectContaining({ type: "react-component" }),
+        path: "/support",
+        routeId: "support",
       }),
     );
+    expect("render" in publicPages.support).toBe(false);
+    expect("rendering" in publicPages.support).toBe(false);
+    expect("module" in publicPages.support).toBe(false);
     expect(publicPages.dashboard).toEqual(
       expect.objectContaining({
         path: "/dashboard",
-        render: "ssr",
-        rendering: {
-          component: "server",
-          html: "server",
-          streaming: false,
-          hydrate: "load",
-        },
         routeId: "dashboard",
       }),
     );
     expect(publicPages.settlement).toEqual(
       expect.objectContaining({
         path: "/settlement-report",
-        render: "ssg",
-        rendering: {
-          component: "server",
-          html: "static",
-          prerender: "full",
-          streaming: false,
-          hydrate: "none",
-        },
         routeId: "settlement",
       }),
     );
@@ -336,6 +315,53 @@ test.describe("render-modes", () => {
     expect(publicPages.insights).toEqual(
       expect.objectContaining({
         path: "/insights",
+        routeId: "insights",
+      }),
+    );
+    expect(publicPages.campaign).toEqual(
+      expect.objectContaining({
+        path: "/campaign",
+        routeId: "campaign",
+      }),
+    );
+    expect("ppr" in publicPages.campaign).toBe(false);
+
+    expect(runtimePages.support).toEqual(
+      expect.objectContaining({
+        render: "csr",
+        rendering: {
+          component: "client",
+          html: "client",
+          streaming: false,
+          hydrate: "load",
+        },
+      }),
+    );
+    expect(runtimePages.dashboard).toEqual(
+      expect.objectContaining({
+        render: "ssr",
+        rendering: {
+          component: "server",
+          html: "server",
+          streaming: false,
+          hydrate: "load",
+        },
+      }),
+    );
+    expect(runtimePages.settlement).toEqual(
+      expect.objectContaining({
+        render: "ssg",
+        rendering: {
+          component: "server",
+          html: "static",
+          prerender: "full",
+          streaming: false,
+          hydrate: "none",
+        },
+      }),
+    );
+    expect(runtimePages.insights).toEqual(
+      expect.objectContaining({
         render: "ssr",
         componentModel: "rsc",
         rendering: {
@@ -344,17 +370,11 @@ test.describe("render-modes", () => {
           streaming: true,
           hydrate: "none",
         },
-        routeId: "insights",
       }),
     );
-    expect(publicPages.campaign).toEqual(
+    expect(runtimePages.campaign).toEqual(
       expect.objectContaining({
-        path: "/campaign",
         render: "ssr",
-        prerender: expect.objectContaining({
-          partial: true,
-          delivery: "stream",
-        }),
         rendering: {
           component: "server",
           html: "partial",
@@ -364,7 +384,7 @@ test.describe("render-modes", () => {
         },
       }),
     );
-    const campaignPpr = getRenderModesCampaignPpr(publicPages);
+    const campaignPpr = getRenderModesCampaignPpr(runtimePages);
     const { id: campaignRegionId, region: campaignRegion } = getSinglePprRegion(
       campaignPpr.regions,
     );
@@ -399,22 +419,50 @@ test.describe("render-modes", () => {
         }),
       ]),
     );
-    expect(Object.values(buildOutput.server.functions)).toEqual(
+    expect(deploymentMetadata.routes).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          exportName: "getMerchantOperationsSnapshot",
-        }),
-      ]),
-    );
-    expect(buildOutput.server.routes).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
+        {
+          kind: "page-server",
+          path: "/dashboard",
+          pageId: "dashboard",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "page-server",
+          path: "/settlement-report",
+          pageId: "settlement",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "framework-function",
+          path: "/__evjs/fn",
+          methods: ["POST"],
+        },
+        {
+          kind: "framework-ppr",
+          path: "/__evjs/ppr/*",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "framework-rsc",
+          path: "/__evjs/rsc",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "server-route",
           path: "/api/render-modes/health",
-          methods: expect.arrayContaining(["GET"]),
-        }),
+          methods: ["GET"],
+        },
       ]),
     );
-    expect(buildOutput.runtime.server).toEqual(
+    expect(deploymentMetadata.server).toEqual(
+      expect.objectContaining({
+        entry: expect.any(String),
+      }),
+    );
+    expect("runtime" in deploymentMetadata).toBe(false);
+    expect("rsc" in deploymentMetadata).toBe(false);
+    expect(frameworkRuntime.runtime.server).toEqual(
       expect.objectContaining({
         basePath: "/__evjs",
         fn: "/__evjs/fn",
@@ -422,7 +470,7 @@ test.describe("render-modes", () => {
         rsc: "/__evjs/rsc",
       }),
     );
-    expect(buildOutput.rsc.pages.insights).toEqual(
+    expect(frameworkRuntime.rsc.pages.insights).toEqual(
       expect.objectContaining({
         renderer: "insights-rsc",
         routeId: "insights",
@@ -431,9 +479,7 @@ test.describe("render-modes", () => {
         }),
       }),
     );
-    expect(manifest.rsc.clientReferences).toBeUndefined();
-    expect(manifest.rsc.clientReferenceManifest).toBeUndefined();
-    expect(manifest.rsc.serverConsumerManifest).toBeUndefined();
+    expect("rsc" in manifest).toBe(false);
     expect(frameworkRuntime.rsc.clientReferenceManifest).toBeDefined();
     expect(
       fs.existsSync(
@@ -490,6 +536,13 @@ function getRenderModesPublicPages(
   return manifest.routing.pages;
 }
 
+function getRenderModesRuntimePages(
+  frameworkRuntime = readRenderModesFrameworkRuntime(),
+): Record<string, RenderModesPublicPage> {
+  expect(frameworkRuntime.routing?.kind).toBe("mpa");
+  return frameworkRuntime.routing.pages;
+}
+
 function getRenderModesCampaignPpr(
   pages: Record<string, RenderModesPublicPage>,
 ): NonNullable<RenderModesPublicPage["ppr"]> {
@@ -498,7 +551,7 @@ function getRenderModesCampaignPpr(
   return ppr as NonNullable<RenderModesPublicPage["ppr"]>;
 }
 
-function readRenderModesBuildOutput() {
+function readRenderModesDeploymentMetadata() {
   return JSON.parse(
     fs.readFileSync(
       path.join(exampleDir, "dist", "build-output.json"),
@@ -509,7 +562,10 @@ function readRenderModesBuildOutput() {
 
 function readRenderModesFrameworkRuntime() {
   return JSON.parse(
-    fs.readFileSync(path.join(exampleDir, "dist/server/runtime.json"), "utf-8"),
+    fs.readFileSync(
+      path.join(exampleDir, "dist/server/framework-runtime.json"),
+      "utf-8",
+    ),
   );
 }
 

--- a/e2e/cases/render-modes.ts
+++ b/e2e/cases/render-modes.ts
@@ -265,7 +265,7 @@ test.describe("render-modes", () => {
       serverDir: "dist/server",
     });
     expect(buildOutputText).not.toContain('"chunks"');
-    expect(manifest.apps.default).toEqual(
+    expect(manifest.app).toEqual(
       expect.objectContaining({
         mount: "#app",
         module: expect.objectContaining({ type: "entry" }),
@@ -358,25 +358,21 @@ test.describe("render-modes", () => {
         expect.objectContaining({
           id: "dashboard",
           path: "/dashboard",
-          appId: "default",
           pageId: "dashboard",
         }),
         expect.objectContaining({
           id: "campaign",
           path: "/campaign",
-          appId: "default",
           pageId: "campaign",
         }),
         expect.objectContaining({
           id: "settlement",
           path: "/settlement-report",
-          appId: "default",
           pageId: "settlement",
         }),
         expect.objectContaining({
           id: "insights",
           path: "/insights",
-          appId: "default",
           pageId: "insights",
         }),
       ]),

--- a/e2e/cases/ssg.ts
+++ b/e2e/cases/ssg.ts
@@ -1,0 +1,178 @@
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import type { DeploymentMetadata } from "@evjs/shared/manifest";
+import { test as base, expect } from "@playwright/test";
+import { buildExample } from "../fixtures.js";
+
+const exampleDir = path.resolve(
+  import.meta.dirname,
+  "../..",
+  "examples",
+  "ssg",
+);
+
+const test = base.extend<
+  { baseURL: string; deploymentMetadata: DeploymentMetadata },
+  { _app: { port: number; deploymentMetadata: DeploymentMetadata } }
+>({
+  _app: [
+    // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture API requires object destructuring
+    async ({}, use, workerInfo) => {
+      const bundlerName =
+        (workerInfo.project.use as unknown as { bundlerName?: string })
+          .bundlerName ?? "utoopack";
+      await buildExample(exampleDir, bundlerName);
+
+      const deploymentMetadata = JSON.parse(
+        fs.readFileSync(
+          path.join(exampleDir, "dist", "build-output.json"),
+          "utf-8",
+        ),
+      ) as DeploymentMetadata;
+      const distDir = path.join(exampleDir, "dist", "client");
+      const rewrites = createStaticPageRewrites(deploymentMetadata);
+
+      const server = http.createServer((req, res) => {
+        const pathname = getRequestPathname(req.url ?? "/");
+        const fileName =
+          rewrites[pathname] ?? pathname.replace(/^\/+/, "") ?? "report.html";
+        const filePath = path.resolve(distDir, fileName);
+        const root = path.resolve(distDir);
+
+        if (
+          filePath !== root &&
+          filePath.startsWith(`${root}${path.sep}`) &&
+          fs.existsSync(filePath)
+        ) {
+          res.writeHead(200, {
+            "Content-Type": getContentType(path.extname(filePath)),
+          });
+          fs.createReadStream(filePath).pipe(res);
+          return;
+        }
+
+        res.writeHead(404, { "Content-Type": "text/plain" });
+        res.end("Not found");
+      });
+
+      await new Promise<void>((resolve) => {
+        server.listen(0, resolve);
+      });
+      const { port } = server.address() as { port: number };
+
+      await use({ port, deploymentMetadata });
+
+      server.close();
+    },
+    { scope: "worker" },
+  ],
+  baseURL: async ({ _app }, use) => {
+    await use(`http://localhost:${_app.port}`);
+  },
+  deploymentMetadata: async ({ _app }, use) => {
+    await use(_app.deploymentMetadata);
+  },
+});
+
+test.describe("ssg", () => {
+  test("emits a prerendered static page document", async ({
+    deploymentMetadata,
+  }) => {
+    expect(deploymentMetadata.documents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          fileName: "report.html",
+          id: "report",
+          kind: "page",
+        }),
+      ]),
+    );
+    expect(deploymentMetadata.routes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          documentId: "report",
+          kind: "static-page",
+          methods: ["GET", "HEAD"],
+          path: "/report",
+          render: "ssg",
+        }),
+      ]),
+    );
+    expect(deploymentMetadata.routes).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "server-page",
+          pageId: "report",
+        }),
+      ]),
+    );
+
+    const html = fs.readFileSync(
+      path.join(exampleDir, "dist", "client", "report.html"),
+      "utf-8",
+    );
+    expect(html).toContain("Build-Time Commerce Report");
+    expect(html).toContain("12,480");
+    expect(html).toContain("<main");
+    expect(html).not.toMatch(/<script[^>]+src=/);
+  });
+
+  test("serves the page from static files without a framework server", async ({
+    page,
+    baseURL,
+  }) => {
+    await page.goto(`${baseURL}/report`);
+
+    await expect(
+      page.getByRole("heading", { name: "Build-Time Commerce Report" }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("metric-orders")).toHaveText("12,480");
+    await expect(page.locator("script[src]")).toHaveCount(0);
+  });
+});
+
+function createStaticPageRewrites(
+  deploymentMetadata: DeploymentMetadata,
+): Record<string, string> {
+  const documents = new Map(
+    deploymentMetadata.documents.map((document) => [
+      document.id,
+      document.fileName,
+    ]),
+  );
+  return Object.fromEntries(
+    deploymentMetadata.routes.flatMap((route) => {
+      if (route.kind !== "static-page" || !route.path.startsWith("/")) {
+        return [];
+      }
+      const fileName = documents.get(route.documentId);
+      return fileName ? [[route.path, fileName]] : [];
+    }),
+  );
+}
+
+function getContentType(ext: string): string {
+  switch (ext) {
+    case ".html":
+      return "text/html";
+    case ".js":
+    case ".mjs":
+      return "application/javascript";
+    case ".css":
+      return "text/css";
+    case ".json":
+    case ".map":
+      return "application/json";
+    default:
+      return "text/plain";
+  }
+}
+
+function getRequestPathname(url: string): string {
+  try {
+    return new URL(url, "http://localhost").pathname;
+  } catch {
+    return url.split("?")[0] || "/";
+  }
+}

--- a/e2e/cases/ssg.ts
+++ b/e2e/cases/ssg.ts
@@ -78,8 +78,29 @@ const test = base.extend<
   },
 });
 
+const expectedPages = [
+  {
+    fileName: "forecast.html",
+    heading: "Build-Time Revenue Forecast",
+    id: "forecast",
+    path: "/forecast",
+  },
+  {
+    fileName: "regions_apac.html",
+    heading: "APAC Operations Snapshot",
+    id: "regions_apac",
+    path: "/regions/apac",
+  },
+  {
+    fileName: "report.html",
+    heading: "Build-Time Commerce Report",
+    id: "report",
+    path: "/report",
+  },
+] as const;
+
 test.describe("ssg", () => {
-  test("emits a prerendered static page document", async ({
+  test("emits prerendered static page documents", async ({
     deploymentMetadata,
   }) => {
     const clientManifest = JSON.parse(
@@ -89,87 +110,87 @@ test.describe("ssg", () => {
       ),
     ) as PublicManifestOutput;
 
-    expect(clientManifest.routing.kind).toBe("spa");
-    if (clientManifest.routing.kind !== "spa") {
-      throw new Error("Expected SSG example to use SPA routing.");
+    expect("routing" in clientManifest).toBe(false);
+    expect("assets" in clientManifest).toBe(false);
+    if (!("documents" in clientManifest)) {
+      throw new Error("Expected SSG public manifest documents.");
     }
-    expect(clientManifest.routing.routes).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: "report",
-          path: "/report",
-        }),
-      ]),
+    expect(clientManifest.documents).toEqual(
+      expectedPages.map((page) => ({
+        fileName: page.fileName,
+        id: page.id,
+        path: page.path,
+        render: "ssg",
+      })),
     );
     expect(deploymentMetadata.documents).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          fileName: "report.html",
-          id: "report",
-          kind: "page",
-        }),
-      ]),
+      expectedPages.map((page) => ({
+        fileName: page.fileName,
+        id: page.id,
+        kind: "page",
+        path: page.path,
+        render: "ssg",
+      })),
     );
-    expect(deploymentMetadata.routes).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          documentId: "report",
-          kind: "static-page",
-          methods: ["GET", "HEAD"],
-          path: "/report",
-          render: "ssg",
-        }),
-      ]),
-    );
+    expect(deploymentMetadata.server).toEqual({});
+    expect(deploymentMetadata.routes).toEqual([]);
     expect(deploymentMetadata.routes).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           kind: "server-page",
-          pageId: "report",
         }),
       ]),
     );
 
-    const html = fs.readFileSync(
-      path.join(exampleDir, "dist", "client", "report.html"),
-      "utf-8",
-    );
-    expect(html).toContain("Build-Time Commerce Report");
-    expect(html).toContain("12,480");
-    expect(html).toContain("<main");
-    expect(html).not.toMatch(/<script[^>]+src=/);
+    expect(
+      fs.readdirSync(path.join(exampleDir, "dist", "client")).sort(),
+    ).toEqual([
+      "forecast.html",
+      "manifest.json",
+      "regions_apac.html",
+      "report.html",
+    ]);
+    expect(fs.existsSync(path.join(exampleDir, "dist", "server"))).toBe(false);
+
+    for (const page of expectedPages) {
+      const html = fs.readFileSync(
+        path.join(exampleDir, "dist", "client", page.fileName),
+        "utf-8",
+      );
+      expect(html).toContain(page.heading);
+      expect(html).toContain("<main");
+      expect(html).not.toMatch(/<script[^>]+src=/);
+      expect(html).not.toContain("__EVJS_CLIENT_RUNTIME__");
+    }
   });
 
-  test("serves the page from static files without a framework server", async ({
+  test("serves pages from static files without a framework server", async ({
     page,
     baseURL,
   }) => {
-    await page.goto(`${baseURL}/report`);
+    for (const staticPage of expectedPages) {
+      await page.goto(`${baseURL}${staticPage.path}`);
 
-    await expect(
-      page.getByRole("heading", { name: "Build-Time Commerce Report" }),
-    ).toBeVisible({ timeout: 10_000 });
+      await expect(
+        page.getByRole("heading", { name: staticPage.heading }),
+      ).toBeVisible({ timeout: 10_000 });
+      await expect(page.locator("script[src]")).toHaveCount(0);
+    }
+
+    await page.goto(`${baseURL}/report`);
     await expect(page.getByTestId("metric-orders")).toHaveText("12,480");
-    await expect(page.locator("script[src]")).toHaveCount(0);
   });
 });
 
 function createStaticPageRewrites(
   deploymentMetadata: DeploymentMetadata,
 ): Record<string, string> {
-  const documents = new Map(
-    deploymentMetadata.documents.map((document) => [
-      document.id,
-      document.fileName,
-    ]),
-  );
   return Object.fromEntries(
-    deploymentMetadata.routes.flatMap((route) => {
-      if (route.kind !== "static-page" || !route.path.startsWith("/")) {
+    deploymentMetadata.documents.flatMap((document) => {
+      if (document.kind !== "page" || !document.path?.startsWith("/")) {
         return [];
       }
-      const fileName = documents.get(route.documentId);
-      return fileName ? [[route.path, fileName]] : [];
+      return [[document.path, document.fileName]];
     }),
   );
 }

--- a/e2e/cases/ssg.ts
+++ b/e2e/cases/ssg.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import http from "node:http";
 import path from "node:path";
-import type { DeploymentMetadata } from "@evjs/shared/manifest";
+import type {
+  DeploymentMetadata,
+  PublicManifestOutput,
+} from "@evjs/shared/manifest";
 import { test as base, expect } from "@playwright/test";
 import { buildExample } from "../fixtures.js";
 
@@ -79,6 +82,25 @@ test.describe("ssg", () => {
   test("emits a prerendered static page document", async ({
     deploymentMetadata,
   }) => {
+    const clientManifest = JSON.parse(
+      fs.readFileSync(
+        path.join(exampleDir, "dist", "client", "manifest.json"),
+        "utf-8",
+      ),
+    ) as PublicManifestOutput;
+
+    expect(clientManifest.routing.kind).toBe("spa");
+    if (clientManifest.routing.kind !== "spa") {
+      throw new Error("Expected SSG example to use SPA routing.");
+    }
+    expect(clientManifest.routing.routes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "report",
+          path: "/report",
+        }),
+      ]),
+    );
     expect(deploymentMetadata.documents).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/e2e/cases/with-tailwind.ts
+++ b/e2e/cases/with-tailwind.ts
@@ -37,7 +37,10 @@ test.describe("with-tailwind", () => {
     const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
 
     expect(manifest.assets.main.js.length).toBeGreaterThan(0);
-    expect(manifest.routes).toEqual([
+    expect(manifest).not.toHaveProperty("pages");
+    expect(manifest).not.toHaveProperty("routes");
+    expect(manifest.routing.kind).toBe("spa");
+    expect(manifest.routing.routes).toEqual([
       expect.objectContaining({
         id: expect.any(String),
         path: "/",

--- a/e2e/fixtures-ws.ts
+++ b/e2e/fixtures-ws.ts
@@ -2,9 +2,7 @@ import { execSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import { createServer } from "node:net";
 import path from "node:path";
-import type { BuildOutput } from "@evjs/shared/manifest";
 import { test as base, expect } from "@playwright/test";
-import { createFrameworkRuntime } from "../packages/ev/src/framework-runtime";
 
 export { expect };
 
@@ -55,7 +53,7 @@ export function createWebSocketExampleTest() {
         });
 
         // 2. Read the server manifest for the bundle entry and project the
-        // BuildOutput into the framework runtime for bootstrap.
+        // Use the generated framework runtime contract for bootstrap.
         const serverManifestPath = path.join(
           exampleDir,
           "dist",
@@ -71,14 +69,12 @@ export function createWebSocketExampleTest() {
             "Built WebSocket example did not emit a server entry.",
           );
         }
-        const buildOutputPath = path.join(
+        const runtimePath = path.join(
           exampleDir,
           "dist",
-          "build-output.json",
+          "server",
+          "runtime.json",
         );
-        const buildOutput = JSON.parse(
-          fs.readFileSync(buildOutputPath, "utf-8"),
-        ) as BuildOutput;
         const frameworkRuntimePath = path.join(
           exampleDir,
           "dist",
@@ -86,7 +82,7 @@ export function createWebSocketExampleTest() {
         );
         fs.writeFileSync(
           frameworkRuntimePath,
-          JSON.stringify(createFrameworkRuntime(buildOutput), null, 2),
+          fs.readFileSync(runtimePath, "utf-8"),
           "utf-8",
         );
         const serverEntryPath = path.join(

--- a/e2e/fixtures-ws.ts
+++ b/e2e/fixtures-ws.ts
@@ -73,7 +73,7 @@ export function createWebSocketExampleTest() {
           exampleDir,
           "dist",
           "server",
-          "runtime.json",
+          "framework-runtime.json",
         );
         const frameworkRuntimePath = path.join(
           exampleDir,

--- a/e2e/fixtures-ws.ts
+++ b/e2e/fixtures-ws.ts
@@ -1,8 +1,9 @@
-import { execSync, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import { createServer } from "node:net";
 import path from "node:path";
 import { test as base, expect } from "@playwright/test";
+import { buildExample } from "./fixtures";
 
 export { expect };
 
@@ -46,14 +47,16 @@ export function createWebSocketExampleTest() {
         // Use dynamic port allocation to avoid conflicts
         const webPort = await getAvailablePort();
 
-        // 1. Build with utoopack
-        execSync("ev build", {
-          cwd: exampleDir,
-          stdio: "pipe",
-        });
+        // 1. Build with utoopack and capture runtime-only framework data.
+        const buildResult = await buildExample(exampleDir, "utoopack");
+        const { frameworkRuntime } = buildResult;
+        if (!frameworkRuntime) {
+          throw new Error(
+            "Built WebSocket example did not produce FrameworkRuntime.",
+          );
+        }
 
-        // 2. Read the server manifest for the bundle entry and project the
-        // Use the generated framework runtime contract for bootstrap.
+        // 2. Read the server manifest for the bundle entry.
         const serverManifestPath = path.join(
           exampleDir,
           "dist",
@@ -69,22 +72,6 @@ export function createWebSocketExampleTest() {
             "Built WebSocket example did not emit a server entry.",
           );
         }
-        const runtimePath = path.join(
-          exampleDir,
-          "dist",
-          "server",
-          "framework-runtime.json",
-        );
-        const frameworkRuntimePath = path.join(
-          exampleDir,
-          "dist",
-          "_e2e_framework_runtime.json",
-        );
-        fs.writeFileSync(
-          frameworkRuntimePath,
-          fs.readFileSync(runtimePath, "utf-8"),
-          "utf-8",
-        );
         const serverEntryPath = path.join(
           exampleDir,
           "dist",
@@ -106,7 +93,7 @@ export function createWebSocketExampleTest() {
             ...process.env,
             SERVER_ENTRY: serverEntryPath,
             CLIENT_DIR: clientDir,
-            FRAMEWORK_RUNTIME_PATH: frameworkRuntimePath,
+            FRAMEWORK_RUNTIME_JSON: JSON.stringify(frameworkRuntime),
             PORT: String(webPort),
           },
         });

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -218,11 +218,11 @@ function getServerProxyPrefixes(output: RoutingFixture): string[] {
     ...output.routes
       .filter((route) =>
         [
-          "framework-function",
-          "framework-ppr",
-          "framework-rsc",
-          "page-server",
-          "server-route",
+          "server-function",
+          "ppr-endpoint",
+          "rsc-endpoint",
+          "server-page",
+          "api-route",
         ].includes(route.kind),
       )
       .map((route) => normalizeProxyRoutePath(route.path)),
@@ -233,16 +233,20 @@ function getClientPathRewrites(output: RoutingFixture): Record<string, string> {
   const documentFiles = new Map(
     output.documents.map((document) => [document.id, document.fileName]),
   );
-  return Object.fromEntries(
-    output.routes.flatMap((route) => {
-      if (route.kind !== "static-document" && route.kind !== "spa-fallback") {
+  return Object.fromEntries([
+    ...output.documents.flatMap((document) => {
+      if (document.kind !== "app" || !document.fallback?.startsWith("/")) {
         return [];
       }
+      return [[document.fallback, document.fileName]];
+    }),
+    ...output.routes.flatMap((route) => {
+      if (route.kind !== "static-page") return [];
       if (!route.path.startsWith("/")) return [];
       const fileName = documentFiles.get(route.documentId);
       return fileName ? [[route.path, fileName]] : [];
     }),
-  );
+  ]);
 }
 
 function normalizeProxyRoutePath(routePath: string): string {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -12,6 +12,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
 import path from "node:path";
+import type { BuildResult } from "@evjs/ev";
 import type { DeploymentMetadata } from "@evjs/shared/manifest";
 import { test as base, expect } from "@playwright/test";
 
@@ -22,13 +23,23 @@ interface ExampleFixture {
   baseURL: string;
   /** Base URL where the framework/API server is served. */
   apiURL: string;
+  /** Framework runtime captured from the build pipeline. */
+  frameworkRuntime: FrameworkRuntimeOutput;
 }
 
 interface WorkerFixture {
-  _exampleApp: { webPort: number; apiPort: number };
+  _exampleApp: {
+    webPort: number;
+    apiPort: number;
+    frameworkRuntime?: FrameworkRuntimeOutput;
+  };
 }
 
 type RoutingFixture = Pick<DeploymentMetadata, "documents" | "routes">;
+type FrameworkRuntimeOutput = NonNullable<BuildResult["frameworkRuntime"]>;
+type BuildExampleResult = {
+  frameworkRuntime?: FrameworkRuntimeOutput;
+};
 
 /**
  * Content-type mapping for static file serving.
@@ -288,9 +299,23 @@ async function loadExampleConfig(
  * (plugins, output structure, etc.) are picked up during the build.
  * Only the bundler adapter is overridden by the test configuration.
  */
-export async function buildExample(exampleDir: string, bundlerName: string) {
+export async function buildExample(
+  exampleDir: string,
+  bundlerName: string,
+): Promise<BuildExampleResult> {
   const { build } = await import("@evjs/cli");
   const bundler = await resolveBundler(bundlerName);
+  let frameworkRuntime: FrameworkRuntimeOutput | undefined;
+  const captureFrameworkRuntimePlugin: import("@evjs/ev").Plugin<unknown> = {
+    name: "e2e-framework-runtime-capture",
+    setup() {
+      return {
+        buildEnd(result) {
+          frameworkRuntime = result.frameworkRuntime;
+        },
+      };
+    },
+  };
   const runBuild = build as (
     config: import("@evjs/ev").Config<unknown>,
     options: { cwd: string },
@@ -308,6 +333,11 @@ export async function buildExample(exampleDir: string, bundlerName: string) {
     await runBuild(
       {
         ...exampleConfig,
+        plugins: [
+          ...((exampleConfig?.plugins as import("@evjs/ev").Plugin<unknown>[]) ??
+            []),
+          captureFrameworkRuntimePlugin,
+        ],
         ...(bundler ? { bundler } : {}),
       },
       { cwd: exampleDir },
@@ -320,6 +350,8 @@ export async function buildExample(exampleDir: string, bundlerName: string) {
       process.env.NODE_ENV = savedNodeEnv;
     }
   }
+
+  return { frameworkRuntime };
 }
 
 async function resolveBundler(
@@ -356,10 +388,14 @@ export function createExampleTest(exampleName: string) {
           (workerInfo.project.use as unknown as { bundlerName?: string })
             .bundlerName ?? "utoopack";
 
-        await buildExample(exampleDir, bundlerName);
+        const buildResult = await buildExample(exampleDir, bundlerName);
+        const { frameworkRuntime } = buildResult;
+        if (!frameworkRuntime) {
+          throw new Error("Built example did not produce FrameworkRuntime.");
+        }
 
-        // Read the server manifest for the bundle entry and the generated
-        // FrameworkRuntime contract for server startup.
+        // Read only the deployment manifest for the bundle entry; runtime-only
+        // FrameworkRuntime data comes from the buildEnd hook above.
         const serverManifestPath = path.join(
           exampleDir,
           "dist",
@@ -373,15 +409,6 @@ export function createExampleTest(exampleName: string) {
         if (!serverEntry) {
           throw new Error("Built example did not emit a server entry.");
         }
-        const frameworkRuntimePath = path.join(
-          exampleDir,
-          "dist",
-          "server",
-          "framework-runtime.json",
-        );
-        const frameworkRuntime = JSON.parse(
-          fs.readFileSync(frameworkRuntimePath, "utf-8"),
-        );
         const buildOutputPath = path.join(
           exampleDir,
           "dist",
@@ -459,7 +486,7 @@ export function createExampleTest(exampleName: string) {
         });
         const { port: webPort } = staticServer.address() as { port: number };
 
-        await use({ webPort, apiPort });
+        await use({ webPort, apiPort, frameworkRuntime });
 
         // Cleanup
         staticServer.close();
@@ -477,6 +504,12 @@ export function createExampleTest(exampleName: string) {
     },
     apiURL: async ({ _exampleApp }, use) => {
       await use(`http://localhost:${_exampleApp.apiPort}`);
+    },
+    frameworkRuntime: async ({ _exampleApp }, use) => {
+      if (!_exampleApp.frameworkRuntime) {
+        throw new Error("Built example did not produce FrameworkRuntime.");
+      }
+      await use(_exampleApp.frameworkRuntime);
     },
   });
 }

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -230,9 +230,6 @@ function getServerProxyPrefixes(output: RoutingFixture): string[] {
 }
 
 function getClientPathRewrites(output: RoutingFixture): Record<string, string> {
-  const documentFiles = new Map(
-    output.documents.map((document) => [document.id, document.fileName]),
-  );
   return Object.fromEntries([
     ...output.documents.flatMap((document) => {
       if (document.kind !== "app" || !document.fallback?.startsWith("/")) {
@@ -240,11 +237,11 @@ function getClientPathRewrites(output: RoutingFixture): Record<string, string> {
       }
       return [[document.fallback, document.fileName]];
     }),
-    ...output.routes.flatMap((route) => {
-      if (route.kind !== "static-page") return [];
-      if (!route.path.startsWith("/")) return [];
-      const fileName = documentFiles.get(route.documentId);
-      return fileName ? [[route.path, fileName]] : [];
+    ...output.documents.flatMap((document) => {
+      if (document.kind !== "page" || !document.path?.startsWith("/")) {
+        return [];
+      }
+      return [[document.path, document.fileName]];
     }),
   ]);
 }

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -19,7 +19,6 @@ import {
   getServerRenderedPaths,
 } from "@evjs/shared/manifest";
 import { test as base, expect } from "@playwright/test";
-import { createFrameworkRuntime } from "../packages/ev/src/framework-runtime";
 
 export { expect };
 
@@ -361,9 +360,8 @@ export function createExampleTest(exampleName: string) {
 
         await buildExample(exampleDir, bundlerName);
 
-        // Read BuildOutput for fixture routing and the server manifest
-        // for the bundle entry. BuildOutput stays in the fixture process and
-        // is projected before the server bootstrap sees it.
+        // Read the server manifest for the bundle entry and the generated
+        // FrameworkRuntime contract for server startup.
         const serverManifestPath = path.join(
           exampleDir,
           "dist",
@@ -377,6 +375,15 @@ export function createExampleTest(exampleName: string) {
         if (!serverEntry) {
           throw new Error("Built example did not emit a server entry.");
         }
+        const frameworkRuntimePath = path.join(
+          exampleDir,
+          "dist",
+          "server",
+          "runtime.json",
+        );
+        const frameworkRuntime = JSON.parse(
+          fs.readFileSync(frameworkRuntimePath, "utf-8"),
+        );
         const buildOutputPath = path.join(
           exampleDir,
           "dist",
@@ -385,7 +392,6 @@ export function createExampleTest(exampleName: string) {
         const buildOutput = JSON.parse(
           fs.readFileSync(buildOutputPath, "utf-8"),
         ) as BuildOutput;
-        const frameworkRuntime = createFrameworkRuntime(buildOutput);
         const serverEntryPath = path.join(
           exampleDir,
           "dist",

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -12,12 +12,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
 import path from "node:path";
-import {
-  type BuildOutput,
-  type ClientRouteTarget,
-  getClientRouteMatches,
-  getServerRenderedPaths,
-} from "@evjs/shared/manifest";
+import type { DeploymentMetadata } from "@evjs/shared/manifest";
 import { test as base, expect } from "@playwright/test";
 
 export { expect };
@@ -33,10 +28,7 @@ interface WorkerFixture {
   _exampleApp: { webPort: number; apiPort: number };
 }
 
-type RoutingFixture = Pick<
-  BuildOutput,
-  "apps" | "pages" | "routes" | "runtime"
->;
+type RoutingFixture = Pick<DeploymentMetadata, "documents" | "routes">;
 
 /**
  * Content-type mapping for static file serving.
@@ -212,32 +204,38 @@ function pathMatchesPrefix(pathname: string, prefix: string): boolean {
 function getServerProxyPrefixes(output: RoutingFixture): string[] {
   return compactUnique([
     "/api",
-    "/__evjs",
-    output.runtime?.server?.basePath,
-    output.runtime?.server?.fn,
-    output.runtime?.server?.ppr,
-    output.runtime?.server?.rsc,
-    ...getServerRenderedPaths(output),
+    ...output.routes
+      .filter((route) =>
+        [
+          "framework-function",
+          "framework-ppr",
+          "framework-rsc",
+          "page-server",
+          "server-route",
+        ].includes(route.kind),
+      )
+      .map((route) => normalizeProxyRoutePath(route.path)),
   ]);
 }
 
 function getClientPathRewrites(output: RoutingFixture): Record<string, string> {
-  const rewrites = Object.fromEntries(
-    Object.entries(output.pages ?? {}).flatMap(([pageId, page]) =>
-      page.path && page.render === "csr" ? [[page.path, `${pageId}.html`]] : [],
-    ),
+  const documentFiles = new Map(
+    output.documents.map((document) => [document.id, document.fileName]),
   );
-
-  for (const { path, target } of getClientRouteMatches(output)) {
-    rewrites[path] ??= getClientRouteHtmlFileName(target);
-  }
-
-  return rewrites;
+  return Object.fromEntries(
+    output.routes.flatMap((route) => {
+      if (route.kind !== "static-document" && route.kind !== "spa-fallback") {
+        return [];
+      }
+      if (!route.path.startsWith("/")) return [];
+      const fileName = documentFiles.get(route.documentId);
+      return fileName ? [[route.path, fileName]] : [];
+    }),
+  );
 }
 
-function getClientRouteHtmlFileName(target: ClientRouteTarget): string {
-  if (target.kind === "page") return `${target.pageId}.html`;
-  return target.appId === "default" ? "index.html" : `${target.appId}.html`;
+function normalizeProxyRoutePath(routePath: string): string {
+  return routePath.replace(/\/\*$/, "");
 }
 
 function compactUnique(values: Array<string | undefined>): string[] {
@@ -379,7 +377,7 @@ export function createExampleTest(exampleName: string) {
           exampleDir,
           "dist",
           "server",
-          "runtime.json",
+          "framework-runtime.json",
         );
         const frameworkRuntime = JSON.parse(
           fs.readFileSync(frameworkRuntimePath, "utf-8"),
@@ -389,9 +387,9 @@ export function createExampleTest(exampleName: string) {
           "dist",
           "build-output.json",
         );
-        const buildOutput = JSON.parse(
+        const deploymentMetadata = JSON.parse(
           fs.readFileSync(buildOutputPath, "utf-8"),
-        ) as BuildOutput;
+        ) as DeploymentMetadata;
         const serverEntryPath = path.join(
           exampleDir,
           "dist",
@@ -452,8 +450,8 @@ export function createExampleTest(exampleName: string) {
         const distDir = path.join(exampleDir, "dist", "client");
         const staticServer = createStaticServer(distDir, {
           apiPort,
-          proxyPrefixes: getServerProxyPrefixes(buildOutput),
-          pathRewrites: getClientPathRewrites(buildOutput),
+          proxyPrefixes: getServerProxyPrefixes(deploymentMetadata),
+          pathRewrites: getClientPathRewrites(deploymentMetadata),
         });
 
         await new Promise<void>((resolve) => {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -20,6 +20,7 @@ export default defineConfig<ExtTestOptions>({
         "cases/scaffold.ts",
         "cases/render-modes.ts",
         "cases/deployment-adapters.ts",
+        "cases/ssg.ts",
       ],
       use: {
         browserName: "chromium",
@@ -28,7 +29,11 @@ export default defineConfig<ExtTestOptions>({
     },
     {
       name: "webpack-examples",
-      testMatch: ["cases/render-modes.ts", "cases/deployment-adapters.ts"],
+      testMatch: [
+        "cases/render-modes.ts",
+        "cases/deployment-adapters.ts",
+        "cases/ssg.ts",
+      ],
       use: {
         browserName: "chromium",
         bundlerName: "webpack",

--- a/e2e/ws-bootstrap.cjs
+++ b/e2e/ws-bootstrap.cjs
@@ -9,7 +9,7 @@
  * Environment variables:
  *   SERVER_ENTRY - path to the built server entry
  *   CLIENT_DIR   - path to the built client directory
- *   FRAMEWORK_RUNTIME_PATH - path to the projected framework runtime JSON
+ *   FRAMEWORK_RUNTIME_JSON - serialized FrameworkRuntime contract
  *   PORT         - port to listen on
  */
 
@@ -22,11 +22,11 @@ const { WebSocketServer } = require("ws");
 const serverEntryPath = process.env.SERVER_ENTRY;
 const distDir = process.env.CLIENT_DIR;
 const port = Number(process.env.PORT);
-const frameworkRuntimePath = process.env.FRAMEWORK_RUNTIME_PATH;
+const frameworkRuntimeJson = process.env.FRAMEWORK_RUNTIME_JSON;
 
-if (!serverEntryPath || !distDir || !port || !frameworkRuntimePath) {
+if (!serverEntryPath || !distDir || !port || !frameworkRuntimeJson) {
   console.error(
-    "Missing required env: SERVER_ENTRY, CLIENT_DIR, PORT, FRAMEWORK_RUNTIME_PATH",
+    "Missing required env: SERVER_ENTRY, CLIENT_DIR, PORT, FRAMEWORK_RUNTIME_JSON",
   );
   process.exit(1);
 }
@@ -35,9 +35,7 @@ if (!serverEntryPath || !distDir || !port || !frameworkRuntimePath) {
 // and exports the fetch handler (app.fetch) as `default`.
 // We use the bundle's own fetch handler to ensure it shares the same
 // server function registry that registerServerReference populated.
-globalThis.__EVJS_FRAMEWORK_RUNTIME__ = JSON.parse(
-  fs.readFileSync(frameworkRuntimePath, "utf-8"),
-);
+globalThis.__EVJS_FRAMEWORK_RUNTIME__ = JSON.parse(frameworkRuntimeJson);
 const serverDir = path.dirname(serverEntryPath);
 globalThis.__EVJS_SERVER_MODULE_LOADER__ = async (asset) => {
   const mod = await import(pathToFileURL(path.resolve(serverDir, asset)).href);

--- a/examples/deployment-adapters/deploy-adapter.mjs
+++ b/examples/deployment-adapters/deploy-adapter.mjs
@@ -29,7 +29,7 @@ export function deploymentExampleAdapter() {
         buildEnd({ output }) {
           const artifactPath = path.join(
             ctx.cwd,
-            output.distDir,
+            output.paths.rootDir,
             "deployment.example.json",
           );
           fs.mkdirSync(path.dirname(artifactPath), { recursive: true });

--- a/examples/deployment-adapters/deploy-adapter.mjs
+++ b/examples/deployment-adapters/deploy-adapter.mjs
@@ -11,7 +11,7 @@ export function deploymentExampleAdapter() {
           output.deployment = {
             ...(output.deployment ?? {}),
             deploymentAdaptersExample: {
-              apps: Object.keys(output.apps),
+              app: Object.keys(output.apps).length > 0,
               pages: Object.keys(output.pages),
               rscPages: Object.keys(output.rsc?.pages ?? {}),
               serverBasePath: output.runtime.server?.basePath,

--- a/examples/render-modes/README.md
+++ b/examples/render-modes/README.md
@@ -7,7 +7,7 @@ simulates a payment operations console with:
 - a REST health route for operations service status;
 - a CSR support queue page for agent workflows;
 - an SSR operations dashboard for document rendering;
-- an SSG settlement report with no client hydration bundle;
+- a full-prerender SSR settlement report with no client hydration bundle;
 - a PPR campaign monitor with a dynamic offer region;
 - an RSC insights page with a client reference.
 
@@ -19,7 +19,7 @@ It exercises the render-mode framework contracts with the webpack adapter:
 - `pages` declarations for standalone page outputs, with render metadata kept in
   the referenced page modules;
 - framework-managed SSR React page;
-- framework-managed SSG React page;
+- framework-managed SSR React page with full prerender metadata;
 - framework-managed CSR component page;
 - PPR page shell plus Suspense-driven dynamic region renderer, delivered with
   streamed shell/region patches in one document response;

--- a/examples/render-modes/src/main.tsx
+++ b/examples/render-modes/src/main.tsx
@@ -39,7 +39,7 @@ function App() {
         <nav className="nav" aria-label="Render modes navigation">
           <a href="/support.html">Support queue</a>
           <a href="/dashboard">SSR operations dashboard</a>
-          <a href="/settlement-report">SSG settlement report</a>
+          <a href="/settlement-report">Prerendered settlement report</a>
           <a href="/campaign">PPR campaign monitor</a>
           <a href="/insights">RSC insights</a>
         </nav>

--- a/examples/render-modes/src/pages/SettlementReport.tsx
+++ b/examples/render-modes/src/pages/SettlementReport.tsx
@@ -5,7 +5,9 @@ import {
 } from "@/domain/operations";
 import RenderModePage from "./RenderModePage";
 
-export const render = "ssg";
+export const render = "ssr";
+export const hydrate = "none";
+export const prerender = true;
 
 export default function SettlementReport() {
   const snapshot = getOperationsSnapshot();
@@ -17,24 +19,24 @@ export default function SettlementReport() {
   return (
     <RenderModePage
       backHref="/"
-      description="This report is rendered as a static page with no client hydration bundle."
-      mode="ssg"
-      title="SSG"
+      description="This report is server rendered with full prerender metadata and no client hydration bundle."
+      mode="ssr"
+      title="Prerendered SSR"
     >
-      <section className="panel hero-panel hero-panel--ssg">
+      <section className="panel hero-panel hero-panel--ssr">
         <div>
-          <p className="eyebrow">Static settlement report</p>
+          <p className="eyebrow">Full-prerender settlement report</p>
           <h1>Settlement Readiness Report</h1>
           <p>
-            SSG pages precompute stable operational summaries for static hosting
-            and audit review. This document is generated from framework page
-            metadata without shipping a page-specific browser bundle.
+            Full prerender pages precompute stable operational summaries through
+            the framework server and audit review path without shipping a
+            page-specific browser bundle.
           </p>
         </div>
-        <dl className="meta-list" aria-label="SSG report metadata">
+        <dl className="meta-list" aria-label="Prerender report metadata">
           <div>
             <dt>Mode</dt>
-            <dd data-testid="settlement-render-mode">static</dd>
+            <dd data-testid="settlement-render-mode">full prerender</dd>
           </div>
           <div>
             <dt>Generated</dt>
@@ -53,7 +55,10 @@ export default function SettlementReport() {
         </dl>
       </section>
 
-      <section className="status-grid" aria-label="Static settlement metrics">
+      <section
+        className="status-grid"
+        aria-label="Prerender settlement metrics"
+      >
         <div className="status">
           <h2>Ready releases</h2>
           <strong data-testid="settlement-ready-count">
@@ -76,7 +81,7 @@ export default function SettlementReport() {
       <section className="panel">
         <div className="section-header">
           <h2>Settlement batches</h2>
-          <span>static HTML table</span>
+          <span>server-rendered HTML table</span>
         </div>
         <table>
           <thead>

--- a/examples/ssg/.gitignore
+++ b/examples/ssg/.gitignore
@@ -1,0 +1,3 @@
+.evjs
+.turbopack
+route-types.d.ts

--- a/examples/ssg/README.md
+++ b/examples/ssg/README.md
@@ -1,12 +1,15 @@
 # ev SSG Example
 
-This example demonstrates a true static generation page:
+This example demonstrates true static generation pages:
 
-- `src/pages/report.tsx` exports `render = "ssg"`;
-- the page is discovered through the default SPA file router, not MPA mode;
-- `ev build` renders the page during the build;
-- the generated `dist/client/report.html` contains the page HTML;
-- `/report` is represented as a `static-page` route in `build-output.json`.
+- `src/pages/report.tsx`, `src/pages/forecast.tsx`, and
+  `src/pages/regions/apac.tsx` export `render = "ssg"`;
+- the pages are discovered through the default SPA file router, not MPA mode;
+- `ev build` renders each page during the build;
+- the generated `dist/client/*.html` files contain the page HTML;
+- `/report`, `/forecast`, and `/regions/apac` are represented as static
+  documents in `client/manifest.json` and `build-output.json`, not as evjs
+  server routes.
 
 It uses the webpack adapter because SSG needs the framework server page renderer
 during the production build.
@@ -17,4 +20,5 @@ during the production build.
 npm run build
 ```
 
-Serve `dist/client` as static files and map `/report` to `report.html`.
+Serve `dist/client` as static files and map each document path to the recorded
+HTML file.

--- a/examples/ssg/README.md
+++ b/examples/ssg/README.md
@@ -3,6 +3,7 @@
 This example demonstrates a true static generation page:
 
 - `src/pages/report.tsx` exports `render = "ssg"`;
+- the page is discovered through the default SPA file router, not MPA mode;
 - `ev build` renders the page during the build;
 - the generated `dist/client/report.html` contains the page HTML;
 - `/report` is represented as a `static-page` route in `build-output.json`.

--- a/examples/ssg/README.md
+++ b/examples/ssg/README.md
@@ -1,0 +1,19 @@
+# ev SSG Example
+
+This example demonstrates a true static generation page:
+
+- `src/pages/report.tsx` exports `render = "ssg"`;
+- `ev build` renders the page during the build;
+- the generated `dist/client/report.html` contains the page HTML;
+- `/report` is represented as a `static-page` route in `build-output.json`.
+
+It uses the webpack adapter because SSG needs the framework server page renderer
+during the production build.
+
+## Run
+
+```bash
+npm run build
+```
+
+Serve `dist/client` as static files and map `/report` to `report.html`.

--- a/examples/ssg/ev.config.ts
+++ b/examples/ssg/ev.config.ts
@@ -1,0 +1,9 @@
+import { webpackAdapter } from "@evjs/bundler-webpack";
+import { defineConfig } from "@evjs/ev";
+
+export default defineConfig({
+  bundler: webpackAdapter,
+  routing: {
+    mode: "mpa",
+  },
+});

--- a/examples/ssg/ev.config.ts
+++ b/examples/ssg/ev.config.ts
@@ -3,7 +3,4 @@ import { defineConfig } from "@evjs/ev";
 
 export default defineConfig({
   bundler: webpackAdapter,
-  routing: {
-    mode: "mpa",
-  },
 });

--- a/examples/ssg/index.html
+++ b/examples/ssg/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SSG Report</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/ssg/package.json
+++ b/examples/ssg/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "example-ssg",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "ev dev",
+    "build": "ev build",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@evjs/bundler-webpack": "*",
+    "@evjs/ev": "*",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
+  },
+  "devDependencies": {
+    "@evjs/cli": "*",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.8",
+    "typescript": "^6.0.2"
+  }
+}

--- a/examples/ssg/src/pages/forecast.tsx
+++ b/examples/ssg/src/pages/forecast.tsx
@@ -1,0 +1,73 @@
+export const render = "ssg";
+
+const forecast = [
+  ["North America", "$142K", "+12%"],
+  ["Europe", "$96K", "+7%"],
+  ["Asia Pacific", "$118K", "+18%"],
+];
+
+export default function Forecast() {
+  return (
+    <main
+      style={{
+        maxWidth: 760,
+        margin: "0 auto",
+        padding: "48px 24px",
+        color: "#172033",
+        fontFamily:
+          'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+      }}
+    >
+      <p
+        style={{
+          margin: "0 0 8px",
+          color: "#64748b",
+          fontSize: 12,
+          fontWeight: 800,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+        }}
+      >
+        Static generation
+      </p>
+      <h1 style={{ margin: "0 0 12px", fontSize: 40, lineHeight: 1.1 }}>
+        Build-Time Revenue Forecast
+      </h1>
+      <p style={{ margin: "0 0 28px", color: "#475569", fontSize: 17 }}>
+        This forecast is rendered once during <code>ev build</code> and shipped
+        as a standalone HTML document.
+      </p>
+      <section
+        aria-label="Forecast by region"
+        style={{
+          display: "grid",
+          gap: 12,
+        }}
+      >
+        {forecast.map(([region, value, growth]) => (
+          <article
+            key={region}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr auto auto",
+              gap: 16,
+              alignItems: "center",
+              border: "1px solid #d8deea",
+              borderRadius: 8,
+              background: "#fff",
+              padding: 16,
+            }}
+          >
+            <strong>{region}</strong>
+            <span
+              data-testid={`forecast-${region.toLowerCase().replaceAll(" ", "-")}`}
+            >
+              {value}
+            </span>
+            <span style={{ color: "#0f766e", fontWeight: 700 }}>{growth}</span>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/examples/ssg/src/pages/regions/apac.tsx
+++ b/examples/ssg/src/pages/regions/apac.tsx
@@ -1,0 +1,70 @@
+export const render = "ssg";
+
+const regions = [
+  ["Singapore", "3,120"],
+  ["Tokyo", "4,860"],
+  ["Sydney", "2,740"],
+];
+
+export default function ApacRegion() {
+  return (
+    <main
+      style={{
+        maxWidth: 760,
+        margin: "0 auto",
+        padding: "48px 24px",
+        color: "#172033",
+        fontFamily:
+          'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+      }}
+    >
+      <p
+        style={{
+          margin: "0 0 8px",
+          color: "#64748b",
+          fontSize: 12,
+          fontWeight: 800,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+        }}
+      >
+        Static generation
+      </p>
+      <h1 style={{ margin: "0 0 12px", fontSize: 40, lineHeight: 1.1 }}>
+        APAC Operations Snapshot
+      </h1>
+      <p style={{ margin: "0 0 28px", color: "#475569", fontSize: 17 }}>
+        Nested SSG routes are emitted as independent static HTML documents
+        without creating a framework server bundle.
+      </p>
+      <section
+        aria-label="APAC city orders"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+          gap: 12,
+        }}
+      >
+        {regions.map(([city, orders]) => (
+          <article
+            key={city}
+            style={{
+              border: "1px solid #d8deea",
+              borderRadius: 8,
+              background: "#fff",
+              padding: 16,
+            }}
+          >
+            <span style={{ color: "#64748b", fontSize: 13 }}>{city}</span>
+            <strong
+              data-testid={`orders-${city.toLowerCase()}`}
+              style={{ display: "block", marginTop: 6, fontSize: 24 }}
+            >
+              {orders}
+            </strong>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/examples/ssg/src/pages/report.tsx
+++ b/examples/ssg/src/pages/report.tsx
@@ -1,0 +1,70 @@
+export const render = "ssg";
+
+const metrics = [
+  ["Orders", "12,480"],
+  ["Conversion", "8.4%"],
+  ["Revenue", "$384K"],
+];
+
+export default function Report() {
+  return (
+    <main
+      style={{
+        maxWidth: 760,
+        margin: "0 auto",
+        padding: "48px 24px",
+        color: "#172033",
+        fontFamily:
+          'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+      }}
+    >
+      <p
+        style={{
+          margin: "0 0 8px",
+          color: "#64748b",
+          fontSize: 12,
+          fontWeight: 800,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+        }}
+      >
+        Static generation
+      </p>
+      <h1 style={{ margin: "0 0 12px", fontSize: 40, lineHeight: 1.1 }}>
+        Build-Time Commerce Report
+      </h1>
+      <p style={{ margin: "0 0 28px", color: "#475569", fontSize: 17 }}>
+        This page is rendered during <code>ev build</code> and emitted as an
+        HTML document that can be served without the framework server.
+      </p>
+      <section
+        aria-label="SSG metrics"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+          gap: 12,
+        }}
+      >
+        {metrics.map(([label, value]) => (
+          <article
+            key={label}
+            style={{
+              border: "1px solid #d8deea",
+              borderRadius: 8,
+              background: "#fff",
+              padding: 16,
+            }}
+          >
+            <span style={{ color: "#64748b", fontSize: 13 }}>{label}</span>
+            <strong
+              data-testid={`metric-${label.toLowerCase()}`}
+              style={{ display: "block", marginTop: 6, fontSize: 24 }}
+            >
+              {value}
+            </strong>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/examples/ssg/tsconfig.json
+++ b/examples/ssg/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "include": ["src"],
+  "compilerOptions": {
+    "target": "ESNext",
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": ["node"],
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -333,6 +333,22 @@
         "typescript": "^6.0.2"
       }
     },
+    "examples/ssg": {
+      "name": "example-ssg",
+      "version": "0.0.0",
+      "dependencies": {
+        "@evjs/bundler-webpack": "*",
+        "@evjs/ev": "*",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4"
+      },
+      "devDependencies": {
+        "@evjs/cli": "*",
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.8",
+        "typescript": "^6.0.2"
+      }
+    },
     "examples/trpc-server-fns": {
       "name": "example-trpc-server-fns",
       "version": "0.0.0",
@@ -12768,6 +12784,10 @@
     },
     "node_modules/example-render-modes": {
       "resolved": "examples/render-modes",
+      "link": true
+    },
+    "node_modules/example-ssg": {
+      "resolved": "examples/ssg",
       "link": true
     },
     "node_modules/example-with-sqlite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5405,13 +5405,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-core": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.2.tgz",
-      "integrity": "sha512-SVjwklkpIV5wrynpYtuYnfYH1QF4/nDuLBX7VXdb+3miglcAgBVZb/5y0cOsehRV/9Vb+3UqhkMq3/NR3ztdkQ==",
+      "version": "4.57.8",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.8.tgz",
+      "integrity": "sha512-YzVbwggV9452VCeHgo0bjsTaUt1O7JE0XpEsPar93nn/+RAwXk0mb1Y+f5EDJ3TRtRCFe+Ck5RuojdfB4jeHVw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.57.2",
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.8",
+        "@jsonjoy.com/fs-node-utils": "4.57.8",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -5426,14 +5426,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-fsa": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.2.tgz",
-      "integrity": "sha512-fhO8+iR2I+OCw668ISDJdn1aArc9zx033sWejIyzQ8RBeXa9bDSaUeA3ix0poYOfrj1KdOzytmYNv2/uLDfV6g==",
+      "version": "4.57.8",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.8.tgz",
+      "integrity": "sha512-vmClyvCQMxgqz7uamDiGtRfp4MjzOznk3pcQjCxlIwJcw7TWeyr+bF30hI0x8NxdtNOGMg1pHM74VDIXOeyjuw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.2",
-        "@jsonjoy.com/fs-node-builtins": "4.57.2",
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-core": "4.57.8",
+        "@jsonjoy.com/fs-node-builtins": "4.57.8",
+        "@jsonjoy.com/fs-node-utils": "4.57.8",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -5448,16 +5448,16 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.2.tgz",
-      "integrity": "sha512-nX2AdL6cOFwLdju9G4/nbRnYevmCJbh7N7hvR3gGm97Cs60uEjyd0rpR+YBS7cTg175zzl22pGKXR5USaQMvKg==",
+      "version": "4.57.8",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.8.tgz",
+      "integrity": "sha512-IPEOlDYSnTDYpjQlQg2F8h+eqxKQN3sdbroI0WrteRiQZ462HzVpBo9ZZX485njz4nAacoe3fd4iDiIhk+k5Hg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.2",
-        "@jsonjoy.com/fs-node-builtins": "4.57.2",
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
-        "@jsonjoy.com/fs-print": "4.57.2",
-        "@jsonjoy.com/fs-snapshot": "4.57.2",
+        "@jsonjoy.com/fs-core": "4.57.8",
+        "@jsonjoy.com/fs-node-builtins": "4.57.8",
+        "@jsonjoy.com/fs-node-utils": "4.57.8",
+        "@jsonjoy.com/fs-print": "4.57.8",
+        "@jsonjoy.com/fs-snapshot": "4.57.8",
         "glob-to-regex.js": "^1.0.0",
         "thingies": "^2.5.0"
       },
@@ -5473,9 +5473,9 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-builtins": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.2.tgz",
-      "integrity": "sha512-xhiegylRmhw43Ki2HO1ZBL7DQ5ja/qpRsL29VtQ2xuUHiuDGbgf2uD4p9Qd8hJI5P6RCtGYD50IXHXVq/Ocjcg==",
+      "version": "4.57.8",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.8.tgz",
+      "integrity": "sha512-mxXSXw8zZwRVakcjLqR2I/psy4gURFSASZS10kKJ2kJw05GC2nXGroGrWVHxwgkxXgQLsFQnB74QaLzsxzdL/w==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.0"
@@ -5489,14 +5489,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.2.tgz",
-      "integrity": "sha512-18LmWTSONhoAPW+IWRuf8w/+zRolPFGPeGwMxlAhhfY11EKzX+5XHDBPAw67dBF5dxDErHJbl40U+3IXSDRXSQ==",
+      "version": "4.57.8",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.8.tgz",
+      "integrity": "sha512-AWZcT/4+H+iDl4XCukbXrarvwEgOrf/prFI5/7eg4ix9FxqVsZysIDJd1Kjd+AjlCeHKHJOaRqjLd5HiGSCJEw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-fsa": "4.57.2",
-        "@jsonjoy.com/fs-node-builtins": "4.57.2",
-        "@jsonjoy.com/fs-node-utils": "4.57.2"
+        "@jsonjoy.com/fs-fsa": "4.57.8",
+        "@jsonjoy.com/fs-node-builtins": "4.57.8",
+        "@jsonjoy.com/fs-node-utils": "4.57.8"
       },
       "engines": {
         "node": ">=10.0"
@@ -5510,12 +5510,12 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-utils": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.2.tgz",
-      "integrity": "sha512-rsPSJgekz43IlNbLyAM/Ab+ouYLWGp5DDBfYBNNEqDaSpsbXfthBn29Q4muFA9L0F+Z3mKo+CWlgSCXrf+mOyQ==",
+      "version": "4.57.8",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.8.tgz",
+      "integrity": "sha512-E/bJ7sQAb4pu9nbeJhbULU3WnqWrswte4N9Js/oHt7aHB746S8/XBqKlcbrqIgnD3095XluovNEZuu5ONT230g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.57.2"
+        "@jsonjoy.com/fs-node-builtins": "4.57.8"
       },
       "engines": {
         "node": ">=10.0"
@@ -5529,12 +5529,12 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-print": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.2.tgz",
-      "integrity": "sha512-wK9NSow48i4DbDl9F1CQE5TqnyZOJ04elU3WFG5aJ76p+YxO/ulyBBQvKsessPxdo381Bc2pcEoyPujMOhcRqQ==",
+      "version": "4.57.8",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.8.tgz",
+      "integrity": "sha512-DfzhOBpmvNu5P/KSe4NNQaOnvNliTdcf0qrh/4EReErF/XUQXYkd0vZl/OiJCm/qjEEo8DWRstliw2/JNS84dA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.8",
         "tree-dump": "^1.1.0"
       },
       "engines": {
@@ -5549,13 +5549,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-snapshot": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.2.tgz",
-      "integrity": "sha512-GdduDZuoP5V/QCgJkx9+BZ6SC0EZ/smXAdTS7PfMqgMTGXLlt/bH/FqMYaqB9JmLf05sJPtO0XRbAwwkEEPbVw==",
+      "version": "4.57.8",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.8.tgz",
+      "integrity": "sha512-L+eqKaWOHLDaiMv1dh/EWQ4hA+o6xAhWSumTo3Teg7OM18jU/KE13/e8Mfal+eAZ/pSl4wIhKHcDiwapJzC8Wg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@jsonjoy.com/buffers": "^17.65.0",
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.8",
         "@jsonjoy.com/json-pack": "^17.65.0",
         "@jsonjoy.com/util": "^17.65.0"
       },
@@ -15942,19 +15942,19 @@
       }
     },
     "node_modules/memfs": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.2.tgz",
-      "integrity": "sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==",
+      "version": "4.57.8",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.8.tgz",
+      "integrity": "sha512-bApYhn8BLpFAnAQmFfEl/NPN+8qx5Ar3V4Qt3ek23mVwBEElzV7c6XoPkb/PCG8ZFpowCEpHcPwMFTwHS7tSMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.2",
-        "@jsonjoy.com/fs-fsa": "4.57.2",
-        "@jsonjoy.com/fs-node": "4.57.2",
-        "@jsonjoy.com/fs-node-builtins": "4.57.2",
-        "@jsonjoy.com/fs-node-to-fsa": "4.57.2",
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
-        "@jsonjoy.com/fs-print": "4.57.2",
-        "@jsonjoy.com/fs-snapshot": "4.57.2",
+        "@jsonjoy.com/fs-core": "4.57.8",
+        "@jsonjoy.com/fs-fsa": "4.57.8",
+        "@jsonjoy.com/fs-node": "4.57.8",
+        "@jsonjoy.com/fs-node-builtins": "4.57.8",
+        "@jsonjoy.com/fs-node-to-fsa": "4.57.8",
+        "@jsonjoy.com/fs-node-utils": "4.57.8",
+        "@jsonjoy.com/fs-print": "4.57.8",
+        "@jsonjoy.com/fs-snapshot": "4.57.8",
         "@jsonjoy.com/json-pack": "^1.11.0",
         "@jsonjoy.com/util": "^1.9.0",
         "glob-to-regex.js": "^1.0.1",
@@ -24918,6 +24918,7 @@
         "@evjs/ev": "*",
         "@logtape/logtape": "^2.0.4",
         "css-loader": "^7.1.4",
+        "memfs": "^4.57.8",
         "mini-css-extract-plugin": "^2.10.2",
         "react-server-dom-webpack": "^19.2.5",
         "swc-loader": "^0.2.7",

--- a/packages/bundler-utoopack/src/adapter/create-config.ts
+++ b/packages/bundler-utoopack/src/adapter/create-config.ts
@@ -137,10 +137,6 @@ export async function createUtoopackConfig(
 
   const finalServerEntry = resolveServerEntry(plan);
 
-  if (!finalServerEntry) {
-    throw new Error("Failed to resolve a server entry for the server bundle.");
-  }
-
   const outputPaths = getOutputPaths(cwd, config.output, plan.distDir);
 
   const utoopackConfig: ConfigComplete = {
@@ -188,19 +184,27 @@ export async function createUtoopackConfig(
       "process.env.NODE_ENV": JSON.stringify(mode),
       __EVJS_FUNCTION_ENDPOINT__: JSON.stringify(config.server.runtime.fn),
     },
-    // Server functions config — utoopack handles "use server" natively
-    server: {
-      entry: finalServerEntry,
-      output: {
-        path: outputPaths.serverDir,
-        filename: isProduction ? "[name].[contenthash:8].js" : "[name].js",
-        chunkFilename: isProduction ? "[name].[contenthash:8].js" : "[name].js",
-      },
-      function: {
-        clientProxy: SERVER_FUNCTION_TRANSFORM_RUNTIME.clientModule,
-        serverRegister: SERVER_FUNCTION_TRANSFORM_RUNTIME.serverModule,
-      },
-    },
+    ...(finalServerEntry
+      ? {
+          // Server functions config — utoopack handles "use server" natively.
+          server: {
+            entry: finalServerEntry,
+            output: {
+              path: outputPaths.serverDir,
+              filename: isProduction
+                ? "[name].[contenthash:8].js"
+                : "[name].js",
+              chunkFilename: isProduction
+                ? "[name].[contenthash:8].js"
+                : "[name].js",
+            },
+            function: {
+              clientProxy: SERVER_FUNCTION_TRANSFORM_RUNTIME.clientModule,
+              serverRegister: SERVER_FUNCTION_TRANSFORM_RUNTIME.serverModule,
+            },
+          },
+        }
+      : {}),
 
     // Dev server configuration
     devServer: {
@@ -218,7 +222,7 @@ export async function createUtoopackConfig(
     cwd,
     config,
     bundlerName: "utoopack",
-    environment: "mixed",
+    environment: finalServerEntry ? "mixed" : "client",
     logger,
     addWatchFile() {},
   };

--- a/packages/bundler-utoopack/src/adapter/index.ts
+++ b/packages/bundler-utoopack/src/adapter/index.ts
@@ -98,6 +98,13 @@ export const utoopackAdapter: BundlerAdapter<ConfigComplete> = {
     await generateDevArtifacts(config, cwd, plan, callbacks.onBuildFacts, {
       isRebuild: false,
     });
+    if (!hasRuntimeServerEntry(plan)) {
+      return new UtoopackDevController({
+        config,
+        cwd,
+        onBuildFacts: callbacks.onBuildFacts,
+      });
+    }
 
     const outDir = getOutputPaths(cwd, config.output, plan.distDir).serverDir;
 
@@ -143,18 +150,25 @@ export const utoopackAdapter: BundlerAdapter<ConfigComplete> = {
   },
 };
 
+function hasRuntimeServerEntry(plan: BuildPlan): boolean {
+  return plan.entries.some(
+    (entry) =>
+      entry.environment === "server" && entry.kind === "server-runtime",
+  );
+}
+
 class UtoopackDevController implements BundlerDevController {
   constructor(
     private options: {
       config: ResolvedConfig<ConfigComplete>;
       cwd: string;
       onBuildFacts: BundlerDevContext<ConfigComplete>["callbacks"]["onBuildFacts"];
-      closeWatcher: () => void;
+      closeWatcher?: () => void;
     },
   ) {}
 
   close(): void {
-    this.options.closeWatcher();
+    this.options.closeWatcher?.();
   }
 
   async updatePlan(update: BuildPlanUpdate): Promise<void> {

--- a/packages/bundler-utoopack/src/manifest-generator.ts
+++ b/packages/bundler-utoopack/src/manifest-generator.ts
@@ -180,12 +180,14 @@ export class UtoopackManifestGenerator {
         const stats = JSON.parse(statsStr);
         const { byName, first } = readEntrypointAssets(stats);
         this.serverEntryAssets = byName;
-        const serverEntryName =
-          this.plan.entries.find((entry) => entry.kind === "server-runtime")
-            ?.name ?? "server";
-        const entryAssets = byName[serverEntryName] ?? first;
-        this.serverAssets = entryAssets;
-        this.serverEntry = entryAssets.js[0];
+        const serverRuntimeEntry = this.plan.entries.find(
+          (entry) => entry.kind === "server-runtime",
+        );
+        if (serverRuntimeEntry) {
+          const entryAssets = byName[serverRuntimeEntry.name] ?? first;
+          this.serverAssets = entryAssets;
+          this.serverEntry = entryAssets.js[0];
+        }
         this.serverModules = collectServerModules(
           stats.modules,
           this.serverAssets,
@@ -197,7 +199,10 @@ export class UtoopackManifestGenerator {
     }
 
     const serverDir = this.outputPaths.serverDir;
-    if (fs.existsSync(serverDir)) {
+    if (
+      this.plan.entries.some((entry) => entry.kind === "server-runtime") &&
+      fs.existsSync(serverDir)
+    ) {
       const files = await fs.promises.readdir(serverDir);
       const jsEntry = files.find((file) => file.endsWith(".js"));
       if (jsEntry) {

--- a/packages/bundler-utoopack/tests/adapter.test.ts
+++ b/packages/bundler-utoopack/tests/adapter.test.ts
@@ -278,7 +278,7 @@ describe("utoopackAdapter dev", () => {
       js: ["dev-hook.js"],
       css: [],
     });
-    expect(manifest.apps.default).toEqual({
+    expect(manifest.app).toEqual({
       assets: {
         js: ["main.js"],
         css: ["main.css"],
@@ -591,8 +591,8 @@ describe("utoopackAdapter dev", () => {
       },
     });
     expect(serverManifest.entry).toBe("index.js");
-    expect(publicManifest.apps.default.entry).toBeUndefined();
-    expect(publicManifest.apps.default.module).toEqual({
+    expect(publicManifest.app.entry).toBeUndefined();
+    expect(publicManifest.app.module).toEqual({
       type: "entry",
       href: "main.js",
     });

--- a/packages/bundler-utoopack/tests/adapter.test.ts
+++ b/packages/bundler-utoopack/tests/adapter.test.ts
@@ -10,6 +10,7 @@ import type {
 } from "@evjs/ev";
 import {
   buildHtml,
+  createDeploymentMetadata,
   createPublicManifest,
   createServerManifest,
   linkBuildOutput,
@@ -24,6 +25,7 @@ import {
 } from "@evjs/ev/build-tools";
 import type { ConfigComplete } from "@utoo/pack";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createClientRuntime } from "../../ev/src/framework-runtime.js";
 import { utoopackAdapter } from "../src/adapter/index.js";
 
 vi.mock("@utoo/pack", () => ({
@@ -65,6 +67,7 @@ vi.mock("@utoo/pack", () => ({
   build: vi.fn(),
 }));
 
+const CLIENT_RUNTIME_SCRIPT_ID = "__EVJS_CLIENT_RUNTIME__";
 const tempDirs: string[] = [];
 
 async function makeProject() {
@@ -137,7 +140,7 @@ function createFrameworkCallbacks(options: {
       );
       await fs.promises.writeFile(
         path.join(rootDir, "build-output.json"),
-        JSON.stringify(output, null, 2),
+        JSON.stringify(createDeploymentMetadata(output), null, 2),
         "utf-8",
       );
       await fs.promises.mkdir(clientDir, { recursive: true });
@@ -170,6 +173,7 @@ function createFrameworkCallbacks(options: {
           doc.documentElement?.setAttribute("data-evjs-kind", "app");
           doc.documentElement?.setAttribute("data-evjs-id", appId);
         }
+        embedClientRuntime(doc, output);
 
         const finalHtml = await buildHtml({
           doc,
@@ -208,6 +212,28 @@ function createFrameworkCallbacks(options: {
     },
     onServerBundleReady: options.onServerBundleReady ?? vi.fn(),
   };
+}
+
+function embedClientRuntime(
+  doc: ReturnType<typeof generateHtml>,
+  output: BuildOutput,
+): void {
+  const body = doc.body ?? doc.querySelector("body");
+  if (!body) return;
+  const json = JSON.stringify(createClientRuntime(output)).replace(
+    /</g,
+    "\\u003c",
+  );
+  const script = doc.createElement("script");
+  script.id = CLIENT_RUNTIME_SCRIPT_ID;
+  script.setAttribute("type", "application/json");
+  script.textContent = json;
+  const firstScript = body.querySelector("script[src]");
+  if (firstScript) {
+    body.insertBefore(script, firstScript);
+    return;
+  }
+  body.appendChild(script);
 }
 
 async function expectRejectedMessage(action: () => void | Promise<void>) {
@@ -278,17 +304,8 @@ describe("utoopackAdapter dev", () => {
       js: ["dev-hook.js"],
       css: [],
     });
-    expect(manifest.app).toEqual({
-      assets: {
-        js: ["main.js"],
-        css: ["main.css"],
-      },
-      document: { fileName: "index.html" },
-      module: {
-        type: "entry",
-        href: "main.js",
-      },
-    });
+    expect("app" in manifest).toBe(false);
+    expect(manifest.routing).toEqual({ kind: "spa", routes: [] });
     expect(html).toContain('<link rel="stylesheet" href="/main.css">');
     expect(html).toContain('src="/main.js"');
     expect(html).toContain('data-evjs-kind="app"');
@@ -562,7 +579,7 @@ describe("utoopackAdapter dev", () => {
       hooks,
     });
 
-    const buildOutput = JSON.parse(
+    const deploymentMetadata = JSON.parse(
       await fs.promises.readFile(
         path.join(cwd, "dist/build-output.json"),
         "utf-8",
@@ -585,23 +602,21 @@ describe("utoopackAdapter dev", () => {
       "utf-8",
     );
 
-    expect(buildOutput.apps.default).toEqual({
-      assets: {
-        js: ["main.js"],
-        css: ["main.css"],
+    expect("apps" in deploymentMetadata).toBe(false);
+    expect(deploymentMetadata.documents).toEqual([
+      {
+        kind: "app",
+        id: "default",
+        fileName: "index.html",
+        assets: {
+          js: ["main.js"],
+          css: ["main.css"],
+        },
       },
-      document: { fileName: "index.html" },
-      module: {
-        type: "entry",
-        href: "main.js",
-      },
-    });
+    ]);
     expect(serverManifest.entry).toBe("index.js");
-    expect(publicManifest.app.entry).toBeUndefined();
-    expect(publicManifest.app.module).toEqual({
-      type: "entry",
-      href: "main.js",
-    });
+    expect("app" in publicManifest).toBe(false);
+    expect(publicManifest.routing.kind).toBe("spa");
     expect(fs.existsSync(path.join(cwd, "dist/manifest.json"))).toBe(false);
     expect(html).toContain('<link rel="stylesheet" href="/main.css">');
     expect(html).toContain('src="/main.js"');

--- a/packages/bundler-utoopack/tests/adapter.test.ts
+++ b/packages/bundler-utoopack/tests/adapter.test.ts
@@ -401,7 +401,7 @@ describe("utoopackAdapter dev", () => {
           path.join(cwd, "dist/manifest.json"),
           "utf-8",
         ),
-      ) as BuildOutput;
+      ) as ReturnType<typeof createPublicManifest>;
 
       expect(update.entries.added).toHaveLength(0);
       expect(update.entries.changed).toHaveLength(0);
@@ -409,7 +409,13 @@ describe("utoopackAdapter dev", () => {
       expect(html).toContain("next-shell");
       expect(html).toContain('data-evjs-kind="page"');
       expect(html).toContain('data-evjs-id="home"');
-      expect(manifest.pages.home.document).toEqual({ fileName: "home.html" });
+      expect(manifest.routing.kind).toBe("mpa");
+      if (manifest.routing.kind !== "mpa") {
+        throw new Error("Expected MPA public manifest.");
+      }
+      expect(manifest.routing.pages.home.document).toEqual({
+        fileName: "home.html",
+      });
       expect(onBuildOutput).toHaveBeenCalledTimes(2);
     } finally {
       await controller.close?.();

--- a/packages/bundler-utoopack/tests/adapter.test.ts
+++ b/packages/bundler-utoopack/tests/adapter.test.ts
@@ -585,7 +585,6 @@ describe("utoopackAdapter dev", () => {
         css: ["main.css"],
       },
       document: { fileName: "index.html" },
-      entry: "./src/main.tsx",
       module: {
         type: "entry",
         href: "main.js",

--- a/packages/bundler-utoopack/tests/adapter.test.ts
+++ b/packages/bundler-utoopack/tests/adapter.test.ts
@@ -132,12 +132,15 @@ function createFrameworkCallbacks(options: {
       const clientDir = path.resolve(options.cwd, plan.output.clientDir);
       await fs.promises.mkdir(rootDir, { recursive: true });
       const serverDir = path.join(rootDir, "server");
-      await fs.promises.mkdir(serverDir, { recursive: true });
-      await fs.promises.writeFile(
-        path.join(serverDir, "manifest.json"),
-        JSON.stringify(createServerManifest(output), null, 2),
-        "utf-8",
-      );
+      const serverManifest = createServerManifest(output);
+      if (serverManifest.entry || serverManifest.routes.length > 0) {
+        await fs.promises.mkdir(serverDir, { recursive: true });
+        await fs.promises.writeFile(
+          path.join(serverDir, "manifest.json"),
+          JSON.stringify(serverManifest, null, 2),
+          "utf-8",
+        );
+      }
       await fs.promises.writeFile(
         path.join(rootDir, "build-output.json"),
         JSON.stringify(createDeploymentMetadata(output), null, 2),
@@ -427,8 +430,7 @@ describe("utoopackAdapter dev", () => {
       expect(html).toContain('data-evjs-kind="page"');
       expect(html).toContain('data-evjs-id="home"');
       expect(manifest).not.toHaveProperty("assets");
-      expect(manifest.routing.kind).toBe("mpa");
-      if (manifest.routing.kind !== "mpa") {
+      if (!("routing" in manifest) || manifest.routing.kind !== "mpa") {
         throw new Error("Expected MPA public manifest.");
       }
       expect(manifest.routing.pages.home.document).toEqual({
@@ -543,7 +545,7 @@ describe("utoopackAdapter dev", () => {
     }
   });
 
-  it("emits split build manifests plus index.html in fullstack mode", async () => {
+  it("emits split build manifests plus index.html in client-only mode", async () => {
     const cwd = await makeProject();
     const onServerBundleReady = vi.fn();
     const config = resolveConfig<ConfigComplete>({
@@ -586,12 +588,6 @@ describe("utoopackAdapter dev", () => {
         "utf-8",
       ),
     );
-    const serverManifest = JSON.parse(
-      await fs.promises.readFile(
-        path.join(cwd, "dist/server/manifest.json"),
-        "utf-8",
-      ),
-    );
     const publicManifest = JSON.parse(
       await fs.promises.readFile(
         path.join(cwd, "dist/client/manifest.json"),
@@ -615,9 +611,9 @@ describe("utoopackAdapter dev", () => {
         },
       },
     ]);
-    expect(serverManifest.entry).toBe("index.js");
-    expect(serverManifest.routes).toEqual([]);
-    expect(serverManifest.assets).toBeUndefined();
+    expect(fs.existsSync(path.join(cwd, "dist/server/manifest.json"))).toBe(
+      false,
+    );
     expect("app" in publicManifest).toBe(false);
     expect(publicManifest.routing.kind).toBe("spa");
     expect(fs.existsSync(path.join(cwd, "dist/manifest.json"))).toBe(false);
@@ -626,7 +622,7 @@ describe("utoopackAdapter dev", () => {
     expect(html).toContain('data-evjs-kind="app"');
     expect(html).toContain('data-evjs-id="default"');
     expect(html).toContain('<meta name="server">');
-    expect(onServerBundleReady).toHaveBeenCalledTimes(1);
+    expect(onServerBundleReady).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/bundler-utoopack/tests/adapter.test.ts
+++ b/packages/bundler-utoopack/tests/adapter.test.ts
@@ -426,6 +426,7 @@ describe("utoopackAdapter dev", () => {
       expect(html).toContain("next-shell");
       expect(html).toContain('data-evjs-kind="page"');
       expect(html).toContain('data-evjs-id="home"');
+      expect(manifest).not.toHaveProperty("assets");
       expect(manifest.routing.kind).toBe("mpa");
       if (manifest.routing.kind !== "mpa") {
         throw new Error("Expected MPA public manifest.");
@@ -615,6 +616,8 @@ describe("utoopackAdapter dev", () => {
       },
     ]);
     expect(serverManifest.entry).toBe("index.js");
+    expect(serverManifest.routes).toEqual([]);
+    expect(serverManifest.assets).toBeUndefined();
     expect("app" in publicManifest).toBe(false);
     expect(publicManifest.routing.kind).toBe("spa");
     expect(fs.existsSync(path.join(cwd, "dist/manifest.json"))).toBe(false);

--- a/packages/bundler-utoopack/tests/create-config.test.ts
+++ b/packages/bundler-utoopack/tests/create-config.test.ts
@@ -104,9 +104,7 @@ describe("createUtoopackConfig", () => {
     expect(utoopackConfig.output?.path).toBe(
       path.resolve(cwd, "custom-dist/client"),
     );
-    expect(utoopackConfig.server?.output?.path).toBe(
-      path.resolve(cwd, "custom-dist/server"),
-    );
+    expect(utoopackConfig.server).toBeUndefined();
   });
 
   it("uses the build plan mode instead of NODE_ENV", async () => {
@@ -741,7 +739,7 @@ describe("createUtoopackConfig", () => {
             cfg.output ??= {};
             cfg.output.publicPath = "runtime";
             expect(ctx.bundlerName).toBe("utoopack");
-            expect(ctx.environment).toBe("mixed");
+            expect(ctx.environment).toBe("client");
           },
         },
       ],

--- a/packages/bundler-utoopack/tests/manifest-generator.test.ts
+++ b/packages/bundler-utoopack/tests/manifest-generator.test.ts
@@ -138,7 +138,6 @@ describe("UtoopackManifestGenerator", () => {
         id: "home",
         path: "/",
         appId: "default",
-        module: "./pages/Home.tsx",
       },
     ]);
     expect(manifest.server?.entry).toBe("server.js");
@@ -149,7 +148,6 @@ describe("UtoopackManifestGenerator", () => {
     expect(manifest.server?.functions).toEqual({
       "function-id": {
         assets: { js: ["server.js"], css: [] },
-        module: "src/actions.ts",
         exportName: "save",
       },
     });
@@ -213,7 +211,7 @@ describe("UtoopackManifestGenerator", () => {
       css: [],
     });
     expect(output.serverEntry).toBe("server.js");
-    expect(manifest.distDir).toBe("custom-dist");
+    expect(manifest.paths.rootDir).toBe("custom-dist");
   });
 
   it("links page assets for MPA output", async () => {
@@ -264,7 +262,6 @@ describe("UtoopackManifestGenerator", () => {
     expect(manifest.pages.home).toMatchObject({
       assets: { js: ["home.js"], css: [] },
       render: "csr",
-      entry: "./src/home.tsx",
       module: {
         type: "entry",
         href: "home.js",
@@ -273,7 +270,6 @@ describe("UtoopackManifestGenerator", () => {
     expect(manifest.pages.about).toMatchObject({
       assets: { js: ["about.js"], css: [] },
       render: "csr",
-      entry: "./src/about.tsx",
       module: {
         type: "entry",
         href: "about.js",
@@ -346,7 +342,6 @@ describe("UtoopackManifestGenerator", () => {
       render: "ssr",
       prerender: { partial: true },
       routeId: "campaign-route",
-      component: "./src/campaign/Page.tsx",
       ppr: {
         delivery: "merge",
         shell: { js: ["campaign.shell.js"], css: [] },
@@ -354,8 +349,6 @@ describe("UtoopackManifestGenerator", () => {
           offer: {
             id: "offer",
             assets: { js: ["campaign.offer.js"], css: [] },
-            component: "./src/campaign/Offer.region.tsx",
-            fallback: "./src/campaign/OfferSkeleton.tsx",
             cache: "no-store",
             hydrate: "visible",
           },

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -34,6 +34,7 @@
     "@evjs/ev": "*",
     "@logtape/logtape": "^2.0.4",
     "css-loader": "^7.1.4",
+    "memfs": "^4.57.8",
     "mini-css-extract-plugin": "^2.10.2",
     "react-server-dom-webpack": "^19.2.5",
     "swc-loader": "^0.2.7",

--- a/packages/bundler-webpack/src/adapter/create-config.ts
+++ b/packages/bundler-webpack/src/adapter/create-config.ts
@@ -80,10 +80,16 @@ export async function createWebpackConfigs(
   const serverEntries = plan.entries.filter(
     (entry) => entry.environment === "server",
   );
-  const rscServerEntries = serverEntries.filter(
+  const buildOnlyServerEntries = serverEntries.filter(
+    (entry) => entry.phase === "build",
+  );
+  const runtimeServerEntries = serverEntries.filter(
+    (entry) => entry.phase !== "build",
+  );
+  const rscServerEntries = runtimeServerEntries.filter(
     (entry) => entry.kind === "rsc-page",
   );
-  const regularServerEntries = serverEntries.filter(
+  const regularServerEntries = runtimeServerEntries.filter(
     (entry) => entry.kind !== "rsc-page",
   );
 
@@ -128,6 +134,27 @@ export async function createWebpackConfigs(
         rscClientReferences: getRscClientReferenceModules(cwd, graph),
         enableRscClientRuntime: false,
         clean: (options.clean ?? true) && rscServerEntries.length === 0,
+        reactServerConditions: false,
+        target: "node",
+      }),
+    );
+  }
+
+  if (buildOnlyServerEntries.length > 0) {
+    configs.push(
+      createWebpackConfig({
+        cwd,
+        entries: buildOnlyServerEntries,
+        mode: plan.mode,
+        name: "server-build",
+        outputPath: path.join(outputPaths.rootDir, "__evjs_build_server"),
+        publicPath: plan.runtime.publicPath,
+        resolveAlias: plan.resolve?.alias,
+        functionEndpoint: config.server.runtime.fn,
+        crossOriginLoading: undefined,
+        rscClientReferences: getRscClientReferenceModules(cwd, graph),
+        enableRscClientRuntime: false,
+        clean: false,
         reactServerConditions: false,
         target: "node",
       }),

--- a/packages/bundler-webpack/src/adapter/index.ts
+++ b/packages/bundler-webpack/src/adapter/index.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import type { ClientRequest } from "node:http";
+import { createRequire } from "node:module";
 import path from "node:path";
+import vm from "node:vm";
 import type {
   AppGraph,
   BuildPlan,
@@ -16,6 +18,7 @@ import type {
 } from "@evjs/ev";
 import { getClientRouteMatches, getServerRenderedPaths } from "@evjs/ev";
 import { getLogger } from "@logtape/logtape";
+import { createFsFromVolume, Volume } from "memfs";
 import type {
   Compiler,
   Configuration,
@@ -34,6 +37,7 @@ import { getOutputPaths } from "./output-paths.js";
 
 const logger = getLogger(["evjs", "bundler-webpack"]);
 const DEV_PAGE_RENDER_PROXY_HEADER = "x-evjs-dev-page-render";
+const BUILD_ONLY_SERVER_CONFIG_NAME = "server-build";
 
 interface WebpackDevServerInstance {
   start(): Promise<void>;
@@ -77,14 +81,19 @@ export const webpackAdapter: BundlerAdapter<WebpackConfig> = {
 
     const configs = await createWebpackConfigs(config, plan, graph, cwd, hooks);
     const stats = await runWebpack(configs);
+    const hasRuntimeServerEntries = plan.entries.some(
+      (entry) => entry.environment === "server" && entry.phase !== "build",
+    );
 
     await emitStats(outputPaths.clientDir, stats.clientStats);
-    await emitStats(outputPaths.serverDir, stats.serverStats);
-    await copyServerCssAssetsToClient(
-      outputPaths.serverDir,
-      outputPaths.clientDir,
-      stats.serverStats,
-    );
+    if (hasRuntimeServerEntries) {
+      await emitStats(outputPaths.serverDir, stats.serverStats);
+      await copyServerCssAssetsToClient(
+        outputPaths.serverDir,
+        outputPaths.clientDir,
+        stats.serverStats,
+      );
+    }
 
     logger.info`Collecting webpack build facts...`;
     const generator = new WebpackManifestGenerator(
@@ -95,7 +104,17 @@ export const webpackAdapter: BundlerAdapter<WebpackConfig> = {
     );
 
     logger.info`Build complete!`;
-    return generator.collectBuildFacts();
+    return {
+      ...generator.collectBuildFacts(),
+      ...(stats.memoryFiles.size > 0
+        ? {
+            loadServerModule: createMemoryServerModuleLoader(
+              cwd,
+              stats.memoryFiles,
+            ),
+          }
+        : {}),
+    };
   },
 
   async dev(
@@ -894,8 +913,23 @@ function toWebpackDevProxy(rule: WebpackDevProxyRule) {
 async function runWebpack(configs: Configuration[]): Promise<{
   clientStats?: WebpackStatsLike;
   serverStats?: WebpackStatsLike;
+  memoryFiles: Map<string, string>;
 }> {
   const compiler = webpack(configs);
+  const memoryVolume = new Volume();
+  const memoryFs = createFsFromVolume(memoryVolume);
+  const memoryOutputPaths = new Set<string>();
+  const childCompilers =
+    "compilers" in compiler
+      ? (compiler.compilers as Compiler[])
+      : ([compiler] as Compiler[]);
+  for (const child of childCompilers) {
+    if (child.options.name !== BUILD_ONLY_SERVER_CONFIG_NAME) continue;
+    child.outputFileSystem =
+      memoryFs as unknown as Compiler["outputFileSystem"];
+    const outputPath = child.options.output.path;
+    if (outputPath) memoryOutputPaths.add(outputPath);
+  }
 
   const stats = await new Promise<Stats | MultiStats>((resolve, reject) => {
     compiler.run((error, result) => {
@@ -921,7 +955,10 @@ async function runWebpack(configs: Configuration[]): Promise<{
     throw new Error(formatWebpackErrors(stats));
   }
 
-  return splitStatsByName(stats);
+  return {
+    ...splitStatsByName(stats),
+    memoryFiles: collectMemoryFiles(memoryVolume, memoryOutputPaths),
+  };
 }
 
 function splitStatsByName(stats: Stats | MultiStats): {
@@ -943,7 +980,11 @@ function splitStatsByName(stats: Stats | MultiStats): {
   let serverStats: WebpackStatsLike | undefined;
 
   for (const child of children) {
-    if (child.name === "server" || child.name === "server-rsc") {
+    if (
+      child.name === "server" ||
+      child.name === "server-rsc" ||
+      child.name === BUILD_ONLY_SERVER_CONFIG_NAME
+    ) {
       serverStats = mergeWebpackStats(serverStats, child, child.name);
     } else if (child.name === "client") {
       clientStats = child;
@@ -951,6 +992,58 @@ function splitStatsByName(stats: Stats | MultiStats): {
   }
 
   return { clientStats, serverStats };
+}
+
+function collectMemoryFiles(
+  volume: Volume,
+  outputPaths: Set<string>,
+): Map<string, string> {
+  const files = new Map<string, string>();
+  for (const outputPath of outputPaths) {
+    const tree = volume.toJSON(outputPath, {}, true);
+    for (const [filePath, value] of Object.entries(tree)) {
+      if (typeof value !== "string") continue;
+      const fileName = path.basename(filePath);
+      files.set(fileName, value);
+    }
+  }
+  return files;
+}
+
+function createMemoryServerModuleLoader(
+  cwd: string,
+  files: Map<string, string>,
+): (asset: string) => Promise<unknown> {
+  const require = createRequire(path.join(cwd, "package.json"));
+  const cache = new Map<string, unknown>();
+  return async (asset) => {
+    const fileName = path.basename(asset);
+    if (cache.has(fileName)) return cache.get(fileName);
+
+    const source = files.get(fileName);
+    if (source === undefined) {
+      throw new Error(
+        `[evjs] Webpack build-only server module "${asset}" was not emitted in memory.`,
+      );
+    }
+
+    const module = { exports: {} as unknown };
+    const filename = path.join(cwd, fileName);
+    const dirname = path.dirname(filename);
+    const factory = vm.runInThisContext(
+      `(function(exports, require, module, __filename, __dirname) {\n${source}\n})`,
+      { filename },
+    ) as (
+      exports: unknown,
+      require: NodeJS.Require,
+      module: { exports: unknown },
+      __filename: string,
+      __dirname: string,
+    ) => void;
+    factory(module.exports, require, module, filename, dirname);
+    cache.set(fileName, module.exports);
+    return module.exports;
+  };
 }
 
 function mergeWebpackStats(

--- a/packages/bundler-webpack/src/manifest-generator.ts
+++ b/packages/bundler-webpack/src/manifest-generator.ts
@@ -202,19 +202,14 @@ function normalizeModuleId(
 function readRscManifests(clientDir: string):
   | {
       clientReferenceManifest?: Record<string, unknown>;
-      serverConsumerManifest?: Record<string, unknown>;
     }
   | undefined {
   const clientReferenceManifest = readJsonObject(
     path.join(clientDir, "react-client-manifest.json"),
   );
-  const serverConsumerManifest = readJsonObject(
-    path.join(clientDir, "react-ssr-manifest.json"),
-  );
-  if (!clientReferenceManifest && !serverConsumerManifest) return undefined;
+  if (!clientReferenceManifest) return undefined;
   return {
     clientReferenceManifest,
-    serverConsumerManifest,
   };
 }
 

--- a/packages/bundler-webpack/src/manifest-generator.ts
+++ b/packages/bundler-webpack/src/manifest-generator.ts
@@ -67,12 +67,15 @@ export class WebpackManifestGenerator {
 
     const serverEntrypoints = readEntrypointAssets(this.serverStats);
     this.serverEntryAssets = serverEntrypoints.byName;
-    const serverEntryName =
-      this.plan.entries.find((entry) => entry.kind === "server-runtime")
-        ?.name ?? "server";
-    this.serverAssets =
-      this.serverEntryAssets[serverEntryName] ?? serverEntrypoints.first;
-    this.serverEntry = this.serverAssets.js[0];
+    const serverRuntimeEntry = this.plan.entries.find(
+      (entry) => entry.kind === "server-runtime",
+    );
+    if (serverRuntimeEntry) {
+      this.serverAssets =
+        this.serverEntryAssets[serverRuntimeEntry.name] ??
+        serverEntrypoints.first;
+      this.serverEntry = this.serverAssets.js[0];
+    }
     this.serverModules = collectServerModules(
       this.serverStats,
       this.serverAssets,

--- a/packages/bundler-webpack/tests/adapter.test.ts
+++ b/packages/bundler-webpack/tests/adapter.test.ts
@@ -469,7 +469,7 @@ describe("webpackAdapter build", () => {
 
       const manifest = JSON.parse(
         await fs.readFile(path.join(cwd, "dist/manifest.json"), "utf-8"),
-      ) as BuildOutput;
+      ) as PublicManifestOutput;
       const html = await fs.readFile(path.join(cwd, "dist/home.html"), "utf-8");
       const bundle = await fs.readFile(path.join(cwd, "dist/home.js"), "utf-8");
 
@@ -479,7 +479,11 @@ describe("webpackAdapter build", () => {
         component: "./src/pages/Home ! page 中文.tsx",
         mount: "#root",
       });
-      expect(manifest.pages.home).toMatchObject({
+      expect(manifest.routing.kind).toBe("mpa");
+      if (manifest.routing.kind !== "mpa") {
+        throw new Error("Expected MPA public manifest.");
+      }
+      expect(manifest.routing.pages.home).toMatchObject({
         assets: { js: ["home.js"], css: [] },
         mount: "#root",
         render: "csr",
@@ -609,7 +613,11 @@ describe("webpackAdapter build", () => {
         type: "entry",
         href: "main.js",
       });
-      expect("component" in publicManifest.pages.dashboard).toBe(false);
+      expect(publicManifest.routing.kind).toBe("mpa");
+      if (publicManifest.routing.kind !== "mpa") {
+        throw new Error("Expected MPA public manifest.");
+      }
+      expect("component" in publicManifest.routing.pages.dashboard).toBe(false);
       await expect(
         fs.access(path.join(cwd, "dist/manifest.json")),
       ).rejects.toThrow();
@@ -998,17 +1006,26 @@ describe("webpackAdapter dev", () => {
     try {
       const manifest = JSON.parse(
         await fs.readFile(path.join(cwd, "dist/manifest.json"), "utf-8"),
-      ) as { pages: BuildOutput["pages"] };
+      ) as PublicManifestOutput;
       const runtime = JSON.parse(
         await fs.readFile(path.join(cwd, "dist/runtime.json"), "utf-8"),
-      ) as { pages: Record<string, Record<string, unknown>> };
+      ) as {
+        routing: {
+          kind: "mpa";
+          pages: Record<string, Record<string, unknown>>;
+        };
+      };
       const html = await fetchDevText(`http://127.0.0.1:${port}/home.html`);
 
       expect(onBuildOutput).toHaveBeenCalledTimes(1);
       expect("distDir" in manifest).toBe(false);
-      expect(manifest.pages.home.assets.js).toEqual(["home.js"]);
-      expect(runtime.pages.home).not.toHaveProperty("assets");
-      expect(runtime.pages.home).toEqual({
+      expect(manifest.routing.kind).toBe("mpa");
+      if (manifest.routing.kind !== "mpa") {
+        throw new Error("Expected MPA public manifest.");
+      }
+      expect(manifest.routing.pages.home.assets.js).toEqual(["home.js"]);
+      expect(runtime.routing.pages.home).not.toHaveProperty("assets");
+      expect(runtime.routing.pages.home).toMatchObject({
         module: { type: "react-component", href: "home.js" },
         mount: "#root",
       });
@@ -1368,13 +1385,17 @@ describe("webpackAdapter dev", () => {
 
       const manifest = JSON.parse(
         await fs.readFile(path.join(cwd, "dist/manifest.json"), "utf-8"),
-      ) as BuildOutput;
+      ) as PublicManifestOutput;
       const html = await fetchDevText(`http://127.0.0.1:${port}/about.html`);
 
       expect(update.entries.added.map((entry) => entry.name)).toEqual([
         "about",
       ]);
-      expect(manifest.pages.about.assets.js).toEqual(["about.js"]);
+      expect(manifest.routing.kind).toBe("mpa");
+      if (manifest.routing.kind !== "mpa") {
+        throw new Error("Expected MPA public manifest.");
+      }
+      expect(manifest.routing.pages.about.assets.js).toEqual(["about.js"]);
       expect(html).toContain('data-evjs-kind="page"');
       expect(html).toContain('data-evjs-id="about"');
       expect(html).toContain('src="/about.js"');

--- a/packages/bundler-webpack/tests/adapter.test.ts
+++ b/packages/bundler-webpack/tests/adapter.test.ts
@@ -500,14 +500,13 @@ describe("webpackAdapter build", () => {
         mount: "#root",
       });
       expect(manifest).not.toHaveProperty("assets");
-      expect(manifest.routing.kind).toBe("mpa");
-      if (manifest.routing.kind !== "mpa") {
+      if (!("routing" in manifest) || manifest.routing.kind !== "mpa") {
         throw new Error("Expected MPA public manifest.");
       }
       expect(manifest.routing.pages.home).toMatchObject({
         assets: { js: ["home.js"], css: [] },
+        render: "csr",
       });
-      expect("render" in manifest.routing.pages.home).toBe(false);
       expect("module" in manifest.routing.pages.home).toBe(false);
       expect(output.pages.home).toMatchObject({
         render: "csr",
@@ -647,17 +646,28 @@ describe("webpackAdapter build", () => {
       expect("apps" in deploymentMetadata).toBe(false);
       expect("pages" in deploymentMetadata).toBe(false);
       expect("app" in publicManifest).toBe(false);
-      expect(publicManifest).not.toHaveProperty("assets");
-      expect(publicManifest.routing.kind).toBe("mpa");
-      if (publicManifest.routing.kind !== "mpa") {
-        throw new Error("Expected MPA public manifest.");
+      if (
+        !("routing" in publicManifest) ||
+        publicManifest.routing.kind !== "spa"
+      ) {
+        throw new Error("Expected SPA public manifest.");
       }
-      expect(publicManifest.routing.pages.dashboard.assets).toEqual({
-        js: [],
-        css: [],
+      expect("assets" in publicManifest).toBe(true);
+      if (!("assets" in publicManifest)) {
+        throw new Error("Expected SPA public manifest assets.");
+      }
+      expect(publicManifest.assets).toEqual({
+        main: {
+          js: ["main.js"],
+          css: [],
+        },
       });
-      expect("component" in publicManifest.routing.pages.dashboard).toBe(false);
-      expect("module" in publicManifest.routing.pages.dashboard).toBe(false);
+      expect(publicManifest.routing.routes).toContainEqual({
+        id: "dashboard",
+        path: "/dashboard",
+        pageId: "dashboard",
+        render: "ssr",
+      });
       await expect(
         fs.access(path.join(cwd, "dist/manifest.json")),
       ).rejects.toThrow();
@@ -1038,8 +1048,7 @@ describe("webpackAdapter dev", () => {
       expect(onBuildOutput).toHaveBeenCalledTimes(1);
       expect("distDir" in manifest).toBe(false);
       expect(manifest).not.toHaveProperty("assets");
-      expect(manifest.routing.kind).toBe("mpa");
-      if (manifest.routing.kind !== "mpa") {
+      if (!("routing" in manifest) || manifest.routing.kind !== "mpa") {
         throw new Error("Expected MPA public manifest.");
       }
       expect(manifest.routing.pages.home.assets.js).toEqual(["home.js"]);
@@ -1302,10 +1311,7 @@ describe("webpackAdapter dev", () => {
       const session = controller as unknown as {
         plan: { entries: Array<{ name: string }> };
       };
-      expect(session.plan.entries.map((entry) => entry.name)).toEqual([
-        "home",
-        "server",
-      ]);
+      expect(session.plan.entries.map((entry) => entry.name)).toEqual(["home"]);
     } finally {
       await controller?.close?.();
     }
@@ -1409,8 +1415,7 @@ describe("webpackAdapter dev", () => {
         "about",
       ]);
       expect(manifest).not.toHaveProperty("assets");
-      expect(manifest.routing.kind).toBe("mpa");
-      if (manifest.routing.kind !== "mpa") {
+      if (!("routing" in manifest) || manifest.routing.kind !== "mpa") {
         throw new Error("Expected MPA public manifest.");
       }
       expect(manifest.routing.pages.about.assets.js).toEqual(["about.js"]);

--- a/packages/bundler-webpack/tests/adapter.test.ts
+++ b/packages/bundler-webpack/tests/adapter.test.ts
@@ -24,6 +24,7 @@ import {
   diffBuildPlan,
   generateHtml,
 } from "@evjs/ev/build-tools";
+import type { PublicManifestOutput } from "@evjs/shared/manifest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createClientRuntime,
@@ -561,7 +562,7 @@ describe("webpackAdapter build", () => {
       ) as BuildOutput;
       const publicManifest = JSON.parse(
         await fs.readFile(path.join(cwd, "dist/client/manifest.json"), "utf-8"),
-      ) as BuildOutput;
+      ) as PublicManifestOutput;
       const html = await fs.readFile(
         path.join(cwd, "dist/client/index.html"),
         "utf-8",
@@ -603,8 +604,8 @@ describe("webpackAdapter build", () => {
       });
       expect(manifest.server?.entry).toBe("server.cjs");
       expect(manifest.assets.plugin).toEqual({ js: ["plugin.js"], css: [] });
-      expect("entry" in publicManifest.apps.default).toBe(false);
-      expect(publicManifest.apps.default.module).toEqual({
+      expect(publicManifest.app).not.toHaveProperty("entry");
+      expect(publicManifest.app?.module).toEqual({
         type: "entry",
         href: "main.js",
       });

--- a/packages/bundler-webpack/tests/adapter.test.ts
+++ b/packages/bundler-webpack/tests/adapter.test.ts
@@ -498,6 +498,7 @@ describe("webpackAdapter build", () => {
         component: "./src/pages/Home ! page 中文.tsx",
         mount: "#root",
       });
+      expect(manifest).not.toHaveProperty("assets");
       expect(manifest.routing.kind).toBe("mpa");
       if (manifest.routing.kind !== "mpa") {
         throw new Error("Expected MPA public manifest.");
@@ -644,6 +645,7 @@ describe("webpackAdapter build", () => {
       expect("apps" in deploymentMetadata).toBe(false);
       expect("pages" in deploymentMetadata).toBe(false);
       expect("app" in publicManifest).toBe(false);
+      expect(publicManifest).not.toHaveProperty("assets");
       expect(publicManifest.routing.kind).toBe("mpa");
       if (publicManifest.routing.kind !== "mpa") {
         throw new Error("Expected MPA public manifest.");
@@ -1037,6 +1039,7 @@ describe("webpackAdapter dev", () => {
 
       expect(onBuildOutput).toHaveBeenCalledTimes(1);
       expect("distDir" in manifest).toBe(false);
+      expect(manifest).not.toHaveProperty("assets");
       expect(manifest.routing.kind).toBe("mpa");
       if (manifest.routing.kind !== "mpa") {
         throw new Error("Expected MPA public manifest.");
@@ -1407,6 +1410,7 @@ describe("webpackAdapter dev", () => {
       expect(update.entries.added.map((entry) => entry.name)).toEqual([
         "about",
       ]);
+      expect(manifest).not.toHaveProperty("assets");
       expect(manifest.routing.kind).toBe("mpa");
       if (manifest.routing.kind !== "mpa") {
         throw new Error("Expected MPA public manifest.");

--- a/packages/bundler-webpack/tests/adapter.test.ts
+++ b/packages/bundler-webpack/tests/adapter.test.ts
@@ -60,6 +60,11 @@ type ServerRuntimeGlobals = typeof globalThis & {
   ) => Promise<Record<string, unknown>>;
 };
 
+const frameworkRuntimeByOutput = new WeakMap<
+  BuildOutput,
+  FrameworkRuntimeOutput
+>();
+
 function devIt(name: string, run: () => void | Promise<void>) {
   it(name, run, WEBPACK_DEV_TEST_TIMEOUT);
 }
@@ -189,6 +194,7 @@ async function emitFrameworkArtifacts(options: {
   const frameworkRuntime = createFrameworkRuntime(output, {
     rscManifests: options.facts.rscManifests,
   });
+  frameworkRuntimeByOutput.set(output, frameworkRuntime);
   await options.onBuildOutput?.(output);
 
   const rootDir = path.join(options.cwd, options.plan.distDir);
@@ -199,11 +205,6 @@ async function emitFrameworkArtifacts(options: {
   await fs.writeFile(
     path.join(serverDir, "manifest.json"),
     JSON.stringify(createServerManifest(output), null, 2),
-    "utf-8",
-  );
-  await fs.writeFile(
-    path.join(serverDir, "framework-runtime.json"),
-    JSON.stringify(frameworkRuntime, null, 2),
     "utf-8",
   );
   await fs.writeFile(
@@ -798,12 +799,8 @@ describe("webpackAdapter build", () => {
       const deploymentMetadata = JSON.parse(
         await fs.readFile(path.join(cwd, "dist/build-output.json"), "utf-8"),
       );
-      const frameworkRuntime = JSON.parse(
-        await fs.readFile(
-          path.join(cwd, "dist/server/framework-runtime.json"),
-          "utf-8",
-        ),
-      ) as FrameworkRuntimeOutput;
+      const frameworkRuntime = frameworkRuntimeByOutput.get(output);
+      expect(frameworkRuntime).toBeDefined();
       const clientReferenceManifest = JSON.parse(
         await fs.readFile(
           path.join(cwd, "dist/client/react-client-manifest.json"),
@@ -822,7 +819,7 @@ describe("webpackAdapter build", () => {
         ]),
       );
       expect("rsc" in deploymentMetadata).toBe(false);
-      expect(frameworkRuntime.rsc?.clientReferenceManifest).toEqual(
+      expect(frameworkRuntime?.rsc?.clientReferenceManifest).toEqual(
         clientReferenceManifest,
       );
       expect(Object.keys(clientReferenceManifest)).toEqual(
@@ -1540,10 +1537,8 @@ async function requestServerEntry(
     manifest.server?.entry ?? "",
   );
   const serverDir = path.dirname(serverEntryPath);
-  const frameworkRuntimePath = path.join(serverDir, "framework-runtime.json");
-  const frameworkRuntime = JSON.parse(
-    await fs.readFile(frameworkRuntimePath, "utf-8"),
-  ) as FrameworkRuntimeOutput;
+  const frameworkRuntime =
+    frameworkRuntimeByOutput.get(manifest) ?? createFrameworkRuntime(manifest);
   const runtimeGlobals = globalThis as ServerRuntimeGlobals;
   runtimeGlobals.__EVJS_FRAMEWORK_RUNTIME__ = frameworkRuntime;
   runtimeGlobals.__EVJS_SERVER_MODULE_LOADER__ = async (asset: string) => {

--- a/packages/bundler-webpack/tests/adapter.test.ts
+++ b/packages/bundler-webpack/tests/adapter.test.ts
@@ -182,6 +182,8 @@ async function emitFrameworkArtifacts(options: {
     serverEntry: options.facts.serverEntry,
     serverAssets: options.facts.serverAssets,
     serverModules: options.facts.serverModules,
+  });
+  const frameworkRuntime = createFrameworkRuntime(output, {
     rscManifests: options.facts.rscManifests,
   });
   await options.onBuildOutput?.(output);
@@ -194,6 +196,11 @@ async function emitFrameworkArtifacts(options: {
   await fs.writeFile(
     path.join(serverDir, "manifest.json"),
     JSON.stringify(createServerManifest(output), null, 2),
+    "utf-8",
+  );
+  await fs.writeFile(
+    path.join(serverDir, "runtime.json"),
+    JSON.stringify(frameworkRuntime, null, 2),
     "utf-8",
   );
   await fs.writeFile(
@@ -566,7 +573,6 @@ describe("webpackAdapter build", () => {
           js: ["main.js"],
           css: [],
         },
-        entry: "./src/main.ts",
         mount: "#app",
         document: {
           fileName: "index.html",
@@ -581,7 +587,6 @@ describe("webpackAdapter build", () => {
           js: [],
           css: [],
         },
-        component: "./src/pages/Dashboard !page 中文.ts",
         hydrate: "load",
         render: "ssr",
         routeId: "dashboard",
@@ -591,7 +596,6 @@ describe("webpackAdapter build", () => {
         path: "/dashboard",
         appId: "default",
         pageId: "dashboard",
-        module: "./src/pages/Dashboard !page 中文.ts",
       });
       expect(manifest.assets["dashboard-server"]).toEqual({
         js: ["dashboard-server.cjs"],
@@ -599,12 +603,12 @@ describe("webpackAdapter build", () => {
       });
       expect(manifest.server?.entry).toBe("server.cjs");
       expect(manifest.assets.plugin).toEqual({ js: ["plugin.js"], css: [] });
-      expect(publicManifest.apps.default.entry).toBeUndefined();
+      expect("entry" in publicManifest.apps.default).toBe(false);
       expect(publicManifest.apps.default.module).toEqual({
         type: "entry",
         href: "main.js",
       });
-      expect(publicManifest.pages.dashboard.component).toBeUndefined();
+      expect("component" in publicManifest.pages.dashboard).toBe(false);
       await expect(
         fs.access(path.join(cwd, "dist/manifest.json")),
       ).rejects.toThrow();
@@ -750,15 +754,12 @@ describe("webpackAdapter build", () => {
       const manifest = JSON.parse(
         await fs.readFile(path.join(cwd, "dist/build-output.json"), "utf-8"),
       ) as BuildOutput;
+      const frameworkRuntime = JSON.parse(
+        await fs.readFile(path.join(cwd, "dist/server/runtime.json"), "utf-8"),
+      ) as FrameworkRuntimeOutput;
       const clientReferenceManifest = JSON.parse(
         await fs.readFile(
           path.join(cwd, "dist/client/react-client-manifest.json"),
-          "utf-8",
-        ),
-      );
-      const serverConsumerManifest = JSON.parse(
-        await fs.readFile(
-          path.join(cwd, "dist/client/react-ssr-manifest.json"),
           "utf-8",
         ),
       );
@@ -773,11 +774,10 @@ describe("webpackAdapter build", () => {
           "insights-rsc",
         ]),
       );
-      expect(manifest.rsc?.clientReferenceManifest).toEqual(
+      expect("clientReferenceManifest" in (manifest.rsc ?? {})).toBe(false);
+      expect("serverConsumerManifest" in (manifest.rsc ?? {})).toBe(false);
+      expect(frameworkRuntime.rsc?.clientReferenceManifest).toEqual(
         clientReferenceManifest,
-      );
-      expect(manifest.rsc?.serverConsumerManifest).toEqual(
-        serverConsumerManifest,
       );
       expect(Object.keys(clientReferenceManifest)).toEqual(
         expect.arrayContaining([badgeFileUrl]),
@@ -785,7 +785,6 @@ describe("webpackAdapter build", () => {
       expect(manifest.rsc?.pages?.insights).toEqual(
         expect.objectContaining({
           renderer: "insights-rsc",
-          component: "./src/pages/Insights !page.tsx",
         }),
       );
       expect(manifest.server?.renderers?.["insights-server"]).toMatchObject({
@@ -909,7 +908,6 @@ describe("webpackAdapter build", () => {
           [campaignRegionId]: {
             id: campaignRegionId,
             assets: { js: [campaignRegionAsset], css: [] },
-            component: "./src/pages/Offer.tsx",
             cache: "no-store",
           },
         },
@@ -917,7 +915,6 @@ describe("webpackAdapter build", () => {
       expect(manifest.server?.renderers?.["campaign-ppr-shell"]).toMatchObject({
         kind: "ppr-shell",
         owner: { pageId: "campaign" },
-        module: "./src/pages/Campaign.tsx",
         assets: { js: ["campaign-ppr-shell.cjs"], css: [] },
       });
       expect(
@@ -925,7 +922,6 @@ describe("webpackAdapter build", () => {
       ).toMatchObject({
         kind: "ppr-region",
         owner: { pageId: "campaign", regionId: campaignRegionId },
-        module: "./src/pages/Offer.tsx",
         assets: { js: [campaignRegionAsset], css: [] },
       });
 
@@ -1492,8 +1488,12 @@ async function requestServerEntry(
     manifest.server?.entry ?? "",
   );
   const serverDir = path.dirname(serverEntryPath);
+  const frameworkRuntimePath = path.join(serverDir, "runtime.json");
+  const frameworkRuntime = JSON.parse(
+    await fs.readFile(frameworkRuntimePath, "utf-8"),
+  ) as FrameworkRuntimeOutput;
   const runtimeGlobals = globalThis as ServerRuntimeGlobals;
-  runtimeGlobals.__EVJS_FRAMEWORK_RUNTIME__ = createFrameworkRuntime(manifest);
+  runtimeGlobals.__EVJS_FRAMEWORK_RUNTIME__ = frameworkRuntime;
   runtimeGlobals.__EVJS_SERVER_MODULE_LOADER__ = async (asset: string) => {
     const mod = await import(
       pathToFileURL(path.resolve(serverDir, asset)).href

--- a/packages/bundler-webpack/tests/adapter.test.ts
+++ b/packages/bundler-webpack/tests/adapter.test.ts
@@ -632,9 +632,10 @@ describe("webpackAdapter build", () => {
         routeId: "dashboard",
       });
       expect(deploymentMetadata.routes).toContainEqual({
-        kind: "page-server",
+        kind: "server-page",
         path: "/dashboard",
         pageId: "dashboard",
+        render: "ssr",
         methods: ["GET", "HEAD"],
       });
       expect(output.assets["dashboard-server"]).toEqual({

--- a/packages/bundler-webpack/tests/adapter.test.ts
+++ b/packages/bundler-webpack/tests/adapter.test.ts
@@ -13,6 +13,7 @@ import type {
 } from "@evjs/ev";
 import {
   buildHtml,
+  createDeploymentMetadata,
   createPublicManifest,
   createServerManifest,
   linkBuildOutput,
@@ -49,6 +50,7 @@ const WEBPACK_DEV_TEST_NAMES = {
   pageAddition:
     "applies page additions through updatePlan without restarting ev dev",
 } as const;
+const CLIENT_RUNTIME_SCRIPT_ID = "__EVJS_CLIENT_RUNTIME__";
 const allocatedDevPorts = new Set<number>();
 
 type ServerRuntimeGlobals = typeof globalThis & {
@@ -200,13 +202,13 @@ async function emitFrameworkArtifacts(options: {
     "utf-8",
   );
   await fs.writeFile(
-    path.join(serverDir, "runtime.json"),
+    path.join(serverDir, "framework-runtime.json"),
     JSON.stringify(frameworkRuntime, null, 2),
     "utf-8",
   );
   await fs.writeFile(
     path.join(rootDir, "build-output.json"),
-    JSON.stringify(output, null, 2),
+    JSON.stringify(createDeploymentMetadata(output), null, 2),
     "utf-8",
   );
   await fs.mkdir(clientDir, { recursive: true });
@@ -215,12 +217,6 @@ async function emitFrameworkArtifacts(options: {
     JSON.stringify(createPublicManifest(output), null, 2),
     "utf-8",
   );
-  await fs.writeFile(
-    path.join(clientDir, "runtime.json"),
-    JSON.stringify(createClientRuntime(output), null, 2),
-    "utf-8",
-  );
-
   for (const html of options.plan.html) {
     const pageId = html.owner.pageId;
     const appId = html.owner.appId;
@@ -244,6 +240,7 @@ async function emitFrameworkArtifacts(options: {
       doc.documentElement?.setAttribute("data-evjs-kind", "app");
       doc.documentElement?.setAttribute("data-evjs-id", appId);
     }
+    embedClientRuntime(doc, output);
 
     const finalHtml = await buildHtml({
       doc,
@@ -283,6 +280,28 @@ async function emitFrameworkArtifacts(options: {
   }
 
   return output;
+}
+
+function embedClientRuntime(
+  doc: ReturnType<typeof generateHtml>,
+  output: BuildOutput,
+): void {
+  const body = doc.body ?? doc.querySelector("body");
+  if (!body) return;
+  const json = JSON.stringify(createClientRuntime(output)).replace(
+    /</g,
+    "\\u003c",
+  );
+  const script = doc.createElement("script");
+  script.id = CLIENT_RUNTIME_SCRIPT_ID;
+  script.setAttribute("type", "application/json");
+  script.textContent = json;
+  const firstScript = body.querySelector("script[src]");
+  if (firstScript) {
+    body.insertBefore(script, firstScript);
+    return;
+  }
+  body.appendChild(script);
 }
 
 describe("webpack stats ownership", () => {
@@ -459,7 +478,7 @@ describe("webpackAdapter build", () => {
         mode: "development",
       });
 
-      await buildWithFrameworkArtifacts({
+      const output = await buildWithFrameworkArtifacts({
         config,
         cwd,
         graph: analysis.graph,
@@ -485,7 +504,10 @@ describe("webpackAdapter build", () => {
       }
       expect(manifest.routing.pages.home).toMatchObject({
         assets: { js: ["home.js"], css: [] },
-        mount: "#root",
+      });
+      expect("render" in manifest.routing.pages.home).toBe(false);
+      expect("module" in manifest.routing.pages.home).toBe(false);
+      expect(output.pages.home).toMatchObject({
         render: "csr",
         module: {
           type: "react-component",
@@ -495,6 +517,17 @@ describe("webpackAdapter build", () => {
       expect(html).toContain('data-evjs-kind="page"');
       expect(html).toContain('data-evjs-id="home"');
       expect(html).toContain('src="/home.js"');
+      expect(readEmbeddedClientRuntime(html)).toMatchObject({
+        routing: {
+          kind: "mpa",
+          pages: {
+            home: {
+              module: { type: "react-component", href: "home.js" },
+              mount: "#root",
+            },
+          },
+        },
+      });
       expect(bundle).toContain("registerShellModule");
       expect(bundle).toContain("data-evjs-shell-load");
       await expect(fs.access(path.join(cwd, ".evjs"))).rejects.toThrow();
@@ -543,7 +576,7 @@ describe("webpackAdapter build", () => {
         output.assets.plugin = { js: ["plugin.js"], css: [] };
       });
 
-      await buildWithFrameworkArtifacts({
+      const output = await buildWithFrameworkArtifacts({
         config,
         cwd,
         graph: analysis.graph,
@@ -561,9 +594,9 @@ describe("webpackAdapter build", () => {
         onBuildOutput,
       });
 
-      const manifest = JSON.parse(
+      const deploymentMetadata = JSON.parse(
         await fs.readFile(path.join(cwd, "dist/build-output.json"), "utf-8"),
-      ) as BuildOutput;
+      );
       const publicManifest = JSON.parse(
         await fs.readFile(path.join(cwd, "dist/client/manifest.json"), "utf-8"),
       ) as PublicManifestOutput;
@@ -573,7 +606,7 @@ describe("webpackAdapter build", () => {
       );
 
       expect(onBuildOutput).toHaveBeenCalledTimes(1);
-      expect(manifest.apps.default).toEqual({
+      expect(output.apps.default).toEqual({
         assets: {
           js: ["main.js"],
           css: [],
@@ -587,7 +620,7 @@ describe("webpackAdapter build", () => {
           href: "main.js",
         },
       });
-      expect(manifest.pages.dashboard).toMatchObject({
+      expect(output.pages.dashboard).toMatchObject({
         assets: {
           js: [],
           css: [],
@@ -596,28 +629,31 @@ describe("webpackAdapter build", () => {
         render: "ssr",
         routeId: "dashboard",
       });
-      expect(manifest.routes).toContainEqual({
-        id: "dashboard",
+      expect(deploymentMetadata.routes).toContainEqual({
+        kind: "page-server",
         path: "/dashboard",
-        appId: "default",
         pageId: "dashboard",
+        methods: ["GET", "HEAD"],
       });
-      expect(manifest.assets["dashboard-server"]).toEqual({
+      expect(output.assets["dashboard-server"]).toEqual({
         js: ["dashboard-server.cjs"],
         css: [],
       });
-      expect(manifest.server?.entry).toBe("server.cjs");
-      expect(manifest.assets.plugin).toEqual({ js: ["plugin.js"], css: [] });
-      expect(publicManifest.app).not.toHaveProperty("entry");
-      expect(publicManifest.app?.module).toEqual({
-        type: "entry",
-        href: "main.js",
-      });
+      expect(deploymentMetadata.server?.entry).toBe("server.cjs");
+      expect(output.assets.plugin).toEqual({ js: ["plugin.js"], css: [] });
+      expect("apps" in deploymentMetadata).toBe(false);
+      expect("pages" in deploymentMetadata).toBe(false);
+      expect("app" in publicManifest).toBe(false);
       expect(publicManifest.routing.kind).toBe("mpa");
       if (publicManifest.routing.kind !== "mpa") {
         throw new Error("Expected MPA public manifest.");
       }
+      expect(publicManifest.routing.pages.dashboard.assets).toEqual({
+        js: [],
+        css: [],
+      });
       expect("component" in publicManifest.routing.pages.dashboard).toBe(false);
+      expect("module" in publicManifest.routing.pages.dashboard).toBe(false);
       await expect(
         fs.access(path.join(cwd, "dist/manifest.json")),
       ).rejects.toThrow();
@@ -625,7 +661,7 @@ describe("webpackAdapter build", () => {
       expect(html).toContain('data-evjs-kind="app"');
       expect(html).toContain('data-evjs-id="default"');
       expect(html).toContain('<meta name="html-kind" content="app">');
-      const response = await requestServerEntry(cwd, manifest, "/dashboard");
+      const response = await requestServerEntry(cwd, output, "/dashboard");
       expect(response.status).toBe(200);
       expect(await response.text()).toContain('<div id="app">dashboard</div>');
       await expect(
@@ -678,7 +714,7 @@ describe("webpackAdapter build", () => {
         mode: "development",
       });
 
-      await buildWithFrameworkArtifacts({
+      const output = await buildWithFrameworkArtifacts({
         config,
         cwd,
         graph: analysis.graph,
@@ -686,10 +722,7 @@ describe("webpackAdapter build", () => {
         hooks: [],
       });
 
-      const manifest = JSON.parse(
-        await fs.readFile(path.join(cwd, "dist/build-output.json"), "utf-8"),
-      ) as BuildOutput;
-      const response = await requestServerEntry(cwd, manifest, "/dashboard");
+      const response = await requestServerEntry(cwd, output, "/dashboard");
 
       expect(response.status).toBe(200);
       const text = await response.text();
@@ -752,7 +785,7 @@ describe("webpackAdapter build", () => {
         mode: "development",
       });
 
-      await buildWithFrameworkArtifacts({
+      const output = await buildWithFrameworkArtifacts({
         config,
         cwd,
         graph: analysis.graph,
@@ -760,11 +793,14 @@ describe("webpackAdapter build", () => {
         hooks: [],
       });
 
-      const manifest = JSON.parse(
+      const deploymentMetadata = JSON.parse(
         await fs.readFile(path.join(cwd, "dist/build-output.json"), "utf-8"),
-      ) as BuildOutput;
+      );
       const frameworkRuntime = JSON.parse(
-        await fs.readFile(path.join(cwd, "dist/server/runtime.json"), "utf-8"),
+        await fs.readFile(
+          path.join(cwd, "dist/server/framework-runtime.json"),
+          "utf-8",
+        ),
       ) as FrameworkRuntimeOutput;
       const clientReferenceManifest = JSON.parse(
         await fs.readFile(
@@ -783,28 +819,27 @@ describe("webpackAdapter build", () => {
           "insights-rsc",
         ]),
       );
-      expect("clientReferenceManifest" in (manifest.rsc ?? {})).toBe(false);
-      expect("serverConsumerManifest" in (manifest.rsc ?? {})).toBe(false);
+      expect("rsc" in deploymentMetadata).toBe(false);
       expect(frameworkRuntime.rsc?.clientReferenceManifest).toEqual(
         clientReferenceManifest,
       );
       expect(Object.keys(clientReferenceManifest)).toEqual(
         expect.arrayContaining([badgeFileUrl]),
       );
-      expect(manifest.rsc?.pages?.insights).toEqual(
+      expect(output.rsc?.pages?.insights).toEqual(
         expect.objectContaining({
           renderer: "insights-rsc",
         }),
       );
-      expect(manifest.server?.renderers?.["insights-server"]).toMatchObject({
+      expect(output.server?.renderers?.["insights-server"]).toMatchObject({
         kind: "page-server",
         assets: { js: ["insights-server.cjs"], css: ["insights-server.css"] },
       });
-      expect(manifest.server?.renderers?.["insights-rsc"]).toMatchObject({
+      expect(output.server?.renderers?.["insights-rsc"]).toMatchObject({
         kind: "rsc-page",
         assets: { js: ["insights-rsc.cjs"], css: ["insights-rsc.css"] },
       });
-      expect(manifest.pages.insights.assets).toEqual({
+      expect(output.pages.insights.assets).toEqual({
         js: ["evjs-rsc-client.js"],
         css: expect.arrayContaining([
           "insights-server.css",
@@ -817,7 +852,7 @@ describe("webpackAdapter build", () => {
 
       const htmlResponse = await requestServerEntry(
         cwd,
-        manifest,
+        output,
         "/insights/weekly?tab=overview&tag=a&tag=b",
       );
       expect(htmlResponse.status).toBe(200);
@@ -831,7 +866,7 @@ describe("webpackAdapter build", () => {
 
       const flightResponse = await requestServerEntry(
         cwd,
-        manifest,
+        output,
         "/__evjs/rsc?page=insights&url=%2Finsights%2Fweekly%3Ftab%3Doverview%26tag%3Da%26tag%3Db",
       );
       expect(flightResponse.status).toBe(200);
@@ -893,7 +928,7 @@ describe("webpackAdapter build", () => {
         mode: "development",
       });
 
-      await buildWithFrameworkArtifacts({
+      const output = await buildWithFrameworkArtifacts({
         config,
         cwd,
         graph: analysis.graph,
@@ -901,16 +936,13 @@ describe("webpackAdapter build", () => {
         hooks: [],
       });
 
-      const manifest = JSON.parse(
-        await fs.readFile(path.join(cwd, "dist/build-output.json"), "utf-8"),
-      ) as BuildOutput;
       const campaignRegionId = getSinglePprRegionId(
-        manifest.pages.campaign.ppr?.regions,
+        output.pages.campaign.ppr?.regions,
       );
       const campaignRegionRenderer = `campaign-${campaignRegionId}-ppr-region`;
       const campaignRegionAsset = `${campaignRegionRenderer}.cjs`;
 
-      expect(manifest.pages.campaign.ppr).toMatchObject({
+      expect(output.pages.campaign.ppr).toMatchObject({
         delivery: "merge",
         shell: { js: ["campaign-ppr-shell.cjs"], css: [] },
         regions: {
@@ -921,24 +953,18 @@ describe("webpackAdapter build", () => {
           },
         },
       });
-      expect(manifest.server?.renderers?.["campaign-ppr-shell"]).toMatchObject({
+      expect(output.server?.renderers?.["campaign-ppr-shell"]).toMatchObject({
         kind: "ppr-shell",
         owner: { pageId: "campaign" },
         assets: { js: ["campaign-ppr-shell.cjs"], css: [] },
       });
-      expect(
-        manifest.server?.renderers?.[campaignRegionRenderer],
-      ).toMatchObject({
+      expect(output.server?.renderers?.[campaignRegionRenderer]).toMatchObject({
         kind: "ppr-region",
         owner: { pageId: "campaign", regionId: campaignRegionId },
         assets: { js: [campaignRegionAsset], css: [] },
       });
 
-      const shellResponse = await requestServerEntry(
-        cwd,
-        manifest,
-        "/campaign",
-      );
+      const shellResponse = await requestServerEntry(cwd, output, "/campaign");
       expect(shellResponse.status).toBe(200);
       expect(await shellResponse.text()).toContain(
         "<main>Campaign <!-- -->campaign<section>Offer region</section></main>",
@@ -946,7 +972,7 @@ describe("webpackAdapter build", () => {
 
       const regionResponse = await requestServerEntry(
         cwd,
-        manifest,
+        output,
         `/__evjs/ppr/campaign/${campaignRegionId}`,
       );
       expect(regionResponse.status).toBe(200);
@@ -1007,14 +1033,6 @@ describe("webpackAdapter dev", () => {
       const manifest = JSON.parse(
         await fs.readFile(path.join(cwd, "dist/manifest.json"), "utf-8"),
       ) as PublicManifestOutput;
-      const runtime = JSON.parse(
-        await fs.readFile(path.join(cwd, "dist/runtime.json"), "utf-8"),
-      ) as {
-        routing: {
-          kind: "mpa";
-          pages: Record<string, Record<string, unknown>>;
-        };
-      };
       const html = await fetchDevText(`http://127.0.0.1:${port}/home.html`);
 
       expect(onBuildOutput).toHaveBeenCalledTimes(1);
@@ -1024,14 +1042,12 @@ describe("webpackAdapter dev", () => {
         throw new Error("Expected MPA public manifest.");
       }
       expect(manifest.routing.pages.home.assets.js).toEqual(["home.js"]);
-      expect(runtime.routing.pages.home).not.toHaveProperty("assets");
-      expect(runtime.routing.pages.home).toMatchObject({
-        module: { type: "react-component", href: "home.js" },
-        mount: "#root",
-      });
       expect(html).toContain('data-evjs-kind="page"');
       expect(html).toContain('data-evjs-id="home"');
       expect(html).toContain('src="/home.js"');
+      await expect(
+        fs.access(path.join(cwd, "dist/runtime.json")),
+      ).rejects.toThrow();
     } finally {
       await controller?.close?.();
     }
@@ -1499,6 +1515,16 @@ async function fetchDevText(url: string): Promise<string> {
   return response.text;
 }
 
+function readEmbeddedClientRuntime(html: string): unknown {
+  const match = html.match(
+    /<script\b(?=[^>]*\bid="__EVJS_CLIENT_RUNTIME__")(?=[^>]*\btype="application\/json")[^>]*>([\s\S]*?)<\/script>/,
+  );
+  if (!match) {
+    throw new Error("Expected embedded client runtime script.");
+  }
+  return JSON.parse(match[1]);
+}
+
 async function requestServerEntry(
   cwd: string,
   manifest: BuildOutput,
@@ -1510,7 +1536,7 @@ async function requestServerEntry(
     manifest.server?.entry ?? "",
   );
   const serverDir = path.dirname(serverEntryPath);
-  const frameworkRuntimePath = path.join(serverDir, "runtime.json");
+  const frameworkRuntimePath = path.join(serverDir, "framework-runtime.json");
   const frameworkRuntime = JSON.parse(
     await fs.readFile(frameworkRuntimePath, "utf-8"),
   ) as FrameworkRuntimeOutput;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -39,9 +39,10 @@ Uses the default bundler adapter directly (no temp config files):
 Runs the production build through `@evjs/ev` with `NODE_ENV=production`:
 - `dist/client/` — optimized client assets with content hashes.
 - `dist/server/main.[hash].js` — server bundle.
-- `dist/client/manifest.json` — browser-safe public manifest.
-- `dist/server/manifest.json` — derived server bundle metadata.
-- `dist/build-output.json` — private complete BuildOutput handoff for tooling and debugging.
+- `dist/client/manifest.json` — lightweight client deployment metadata.
+- `dist/server/manifest.json` — entry-only server manifest.
+- `dist/server/framework-runtime.json` — runtime-required framework data for raw server bundles.
+- `dist/build-output.json` — canonical deployment metadata for tooling and adapters.
 
 ### `ev inspect`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,7 +40,7 @@ Runs the production build through `@evjs/ev` with `NODE_ENV=production`:
 - `dist/client/` — optimized client assets with content hashes.
 - `dist/server/main.[hash].js` — server bundle.
 - `dist/client/manifest.json` — lightweight client deployment metadata.
-- `dist/server/manifest.json` — entry-only server manifest.
+- `dist/server/manifest.json` — lightweight server entry and route metadata.
 - `dist/server/framework-runtime.json` — runtime-required framework data for raw server bundles.
 - `dist/build-output.json` — canonical deployment metadata for tooling and adapters.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -41,7 +41,6 @@ Runs the production build through `@evjs/ev` with `NODE_ENV=production`:
 - `dist/server/main.[hash].js` — server bundle.
 - `dist/client/manifest.json` — lightweight client deployment metadata.
 - `dist/server/manifest.json` — lightweight server entry and route metadata.
-- `dist/server/framework-runtime.json` — runtime-required framework data for raw server bundles.
 - `dist/build-output.json` — canonical deployment metadata for tooling and adapters.
 
 ### `ev inspect`

--- a/packages/cli/tests/plugin-hooks.test.ts
+++ b/packages/cli/tests/plugin-hooks.test.ts
@@ -105,14 +105,11 @@ function createTestBuildResult(
     serverManifest: {
       version: 1 as const,
       ...(output.server.entry ? { entry: output.server.entry } : {}),
-      assets: output.server.assets,
-      functions: Object.fromEntries(
-        Object.entries(output.server.functions).map(([id, fn]) => [
-          id,
-          { assets: fn.assets },
-        ]),
-      ),
-      routes: output.server.routes,
+      functions: Object.keys(output.server.functions),
+      routes: output.server.routes.map((route) => ({
+        path: route.path,
+        methods: route.methods,
+      })),
     },
     isRebuild,
   };

--- a/packages/cli/tests/plugin-hooks.test.ts
+++ b/packages/cli/tests/plugin-hooks.test.ts
@@ -6,7 +6,11 @@ import type {
   PluginContext,
   PluginHooks,
 } from "@evjs/ev";
-import { resolveConfig } from "@evjs/ev";
+import {
+  createDeploymentMetadata,
+  createPublicManifest,
+  resolveConfig,
+} from "@evjs/ev";
 import { getLogger } from "@logtape/logtape";
 import { describe, expect, it } from "vitest";
 
@@ -98,20 +102,12 @@ function createTestBuildResult(
 ): BuildResult {
   return {
     output,
-    clientManifest: {
-      version: 1,
-      kind: "spa",
-      assets: output.apps.default?.assets ?? { js: [], css: [] },
-    },
+    clientManifest: createPublicManifest(output),
     serverManifest: {
       version: 1 as const,
       ...(output.server.entry ? { entry: output.server.entry } : {}),
-      functions: Object.keys(output.server.functions),
-      routes: output.server.routes.map((route) => ({
-        path: route.path,
-        methods: route.methods,
-      })),
     },
+    deploymentMetadata: createDeploymentMetadata(output),
     isRebuild,
   };
 }

--- a/packages/cli/tests/plugin-hooks.test.ts
+++ b/packages/cli/tests/plugin-hooks.test.ts
@@ -100,6 +100,7 @@ function createTestBuildResult(
     output,
     clientManifest: {
       version: 1,
+      kind: "spa",
       assets: output.apps.default?.assets ?? { js: [], css: [] },
     },
     serverManifest: {

--- a/packages/cli/tests/plugin-hooks.test.ts
+++ b/packages/cli/tests/plugin-hooks.test.ts
@@ -62,7 +62,11 @@ const CTX: PluginContext = {
 const TEST_OUTPUT: BuildOutput = {
   version: 1,
   buildId: "test",
-  distDir: "dist",
+  paths: {
+    rootDir: "dist",
+    publicDir: "dist/client",
+    serverDir: "dist/server",
+  },
   publicPath: "/",
   runtime: {
     server: {
@@ -76,7 +80,6 @@ const TEST_OUTPUT: BuildOutput = {
   apps: {
     default: {
       assets: { js: ["main.js"], css: [] },
-      entry: "./src/main.tsx",
     },
   },
   pages: {},

--- a/packages/cli/tests/plugin-hooks.test.ts
+++ b/packages/cli/tests/plugin-hooks.test.ts
@@ -9,6 +9,7 @@ import type {
 import {
   createDeploymentMetadata,
   createPublicManifest,
+  createServerManifest,
   resolveConfig,
 } from "@evjs/ev";
 import { getLogger } from "@logtape/logtape";
@@ -103,10 +104,7 @@ function createTestBuildResult(
   return {
     output,
     clientManifest: createPublicManifest(output),
-    serverManifest: {
-      version: 1 as const,
-      ...(output.server.entry ? { entry: output.server.entry } : {}),
-    },
+    serverManifest: createServerManifest(output),
     deploymentMetadata: createDeploymentMetadata(output),
     isRebuild,
   };

--- a/packages/client/src/page.ts
+++ b/packages/client/src/page.ts
@@ -166,14 +166,8 @@ function assertLoadedRuntime(
   if (!isRecord(runtime.runtime)) {
     throw new Error(`[evjs] Loaded ${source} runtime must be an object.`);
   }
-  if (!isRecord(runtime.pages)) {
-    throw new Error(`[evjs] Loaded ${source} pages must be an object.`);
-  }
   if (runtime.app !== undefined && !isRecord(runtime.app)) {
     throw new Error(`[evjs] Loaded ${source} app must be an object.`);
-  }
-  if (!Array.isArray(runtime.routes)) {
-    throw new Error(`[evjs] Loaded ${source} routes must be an array.`);
   }
   assertClientRuntime(runtime, `Loaded ${source}`);
 }

--- a/packages/client/src/page.ts
+++ b/packages/client/src/page.ts
@@ -169,8 +169,8 @@ function assertLoadedRuntime(
   if (!isRecord(runtime.pages)) {
     throw new Error(`[evjs] Loaded ${source} pages must be an object.`);
   }
-  if (!isRecord(runtime.apps)) {
-    throw new Error(`[evjs] Loaded ${source} apps must be an object.`);
+  if (runtime.app !== undefined && !isRecord(runtime.app)) {
+    throw new Error(`[evjs] Loaded ${source} app must be an object.`);
   }
   if (!Array.isArray(runtime.routes)) {
     throw new Error(`[evjs] Loaded ${source} routes must be an array.`);

--- a/packages/client/src/react.ts
+++ b/packages/client/src/react.ts
@@ -27,6 +27,7 @@ import {
 import {
   assertClientRuntime,
   type ClientRuntime,
+  getClientRuntimeRoutes,
   type HydrationMode,
   type RenderMode,
 } from "./runtime-config.js";
@@ -541,7 +542,7 @@ function findRouteForPage(
   pageId: string,
   pathname: string | undefined,
 ): ReactPageRouteContext | undefined {
-  const pageRoutes = runtime.routes.filter(
+  const pageRoutes = getClientRuntimeRoutes(runtime).filter(
     (candidate) => candidate.pageId === pageId,
   );
   const route = pathname

--- a/packages/client/src/rsc-page-context.ts
+++ b/packages/client/src/rsc-page-context.ts
@@ -16,6 +16,22 @@ const storage = new AsyncLocalStorage<PageProps>();
 
 interface RscPageRuntime {
   buildId: string;
+  routing?: {
+    kind: "spa" | "mpa";
+    routes?: Array<{
+      id: string;
+      path: string;
+      pageId?: string;
+    }>;
+    pages?: Record<
+      string,
+      {
+        path?: string;
+        routeId?: string;
+      }
+    >;
+  };
+  /** @deprecated Use routing. */
   routes?: Array<{
     id: string;
     path: string;
@@ -124,7 +140,7 @@ function findRouteForPage(
   pageId: string | undefined,
 ): { id: string; path: string } | undefined {
   if (!pageId) return undefined;
-  const route = runtime.routes?.find(
+  const route = getRuntimeRoutes(runtime).find(
     (candidate) => candidate.pageId === pageId,
   );
   return route
@@ -133,6 +149,21 @@ function findRouteForPage(
         path: route.path,
       }
     : undefined;
+}
+
+function getRuntimeRoutes(
+  runtime: RscPageRuntime,
+): Array<{ id: string; path: string; pageId?: string }> {
+  if (runtime.routing?.kind === "spa") return runtime.routing.routes ?? [];
+  if (runtime.routing?.kind === "mpa") {
+    return Object.entries(runtime.routing.pages ?? {}).flatMap(
+      ([pageId, page]) =>
+        page.path && page.routeId
+          ? [{ id: page.routeId, path: page.path, pageId }]
+          : [],
+    );
+  }
+  return runtime.routes ?? [];
 }
 
 function createRscPageProps(ctx: RscPageFlightRenderContext): PageProps & {

--- a/packages/client/src/rsc.ts
+++ b/packages/client/src/rsc.ts
@@ -478,7 +478,6 @@ function createBootstrapRuntime(
       },
       transport: {},
     },
-    apps: {},
     pages: {
       [bootstrap.pageId]: {},
     },

--- a/packages/client/src/runtime-config.ts
+++ b/packages/client/src/runtime-config.ts
@@ -24,7 +24,7 @@ export interface ClientRuntime {
       baseUrl?: string;
     };
   };
-  apps: Record<string, ClientRuntimeApp>;
+  app?: ClientRuntimeApp;
   pages: Record<string, ClientRuntimePage>;
   routes: ClientRuntimeRoute[];
 }
@@ -52,7 +52,6 @@ export interface ClientRuntimePage {
 export interface ClientRuntimeRoute {
   id: string;
   path: string;
-  appId?: string;
   pageId?: string;
 }
 
@@ -80,27 +79,24 @@ export function assertClientRuntime(
       `${source}.runtime.transport.baseUrl`,
     );
   }
-  assertObject(value.apps, `${source}.apps`);
-  assertApps(value.apps, `${source}.apps`);
+  if (value.app !== undefined) {
+    assertApp(value.app, `${source}.app`);
+  }
   assertObject(value.pages, `${source}.pages`);
   assertPages(value.pages, `${source}.pages`);
   if (!Array.isArray(value.routes)) {
     throw new Error(`[evjs] ${source}.routes must be an array.`);
   }
-  assertRoutes(value.routes, `${source}.routes`, value.pages, value.apps);
+  assertRoutes(value.routes, `${source}.routes`, value.pages);
 }
 
-function assertApps(value: Record<string, unknown>, source: string): void {
-  for (const [name, app] of Object.entries(value)) {
-    assertBuildIdentifierKey(name, source);
-    const appSource = `${source}.${name}`;
-    assertObject(app, appSource);
-    if (app.module !== undefined) {
-      assertRuntimeModule(app.module, `${appSource}.module`);
-    }
-    if (app.mount !== undefined) {
-      assertRuntimeString(app.mount, `${appSource}.mount`);
-    }
+function assertApp(value: unknown, source: string): void {
+  assertObject(value, source);
+  if (value.module !== undefined) {
+    assertRuntimeModule(value.module, `${source}.module`);
+  }
+  if (value.mount !== undefined) {
+    assertRuntimeString(value.mount, `${source}.mount`);
   }
 }
 
@@ -138,7 +134,6 @@ function assertRoutes(
   value: unknown[],
   source: string,
   pages: Record<string, unknown>,
-  apps: Record<string, unknown>,
 ): void {
   const idOwners = new Map<string, string>();
   const pathOwners = new Map<string, { path: string; source: string }>();
@@ -158,12 +153,6 @@ function assertRoutes(
       `${routeSource}.pageId`,
       `${source.replace(/\.routes$/, "")}.pages`,
       pages,
-    );
-    assertOptionalRecordReference(
-      route.appId,
-      `${routeSource}.appId`,
-      `${source.replace(/\.routes$/, "")}.apps`,
-      apps,
     );
   });
 }

--- a/packages/client/src/runtime-config.ts
+++ b/packages/client/src/runtime-config.ts
@@ -25,8 +25,11 @@ export interface ClientRuntime {
     };
   };
   app?: ClientRuntimeApp;
-  pages: Record<string, ClientRuntimePage>;
-  routes: ClientRuntimeRoute[];
+  routing?: ClientRuntimeRouting;
+  /** @deprecated Use routing.kind === "mpa".pages. */
+  pages?: Record<string, ClientRuntimePage>;
+  /** @deprecated Use routing.kind === "spa".routes or page route metadata. */
+  routes?: ClientRuntimeRoute[];
 }
 
 export interface ClientAssetGroup {
@@ -47,6 +50,8 @@ export interface ClientRuntimeApp {
 export interface ClientRuntimePage {
   mount?: string;
   module?: ClientRuntimeModule;
+  path?: string;
+  routeId?: string;
 }
 
 export interface ClientRuntimeRoute {
@@ -54,6 +59,16 @@ export interface ClientRuntimeRoute {
   path: string;
   pageId?: string;
 }
+
+export type ClientRuntimeRouting =
+  | {
+      kind: "spa";
+      routes: ClientRuntimeRoute[];
+    }
+  | {
+      kind: "mpa";
+      pages: Record<string, ClientRuntimePage>;
+    };
 
 export function assertClientRuntime(
   value: unknown,
@@ -82,6 +97,57 @@ export function assertClientRuntime(
   if (value.app !== undefined) {
     assertApp(value.app, `${source}.app`);
   }
+  assertRuntimeRouting(value, source);
+}
+
+export function getClientRuntimePages(
+  runtime: ClientRuntime,
+): Record<string, ClientRuntimePage> {
+  if (runtime.routing?.kind === "mpa") return runtime.routing.pages;
+  return runtime.pages ?? {};
+}
+
+export function getClientRuntimeRoutes(
+  runtime: ClientRuntime,
+): ClientRuntimeRoute[] {
+  if (runtime.routing?.kind === "spa") return runtime.routing.routes;
+  if (runtime.routing?.kind === "mpa") {
+    return createRoutesFromPages(runtime.routing.pages);
+  }
+  return runtime.routes ?? [];
+}
+
+function assertRuntimeRouting(
+  value: Record<string, unknown>,
+  source: string,
+): void {
+  if (value.routing !== undefined) {
+    if (value.pages !== undefined || value.routes !== undefined) {
+      throw new Error(
+        `[evjs] ${source} must not define both routing and pages/routes.`,
+      );
+    }
+    assertObject(value.routing, `${source}.routing`);
+    if (value.routing.kind === "spa") {
+      if (!Array.isArray(value.routing.routes)) {
+        throw new Error(`[evjs] ${source}.routing.routes must be an array.`);
+      }
+      assertRoutes(value.routing.routes, `${source}.routing.routes`, {});
+      return;
+    }
+    if (value.routing.kind === "mpa") {
+      assertObject(value.routing.pages, `${source}.routing.pages`);
+      assertPages(value.routing.pages, `${source}.routing.pages`);
+      assertRoutes(
+        createRoutesFromPages(value.routing.pages),
+        `${source}.routing.pages`,
+        value.routing.pages,
+      );
+      return;
+    }
+    throw new Error(`[evjs] ${source}.routing.kind must be "spa" or "mpa".`);
+  }
+
   assertObject(value.pages, `${source}.pages`);
   assertPages(value.pages, `${source}.pages`);
   if (!Array.isArray(value.routes)) {
@@ -111,7 +177,31 @@ function assertPages(value: Record<string, unknown>, source: string): void {
     if (page.module !== undefined) {
       assertRuntimeModule(page.module, `${pageSource}.module`);
     }
+    if (page.path !== undefined) {
+      assertRuntimePathname(page.path, `${pageSource}.path`, true);
+    }
+    if (page.routeId !== undefined) {
+      assertRuntimeString(page.routeId, `${pageSource}.routeId`);
+    }
   }
+}
+
+function createRoutesFromPages(
+  pages: Record<string, unknown>,
+): ClientRuntimeRoute[] {
+  return Object.entries(pages).flatMap(([pageId, page]) => {
+    if (!isRecord(page)) return [];
+    if (typeof page.path !== "string" || typeof page.routeId !== "string") {
+      return [];
+    }
+    return [
+      {
+        id: page.routeId,
+        path: page.path,
+        pageId,
+      },
+    ];
+  });
 }
 
 function assertRuntimeModule(value: unknown, source: string): void {

--- a/packages/client/src/shell/drivers.ts
+++ b/packages/client/src/shell/drivers.ts
@@ -1,3 +1,4 @@
+import { assertClientRuntime } from "../runtime-config.js";
 import { formatErrorDetail, isRecord } from "../validation.js";
 import { createActivationRequestFromUrl } from "./routing.js";
 import type {
@@ -175,11 +176,7 @@ function assertHistoryDriverRuntime(
   if (!isRecord(runtime)) {
     throw new Error("[evjs] createHistoryDriver() runtime must be an object.");
   }
-  if (!Array.isArray(runtime.routes)) {
-    throw new Error(
-      "[evjs] createHistoryDriver() runtime.routes must be an array.",
-    );
-  }
+  assertClientRuntime(runtime, "createHistoryDriver() runtime");
 }
 
 function assertBrowserWindow(

--- a/packages/client/src/shell/routing.ts
+++ b/packages/client/src/shell/routing.ts
@@ -1,5 +1,8 @@
 import { findBestPageRoute } from "@evjs/shared";
-import type { ClientRuntime } from "../runtime-config.js";
+import {
+  type ClientRuntime,
+  getClientRuntimeRoutes,
+} from "../runtime-config.js";
 import type { ActivationRequest } from "./types.js";
 
 export function createActivationRequestFromUrl(
@@ -8,7 +11,7 @@ export function createActivationRequestFromUrl(
 ): ActivationRequest {
   const href = url.toString();
   const pathname = getPathname(href);
-  const route = findBestPageRoute(runtime.routes, pathname);
+  const route = findBestPageRoute(getClientRuntimeRoutes(runtime), pathname);
 
   return {
     url: href,

--- a/packages/client/src/shell/routing.ts
+++ b/packages/client/src/shell/routing.ts
@@ -12,7 +12,6 @@ export function createActivationRequestFromUrl(
 
   return {
     url: href,
-    appId: route?.appId,
     pageId: route?.pageId,
   };
 }

--- a/packages/client/src/shell/runtime.ts
+++ b/packages/client/src/shell/runtime.ts
@@ -471,8 +471,8 @@ function assertShellRuntime(runtime: unknown): void {
   if (!isRecord(runtime.pages)) {
     throw new Error("[evjs] createShell() runtime.pages must be an object.");
   }
-  if (!isRecord(runtime.apps)) {
-    throw new Error("[evjs] createShell() runtime.apps must be an object.");
+  if (runtime.app !== undefined && !isRecord(runtime.app)) {
+    throw new Error("[evjs] createShell() runtime.app must be an object.");
   }
   if (!Array.isArray(runtime.routes)) {
     throw new Error("[evjs] createShell() runtime.routes must be an array.");

--- a/packages/client/src/shell/runtime.ts
+++ b/packages/client/src/shell/runtime.ts
@@ -468,14 +468,8 @@ function assertShellRuntime(runtime: unknown): void {
   if (!isRecord(runtime.runtime)) {
     throw new Error("[evjs] createShell() runtime.runtime must be an object.");
   }
-  if (!isRecord(runtime.pages)) {
-    throw new Error("[evjs] createShell() runtime.pages must be an object.");
-  }
   if (runtime.app !== undefined && !isRecord(runtime.app)) {
     throw new Error("[evjs] createShell() runtime.app must be an object.");
-  }
-  if (!Array.isArray(runtime.routes)) {
-    throw new Error("[evjs] createShell() runtime.routes must be an array.");
   }
   assertClientRuntime(runtime, "createShell() runtime");
 }

--- a/packages/client/src/shell/targets.ts
+++ b/packages/client/src/shell/targets.ts
@@ -30,22 +30,21 @@ export async function resolveTarget(
     };
   }
 
-  const appId = request.appId ?? Object.keys(runtime.apps)[0];
-  const app = appId ? runtime.apps[appId] : undefined;
-  if (!appId || !app) {
+  const app = runtime.app;
+  if (!app) {
     throw new Error("[evjs] No app target is available in the runtime.");
   }
-  const href = readRuntimeModuleHref(app.module, `App "${appId}"`);
+  const id = request.appId ?? "default";
+  const label = request.appId ? `App "${request.appId}"` : "App";
+  const href = readRuntimeModuleHref(app.module, label);
   if (!href) {
-    throw new Error(
-      `[evjs] App "${appId}" does not expose an importable runtime module.`,
-    );
+    throw new Error(`${label} does not expose an importable runtime module.`);
   }
   return {
-    id: appId,
+    id,
     href,
     ctx: {
-      id: appId,
+      id,
       kind: "app",
       runtime,
       output: app,

--- a/packages/client/src/shell/targets.ts
+++ b/packages/client/src/shell/targets.ts
@@ -1,4 +1,7 @@
-import type { ClientRuntime } from "../runtime-config.js";
+import {
+  type ClientRuntime,
+  getClientRuntimePages,
+} from "../runtime-config.js";
 import { isRecord } from "../validation.js";
 import type { ActivationRequest, ResolvedShellTarget } from "./types.js";
 
@@ -7,7 +10,7 @@ export async function resolveTarget(
   request: ActivationRequest,
 ): Promise<ResolvedShellTarget> {
   if (request.pageId) {
-    const page = runtime.pages[request.pageId];
+    const page = getClientRuntimePages(runtime)[request.pageId];
     if (!page) {
       throw new Error(`[evjs] Page "${request.pageId}" is not in the runtime.`);
     }

--- a/packages/client/tests/page-runtime.test.ts
+++ b/packages/client/tests/page-runtime.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { startPageRuntime } from "../src/internal";
-import type { ClientRuntime } from "../src/runtime-config.js";
+import type {
+  ClientRuntime,
+  ClientRuntimePage,
+  ClientRuntimeRoute,
+} from "../src/runtime-config.js";
 import {
   __resetForTesting,
   callServer,
@@ -489,7 +493,7 @@ describe("startPageRuntime", () => {
         }),
       }),
     ).rejects.toThrow(
-      '[evjs] Loaded embedded runtime "__EVJS_CLIENT_RUNTIME__" pages must be an object.',
+      '[evjs] Loaded embedded runtime "__EVJS_CLIENT_RUNTIME__".pages must be an object.',
     );
   });
 
@@ -581,7 +585,7 @@ describe("startPageRuntime", () => {
         } as never,
       }),
     ).rejects.toThrow(
-      "[evjs] Loaded provided runtime routes must be an array.",
+      "[evjs] Loaded provided runtime.routes must be an array.",
     );
 
     await expect(
@@ -804,7 +808,12 @@ describe("startPageRuntime", () => {
   });
 });
 
-function createRuntime(): ClientRuntime {
+type LegacyClientRuntime = ClientRuntime & {
+  pages: Record<string, ClientRuntimePage>;
+  routes: ClientRuntimeRoute[];
+};
+
+function createRuntime(): LegacyClientRuntime {
   return {
     version: 1,
     buildId: "test",

--- a/packages/client/tests/page-runtime.test.ts
+++ b/packages/client/tests/page-runtime.test.ts
@@ -567,10 +567,10 @@ describe("startPageRuntime", () => {
         document,
         runtime: {
           ...createRuntime(),
-          apps: [],
+          app: [],
         } as never,
       }),
-    ).rejects.toThrow("[evjs] Loaded provided runtime apps must be an object.");
+    ).rejects.toThrow("[evjs] Loaded provided runtime app must be an object.");
 
     await expect(
       startPageRuntime({
@@ -809,7 +809,6 @@ function createRuntime(): ClientRuntime {
     version: 1,
     buildId: "test",
     runtime: {},
-    apps: {},
     pages: {
       home: {
         mount: "#root",

--- a/packages/client/tests/react-runtime.test.ts
+++ b/packages/client/tests/react-runtime.test.ts
@@ -579,7 +579,6 @@ describe("fetchRscFlight", () => {
             rsc: "/__evjs/rsc",
           },
         },
-        apps: {},
         pages: {},
         routes: [],
       },
@@ -1099,7 +1098,6 @@ function createRscRuntime(): ClientRuntime {
         rsc: "/__evjs/rsc",
       },
     },
-    apps: {},
     pages: {},
     routes: [],
   };

--- a/packages/client/tests/react-runtime.test.ts
+++ b/packages/client/tests/react-runtime.test.ts
@@ -7,7 +7,16 @@ import {
   loadRscDebugPage,
   mountRscDebugPayload,
 } from "../src/react.js";
-import type { ClientRuntime } from "../src/runtime-config.js";
+import type {
+  ClientRuntime,
+  ClientRuntimePage,
+  ClientRuntimeRoute,
+} from "../src/runtime-config.js";
+
+type LegacyClientRuntime = ClientRuntime & {
+  pages: Record<string, ClientRuntimePage>;
+  routes: ClientRuntimeRoute[];
+};
 
 const calls: string[] = [];
 const renderedElements: unknown[] = [];
@@ -343,7 +352,7 @@ describe("createReactPageModule", () => {
       pathname: "/users/settings",
       search: "",
     });
-    const runtime: ClientRuntime = {
+    const runtime: LegacyClientRuntime = {
       ...createRscRuntime(),
       pages: {
         profile: {},

--- a/packages/client/tests/rsc-runtime.test.ts
+++ b/packages/client/tests/rsc-runtime.test.ts
@@ -830,7 +830,6 @@ function createRuntime(): ClientRuntime {
         rsc: "/__evjs/rsc",
       },
     },
-    apps: {},
     pages: {},
     routes: [],
   };

--- a/packages/client/tests/shell.test.ts
+++ b/packages/client/tests/shell.test.ts
@@ -7,9 +7,18 @@ import {
   type HistoryDriverOptions,
   registerShellModule,
 } from "../src/internal";
-import type { ClientRuntime } from "../src/runtime-config.js";
+import type {
+  ClientRuntime,
+  ClientRuntimePage,
+  ClientRuntimeRoute,
+} from "../src/runtime-config.js";
 
-const runtime: ClientRuntime = {
+type LegacyClientRuntime = ClientRuntime & {
+  pages: Record<string, ClientRuntimePage>;
+  routes: ClientRuntimeRoute[];
+};
+
+const runtime: LegacyClientRuntime = {
   version: 1,
   buildId: "test",
   runtime: {},

--- a/packages/client/tests/shell.test.ts
+++ b/packages/client/tests/shell.test.ts
@@ -13,12 +13,10 @@ const runtime: ClientRuntime = {
   version: 1,
   buildId: "test",
   runtime: {},
-  apps: {
-    default: {
-      module: {
-        type: "lifecycle",
-        href: "/default.js",
-      },
+  app: {
+    module: {
+      type: "lifecycle",
+      href: "/default.js",
     },
   },
   pages: {
@@ -49,7 +47,6 @@ const runtime: ClientRuntime = {
     {
       id: "app.order",
       path: "/orders/$orderId",
-      appId: "default",
     },
   ],
 };
@@ -106,25 +103,10 @@ describe("createShell", () => {
     ).toThrow("[evjs] createShell() runtime.pages must be an object.");
     expect(() =>
       createShell({
-        runtime: { ...runtime, apps: [] },
+        runtime: { ...runtime, app: [] },
         resolveMountPoint: () => ({}) as Element,
       } as never),
-    ).toThrow("[evjs] createShell() runtime.apps must be an object.");
-    expect(() =>
-      createShell({
-        runtime: {
-          ...runtime,
-          apps: {
-            "admin.app": {
-              module: { type: "lifecycle", href: "/admin.js" },
-            },
-          },
-        },
-        resolveMountPoint: () => ({}) as Element,
-      } as never),
-    ).toThrow(
-      '[evjs] createShell() runtime.apps key "admin.app" must contain only letters, numbers, underscores, or hyphens.',
-    );
+    ).toThrow("[evjs] createShell() runtime.app must be an object.");
     expect(() =>
       createShell({
         runtime: { ...runtime, routes: {} },
@@ -152,28 +134,6 @@ describe("createShell", () => {
       } as never),
     ).toThrow(
       "[evjs] createShell() runtime.routes[0].id must not contain leading or trailing whitespace.",
-    );
-    expect(() =>
-      createShell({
-        runtime: {
-          ...runtime,
-          routes: [{ id: "orders", path: "/orders", appId: "missing" }],
-        },
-        resolveMountPoint: () => ({}) as Element,
-      } as never),
-    ).toThrow(
-      '[evjs] createShell() runtime.routes[0].appId "missing" does not match any runtime.apps entry.',
-    );
-    expect(() =>
-      createShell({
-        runtime: {
-          ...runtime,
-          routes: [{ id: "orders", path: "/orders", appId: "default " }],
-        },
-        resolveMountPoint: () => ({}) as Element,
-      } as never),
-    ).toThrow(
-      "[evjs] createShell() runtime.routes[0].appId must not contain leading or trailing whitespace.",
     );
     expect(() =>
       createShell({
@@ -366,17 +326,15 @@ describe("createShell", () => {
     expect(() =>
       createMalformedShell({
         ...runtime,
-        apps: {
-          default: {
-            module: {
-              type: "lifecycle",
-              href: " /app.js",
-            },
+        app: {
+          module: {
+            type: "lifecycle",
+            href: " /app.js",
           },
         },
       }),
     ).toThrow(
-      "[evjs] createShell() runtime.apps.default.module.href must not contain leading or trailing whitespace.",
+      "[evjs] createShell() runtime.app.module.href must not contain leading or trailing whitespace.",
     );
 
     expect(loadModule).not.toHaveBeenCalled();
@@ -1439,7 +1397,6 @@ describe("createHistoryDriver", () => {
     });
 
     expect(driver.current()).toEqual({
-      appId: "default",
       pageId: undefined,
       url: "https://example.com/orders/123",
     });

--- a/packages/ev/src/build-tools/plan/index.ts
+++ b/packages/ev/src/build-tools/plan/index.ts
@@ -487,12 +487,32 @@ function shouldEmitDocumentForPage(
   },
 ): boolean {
   if (isMpaFileRoutePage(config, page) && page.render === "ssg") return true;
+  const pagePath = getPageRoutePath(config, page);
+  if (page.render === "ssg" && pagePath && isStaticPagePath(pagePath)) {
+    return true;
+  }
 
   // Route-derived pages are served through the owning app/framework route.
   // In SPA mode this avoids colliding with the app HTML fallback.
   if (isRouteDerivedPage(page)) return false;
   if (page.path && page.render !== "csr") return false;
   return true;
+}
+
+function getPageRoutePath(
+  config: BuildPlanConfig,
+  page: {
+    id: string;
+    path?: string;
+    routeId?: string;
+  },
+): string | undefined {
+  return (
+    page.path ??
+    config.routing?.routes.find(
+      (route) => route.id === (page.routeId ?? page.id),
+    )?.path
+  );
 }
 
 function isMpaFileRoutePage(
@@ -511,6 +531,10 @@ function isMpaFileRoutePage(
       route.path === page.path &&
       route.module === page.component,
   );
+}
+
+function isStaticPagePath(pathname: string): boolean {
+  return !/(^|\/)(?:[$:]|[*])/.test(pathname);
 }
 
 function createServerPlan(

--- a/packages/ev/src/build-tools/plan/index.ts
+++ b/packages/ev/src/build-tools/plan/index.ts
@@ -28,6 +28,7 @@ import { SERVER_ROUTES_ENTRY_IMPORT } from "../server-routes-entry.js";
 import { sanitizePageId } from "../utils.js";
 
 const DEFAULT_PUBLIC_PATH: RuntimePlan["publicPath"] = "auto";
+const FRAMEWORK_SERVER_FETCH_ENTRY = "@evjs/ev/internal/server/fetch";
 const DEFAULT_RESOLVE_ALIAS = {
   "@": "./src",
 } as const satisfies NonNullable<BuildPlan["resolve"]>["alias"];
@@ -183,6 +184,8 @@ function createEntries(
   const spaRoutingEntry = getSpaRoutingEntry(config);
 
   for (const app of apps) {
+    if (isStaticOnlyRoutingApp(config, graph, app.id)) continue;
+
     const pagesAppRouting =
       config.routing?.mode === "spa" && spaRoutingEntry === app.entry
         ? config.routing
@@ -234,6 +237,7 @@ function createEntries(
           environment: "server" as const,
           runtime: "node" as const,
           kind: renderer.kind,
+          ...(renderer.phase ? { phase: renderer.phase } : {}),
           owner: renderer.owner,
         })),
     );
@@ -249,15 +253,17 @@ function createEntries(
     });
   }
 
-  const serverEntry = createServerRuntimeEntry(config, graph);
-  entries.push({
-    name: "server",
-    import: serverEntry.import,
-    environment: "server",
-    runtime: "node",
-    kind: "server-runtime",
-    ...(serverEntry.metadata ? { metadata: serverEntry.metadata } : {}),
-  });
+  const serverEntry = createServerRuntimeEntry(config, graph, serverRenderers);
+  if (serverEntry) {
+    entries.push({
+      name: "server",
+      import: serverEntry.import,
+      environment: "server",
+      runtime: "node",
+      kind: "server-runtime",
+      ...(serverEntry.metadata ? { metadata: serverEntry.metadata } : {}),
+    });
+  }
 
   return entries;
 }
@@ -369,6 +375,7 @@ function createServerRenderers(graph: AppGraph): ServerRenderPlan[] {
           name: `${page.id}-server`,
           import: pageServerEntry,
           kind: "page-server",
+          ...(isBuildOnlySsgPage(page) ? { phase: "build" as const } : {}),
           owner: pageOwner(page),
         });
       }
@@ -404,6 +411,21 @@ function getPageServerEntry(page: {
   app?: string;
 }): string | undefined {
   return page.component ?? page.app ?? page.entry;
+}
+
+function isBuildOnlySsgPage(page: {
+  render: RenderMode;
+  componentModel?: ComponentModel;
+  prerender?: PrerenderConfig;
+  ppr?: PprConfig;
+  hydrate?: HydrationMode;
+}): boolean {
+  return (
+    page.render === "ssg" &&
+    !isRscPage(page) &&
+    !isPartialPrerenderPage(page) &&
+    (page.hydrate ?? defaultHydrate(page.render)) === "none"
+  );
 }
 
 function getPageClientEntry(page: {
@@ -459,12 +481,14 @@ function createHtmlPlans(config: BuildPlanConfig, graph: AppGraph): HtmlPlan[] {
   const pages = Object.values(graph.pages);
 
   return [
-    ...apps.map((app) => ({
-      id: app.id === "default" ? "index" : app.id,
-      template: app.html,
-      fileName: app.id === "default" ? "index.html" : `${app.id}.html`,
-      owner: { appId: app.id },
-    })),
+    ...apps
+      .filter((app) => !isStaticOnlyRoutingApp(config, graph, app.id))
+      .map((app) => ({
+        id: app.id === "default" ? "index" : app.id,
+        template: app.html,
+        fileName: app.id === "default" ? "index.html" : `${app.id}.html`,
+        owner: { appId: app.id },
+      })),
     ...pages
       .filter((page) => shouldEmitDocumentForPage(config, page))
       .map((page) => ({
@@ -474,6 +498,27 @@ function createHtmlPlans(config: BuildPlanConfig, graph: AppGraph): HtmlPlan[] {
         owner: { pageId: page.id },
       })),
   ];
+}
+
+function isStaticOnlyRoutingApp(
+  config: BuildPlanConfig,
+  graph: AppGraph,
+  appId: string,
+): boolean {
+  if (config.routing?.mode !== "spa") return false;
+
+  const routes = graph.routes.filter((route) => route.appId === appId);
+  if (routes.length === 0) return false;
+
+  return routes.every((route) => isStaticSsgRoute(graph, route));
+}
+
+function isStaticSsgRoute(graph: AppGraph, route: AppGraph["routes"][number]) {
+  if (route.kind === "layout" || !route.pageId) return false;
+  if (!isStaticPagePath(route.path)) return false;
+
+  const page = graph.pages[route.pageId];
+  return page ? isBuildOnlySsgPage(page) : false;
 }
 
 function shouldEmitDocumentForPage(
@@ -542,8 +587,9 @@ function createServerPlan(
   graph: AppGraph,
   renderers: ServerRenderPlan[],
 ): ServerBuildPlan {
+  const entry = createServerRuntimeEntry(config, graph, renderers)?.import;
   return {
-    entry: createServerRuntimeEntry(config, graph).import,
+    ...(entry ? { entry } : {}),
     ...(renderers.length > 0 ? { renderers } : {}),
   };
 }
@@ -551,10 +597,14 @@ function createServerPlan(
 function createServerRuntimeEntry(
   config: BuildPlanConfig,
   graph: AppGraph,
-): Pick<BuildEntry, "import" | "metadata"> {
+  renderers: ServerRenderPlan[],
+): Pick<BuildEntry, "import" | "metadata"> | undefined {
   const routes = getConfiguredServerRoutes(config, graph);
   const middlewares = config.server.conventions?.globalMiddlewares ?? [];
   const serverFunctions = graph.serverFunctions;
+  const runtimeRenderers = renderers.filter(
+    (renderer) => renderer.phase !== "build",
+  );
   if (
     routes.length > 0 ||
     middlewares.length > 0 ||
@@ -570,7 +620,10 @@ function createServerRuntimeEntry(
       },
     };
   }
-  return { import: "@evjs/ev/internal/server/fetch" };
+  if (runtimeRenderers.length > 0) {
+    return { import: FRAMEWORK_SERVER_FETCH_ENTRY };
+  }
+  return undefined;
 }
 
 function getConfiguredServerRoutes(

--- a/packages/ev/src/bundler.ts
+++ b/packages/ev/src/bundler.ts
@@ -18,6 +18,7 @@ export interface BundlerBuildFacts {
   serverEntry?: string;
   serverAssets?: AssetGroup;
   serverModules?: BuildOutputServerModule[];
+  loadServerModule?: (asset: string) => Promise<unknown>;
   rscManifests?: {
     clientReferenceManifest?: Record<string, unknown>;
   };

--- a/packages/ev/src/bundler.ts
+++ b/packages/ev/src/bundler.ts
@@ -20,7 +20,6 @@ export interface BundlerBuildFacts {
   serverModules?: BuildOutputServerModule[];
   rscManifests?: {
     clientReferenceManifest?: Record<string, unknown>;
-    serverConsumerManifest?: Record<string, unknown>;
   };
 }
 

--- a/packages/ev/src/commands.ts
+++ b/packages/ev/src/commands.ts
@@ -79,6 +79,10 @@ const DEV_DIST_LOCK_FILE = ".evjs-dev.lock";
 const MANIFEST_FILE = "manifest.json";
 const RUNTIME_FILE = "runtime.json";
 const BUILD_OUTPUT_FILE = "build-output.json";
+const RUNTIME_ONLY_BUNDLER_MANIFEST_FILES = [
+  "react-client-manifest.json",
+  "react-ssr-manifest.json",
+];
 const PLUGIN_HOOK_NAMES = [
   "buildStart",
   "buildOutput",
@@ -1191,10 +1195,9 @@ function getFrameworkOutputPaths(
   cwd: string,
   output: BuildOutput,
 ): { rootDir: string; clientDir: string; serverDir: string } {
-  const rootDir = path.resolve(cwd, output.distDir);
-  const publicDir = output.paths?.publicDir ?? output.distDir;
-  const serverDir =
-    output.paths?.serverDir ?? path.join(output.distDir, "server");
+  const rootDir = path.resolve(cwd, output.paths.rootDir);
+  const publicDir = output.paths.publicDir;
+  const serverDir = output.paths.serverDir;
   return {
     rootDir,
     clientDir: path.resolve(cwd, publicDir),
@@ -1205,6 +1208,9 @@ function getFrameworkOutputPaths(
 async function emitFrameworkManifest(
   cwd: string,
   output: BuildOutput,
+  options: {
+    frameworkRuntime?: ReturnType<typeof createFrameworkRuntime>;
+  } = {},
 ): Promise<void> {
   const { rootDir, clientDir, serverDir } = getFrameworkOutputPaths(
     cwd,
@@ -1257,6 +1263,8 @@ async function emitFrameworkManifest(
 
   const publicManifest = createPublicManifest(output);
   const clientRuntime = createClientRuntime(output);
+  const frameworkRuntime =
+    options.frameworkRuntime ?? createFrameworkRuntime(output);
   await fs.promises.mkdir(clientDir, { recursive: true });
   await fs.promises.writeFile(
     path.join(clientDir, MANIFEST_FILE),
@@ -1267,6 +1275,25 @@ async function emitFrameworkManifest(
     path.join(clientDir, RUNTIME_FILE),
     JSON.stringify(clientRuntime, null, 2),
     "utf-8",
+  );
+  if (output.server.entry) {
+    await fs.promises.mkdir(serverDir, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(serverDir, RUNTIME_FILE),
+      JSON.stringify(frameworkRuntime, null, 2),
+      "utf-8",
+    );
+  }
+  await removeRuntimeOnlyBundlerManifests(clientDir);
+}
+
+async function removeRuntimeOnlyBundlerManifests(
+  clientDir: string,
+): Promise<void> {
+  await Promise.all(
+    RUNTIME_ONLY_BUNDLER_MANIFEST_FILES.map((fileName) =>
+      fs.promises.rm(path.join(clientDir, fileName), { force: true }),
+    ),
   );
 }
 
@@ -1394,7 +1421,10 @@ async function linkAndEmitBuildOutput<TBundlerCfg>(options: {
   hooks: PluginHooks<TBundlerCfg>[];
   pluginCtx: PluginContext<TBundlerCfg>;
   isRebuild: boolean;
-}): Promise<BuildOutput> {
+}): Promise<{
+  output: BuildOutput;
+  frameworkRuntime: ReturnType<typeof createFrameworkRuntime>;
+}> {
   const output = linkBuildOutput({
     graph: options.graph,
     plan: options.plan,
@@ -1404,12 +1434,14 @@ async function linkAndEmitBuildOutput<TBundlerCfg>(options: {
     serverEntry: options.bundlerFacts.serverEntry,
     serverAssets: options.bundlerFacts.serverAssets,
     serverModules: options.bundlerFacts.serverModules,
-    rscManifests: options.bundlerFacts.rscManifests,
   });
 
   await runBuildOutputHooks(options.hooks, output, options.pluginCtx);
   assertFrameworkManifestShape(output, "BuildOutput after buildOutput hooks");
-  await emitFrameworkManifest(options.cwd, output);
+  const frameworkRuntime = createFrameworkRuntime(output, {
+    rscManifests: options.bundlerFacts.rscManifests,
+  });
+  await emitFrameworkManifest(options.cwd, output, { frameworkRuntime });
   await emitFrameworkHtml(
     options.cwd,
     options.config,
@@ -1420,7 +1452,7 @@ async function linkAndEmitBuildOutput<TBundlerCfg>(options: {
     options.isRebuild,
   );
 
-  return output;
+  return { output, frameworkRuntime };
 }
 
 function normalizeAssetName(name: string | undefined): string | undefined {
@@ -1526,6 +1558,18 @@ function readFrameworkRuntime(
   cwd: string,
   distDir: string,
 ): ReturnType<typeof createFrameworkRuntime> | undefined {
+  const runtimePath = path.resolve(cwd, distDir, "server", RUNTIME_FILE);
+  if (fs.existsSync(runtimePath)) {
+    try {
+      return JSON.parse(fs.readFileSync(runtimePath, "utf-8")) as ReturnType<
+        typeof createFrameworkRuntime
+      >;
+    } catch (err) {
+      logger.warn`Failed to parse framework runtime: ${err}`;
+      return undefined;
+    }
+  }
+
   const outputPath = path.resolve(cwd, distDir, BUILD_OUTPUT_FILE);
   if (!fs.existsSync(outputPath)) return undefined;
 
@@ -2577,7 +2621,7 @@ export async function build<TBundlerCfg = DefaultBundlerConfig>(
       graph: prepared.graph,
       plan: prepared.plan,
     });
-    const buildOutput = await linkAndEmitBuildOutput({
+    const { output, frameworkRuntime } = await linkAndEmitBuildOutput({
       bundlerFacts,
       graph: prepared.graph,
       plan: prepared.plan,
@@ -2590,7 +2634,7 @@ export async function build<TBundlerCfg = DefaultBundlerConfig>(
 
     await runBuildEndHooks(
       prepared.hooks,
-      createBuildResult(buildOutput, false),
+      createBuildResult(output, false, { frameworkRuntime }),
     );
   } finally {
     await prepared.dispose();

--- a/packages/ev/src/commands.ts
+++ b/packages/ev/src/commands.ts
@@ -9,6 +9,7 @@ import type {
 } from "@evjs/shared/manifest";
 import {
   assertFrameworkManifestShape,
+  createDeploymentMetadata,
   createPublicManifest,
   createServerManifest,
   linkBuildOutput,
@@ -77,7 +78,9 @@ const DEV_PAGE_RENDER_PROXY_HEADER = "x-evjs-dev-page-render";
 const DEV_DIST_DIR = "dist";
 const DEV_DIST_LOCK_FILE = ".evjs-dev.lock";
 const MANIFEST_FILE = "manifest.json";
-const RUNTIME_FILE = "runtime.json";
+const CLIENT_RUNTIME_SCRIPT_ID = "__EVJS_CLIENT_RUNTIME__";
+const LEGACY_RUNTIME_FILE = "runtime.json";
+const FRAMEWORK_RUNTIME_FILE = "framework-runtime.json";
 const BUILD_OUTPUT_FILE = "build-output.json";
 const RUNTIME_ONLY_BUNDLER_MANIFEST_FILES = [
   "react-client-manifest.json",
@@ -1226,7 +1229,7 @@ async function emitFrameworkManifest(
   );
   await fs.promises.writeFile(
     path.join(rootDir, BUILD_OUTPUT_FILE),
-    JSON.stringify(output, null, 2),
+    JSON.stringify(createDeploymentMetadata(output), null, 2),
     "utf-8",
   );
   await fs.promises.rm(path.join(serverDir, BUILD_OUTPUT_FILE), {
@@ -1236,7 +1239,7 @@ async function emitFrameworkManifest(
     clientDir,
     serverDir,
   ]);
-  await removeFrameworkOutputFileIfInactive(rootDir, RUNTIME_FILE, [
+  await removeFrameworkOutputFileIfInactive(rootDir, LEGACY_RUNTIME_FILE, [
     clientDir,
     serverDir,
   ]);
@@ -1247,7 +1250,7 @@ async function emitFrameworkManifest(
   );
   await removeFrameworkOutputFileIfInactive(
     path.join(rootDir, "client"),
-    RUNTIME_FILE,
+    LEGACY_RUNTIME_FILE,
     [clientDir, serverDir],
   );
   await removeFrameworkOutputFileIfInactive(
@@ -1257,12 +1260,16 @@ async function emitFrameworkManifest(
   );
   await removeFrameworkOutputFileIfInactive(
     path.join(rootDir, "server"),
-    RUNTIME_FILE,
+    LEGACY_RUNTIME_FILE,
+    [clientDir, serverDir],
+  );
+  await removeFrameworkOutputFileIfInactive(
+    path.join(rootDir, "server"),
+    FRAMEWORK_RUNTIME_FILE,
     [clientDir, serverDir],
   );
 
   const publicManifest = createPublicManifest(output);
-  const clientRuntime = createClientRuntime(output);
   const frameworkRuntime =
     options.frameworkRuntime ?? createFrameworkRuntime(output);
   await fs.promises.mkdir(clientDir, { recursive: true });
@@ -1271,18 +1278,23 @@ async function emitFrameworkManifest(
     JSON.stringify(publicManifest, null, 2),
     "utf-8",
   );
-  await fs.promises.writeFile(
-    path.join(clientDir, RUNTIME_FILE),
-    JSON.stringify(clientRuntime, null, 2),
-    "utf-8",
-  );
+  await fs.promises.rm(path.join(clientDir, LEGACY_RUNTIME_FILE), {
+    force: true,
+  });
   if (output.server.entry) {
     await fs.promises.mkdir(serverDir, { recursive: true });
     await fs.promises.writeFile(
-      path.join(serverDir, RUNTIME_FILE),
+      path.join(serverDir, FRAMEWORK_RUNTIME_FILE),
       JSON.stringify(frameworkRuntime, null, 2),
       "utf-8",
     );
+    await fs.promises.rm(path.join(serverDir, LEGACY_RUNTIME_FILE), {
+      force: true,
+    });
+  } else {
+    await fs.promises.rm(path.join(serverDir, FRAMEWORK_RUNTIME_FILE), {
+      force: true,
+    });
   }
   await removeRuntimeOnlyBundlerManifests(clientDir);
 }
@@ -1372,6 +1384,7 @@ async function emitFrameworkHtml<TBundlerCfg>(
   isRebuild: boolean,
 ): Promise<void> {
   const { clientDir } = getFrameworkOutputPaths(cwd, output);
+  const clientRuntime = createClientRuntime(output);
 
   for (const html of plan.html) {
     const htmlInfo = createHtmlDocumentInfo(html, output);
@@ -1396,6 +1409,7 @@ async function emitFrameworkHtml<TBundlerCfg>(
       doc.documentElement?.setAttribute("data-evjs-kind", "app");
       doc.documentElement?.setAttribute("data-evjs-id", htmlInfo.appId);
     }
+    embedClientRuntime(doc, clientRuntime);
 
     const finalHtml = await buildHtml({
       doc,
@@ -1410,6 +1424,28 @@ async function emitFrameworkHtml<TBundlerCfg>(
     await fs.promises.mkdir(path.dirname(outPath), { recursive: true });
     await fs.promises.writeFile(outPath, finalHtml, "utf-8");
   }
+}
+
+function embedClientRuntime(
+  doc: ReturnType<typeof generateHtml>,
+  runtime: ReturnType<typeof createClientRuntime>,
+): void {
+  const body = doc.body ?? doc.querySelector("body");
+  if (!body) return;
+  const json = JSON.stringify(runtime)
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+  const script = doc.createElement("script");
+  script.id = CLIENT_RUNTIME_SCRIPT_ID;
+  script.setAttribute("type", "application/json");
+  script.textContent = json;
+  const firstScript = body.querySelector("script[src]");
+  if (firstScript) {
+    body.insertBefore(script, firstScript);
+    return;
+  }
+  body.appendChild(script);
 }
 
 async function linkAndEmitBuildOutput<TBundlerCfg>(options: {
@@ -1558,7 +1594,12 @@ function readFrameworkRuntime(
   cwd: string,
   distDir: string,
 ): ReturnType<typeof createFrameworkRuntime> | undefined {
-  const runtimePath = path.resolve(cwd, distDir, "server", RUNTIME_FILE);
+  const runtimePath = path.resolve(
+    cwd,
+    distDir,
+    "server",
+    FRAMEWORK_RUNTIME_FILE,
+  );
   if (fs.existsSync(runtimePath)) {
     try {
       return JSON.parse(fs.readFileSync(runtimePath, "utf-8")) as ReturnType<
@@ -1569,19 +1610,7 @@ function readFrameworkRuntime(
       return undefined;
     }
   }
-
-  const outputPath = path.resolve(cwd, distDir, BUILD_OUTPUT_FILE);
-  if (!fs.existsSync(outputPath)) return undefined;
-
-  try {
-    const output = JSON.parse(
-      fs.readFileSync(outputPath, "utf-8"),
-    ) as BuildOutput;
-    return createFrameworkRuntime(output);
-  } catch (err) {
-    logger.warn`Failed to parse build output for framework runtime: ${err}`;
-    return undefined;
-  }
+  return undefined;
 }
 
 function readServerEntryFromStats(

--- a/packages/ev/src/commands.ts
+++ b/packages/ev/src/commands.ts
@@ -1219,13 +1219,15 @@ async function emitFrameworkManifest(
     output,
   );
   await fs.promises.mkdir(rootDir, { recursive: true });
-  await fs.promises.mkdir(serverDir, { recursive: true });
   const serverManifest = createServerManifest(output);
-  await fs.promises.writeFile(
-    path.join(serverDir, MANIFEST_FILE),
-    JSON.stringify(serverManifest, null, 2),
-    "utf-8",
-  );
+  if (serverManifest.entry || serverManifest.routes.length > 0) {
+    await fs.promises.mkdir(serverDir, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(serverDir, MANIFEST_FILE),
+      JSON.stringify(serverManifest, null, 2),
+      "utf-8",
+    );
+  }
   await fs.promises.writeFile(
     path.join(rootDir, BUILD_OUTPUT_FILE),
     JSON.stringify(createDeploymentMetadata(output), null, 2),
@@ -1374,6 +1376,7 @@ async function emitFrameworkHtml<TBundlerCfg>(
   plan: BuildPlan,
   frameworkRuntime: ReturnType<typeof createFrameworkRuntime>,
   isRebuild: boolean,
+  loadServerModule?: (asset: string) => Promise<unknown>,
 ): Promise<void> {
   const { clientDir, serverDir } = getFrameworkOutputPaths(cwd, output);
   const clientRuntime = createClientRuntime(output);
@@ -1401,7 +1404,9 @@ async function emitFrameworkHtml<TBundlerCfg>(
       doc.documentElement?.setAttribute("data-evjs-kind", "app");
       doc.documentElement?.setAttribute("data-evjs-id", htmlInfo.appId);
     }
-    embedClientRuntime(doc, clientRuntime);
+    if (htmlInfo.assets.js.length > 0) {
+      embedClientRuntime(doc, clientRuntime);
+    }
     if (
       plan.mode === "production" &&
       shouldPrerenderStaticPage(output, htmlInfo)
@@ -1412,6 +1417,7 @@ async function emitFrameworkHtml<TBundlerCfg>(
         html: htmlInfo,
         frameworkRuntime,
         serverDir,
+        loadServerModule,
       });
     }
 
@@ -1450,8 +1456,10 @@ async function prerenderStaticPageHtml(options: {
   html: Extract<HtmlDocumentInfo, { kind: "page" }>;
   frameworkRuntime: ReturnType<typeof createFrameworkRuntime>;
   serverDir: string;
+  loadServerModule?: (asset: string) => Promise<unknown>;
 }): Promise<void> {
-  const { doc, output, html, frameworkRuntime, serverDir } = options;
+  const { doc, output, html, frameworkRuntime, serverDir, loadServerModule } =
+    options;
   const page = output.pages[html.pageId];
   const pathname = findStaticPagePath(output, html.pageId, page);
   if (!page || !pathname) return;
@@ -1460,7 +1468,9 @@ async function prerenderStaticPageHtml(options: {
     runtime: frameworkRuntime,
     loadModule: async (asset) =>
       normalizeServerModule(
-        await import(pathToFileURL(path.resolve(serverDir, asset)).href),
+        loadServerModule
+          ? await loadServerModule(asset)
+          : await import(pathToFileURL(path.resolve(serverDir, asset)).href),
       ),
     react: {
       renderDocument(appHtml) {
@@ -1585,6 +1595,7 @@ async function linkAndEmitBuildOutput<TBundlerCfg>(options: {
     options.plan,
     frameworkRuntime,
     options.isRebuild,
+    options.bundlerFacts.loadServerModule,
   );
 
   return { output, frameworkRuntime };

--- a/packages/ev/src/commands.ts
+++ b/packages/ev/src/commands.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { createApp } from "@evjs/server/app";
+import { createReactFrameworkServer } from "@evjs/server/react";
 import type {
   AppGraph,
   BuildOutput,
@@ -1370,9 +1372,10 @@ async function emitFrameworkHtml<TBundlerCfg>(
   pluginCtx: PluginContext<TBundlerCfg>,
   output: BuildOutput,
   plan: BuildPlan,
+  frameworkRuntime: ReturnType<typeof createFrameworkRuntime>,
   isRebuild: boolean,
 ): Promise<void> {
-  const { clientDir } = getFrameworkOutputPaths(cwd, output);
+  const { clientDir, serverDir } = getFrameworkOutputPaths(cwd, output);
   const clientRuntime = createClientRuntime(output);
 
   for (const html of plan.html) {
@@ -1399,6 +1402,18 @@ async function emitFrameworkHtml<TBundlerCfg>(
       doc.documentElement?.setAttribute("data-evjs-id", htmlInfo.appId);
     }
     embedClientRuntime(doc, clientRuntime);
+    if (
+      plan.mode === "production" &&
+      shouldPrerenderStaticPage(output, htmlInfo)
+    ) {
+      await prerenderStaticPageHtml({
+        doc,
+        output,
+        html: htmlInfo,
+        frameworkRuntime,
+        serverDir,
+      });
+    }
 
     const finalHtml = await buildHtml({
       doc,
@@ -1413,6 +1428,100 @@ async function emitFrameworkHtml<TBundlerCfg>(
     await fs.promises.mkdir(path.dirname(outPath), { recursive: true });
     await fs.promises.writeFile(outPath, finalHtml, "utf-8");
   }
+}
+
+function shouldPrerenderStaticPage(
+  output: BuildOutput,
+  html: HtmlDocumentInfo,
+): html is Extract<HtmlDocumentInfo, { kind: "page" }> {
+  if (html.kind !== "page") return false;
+  const page = output.pages[html.pageId];
+  return Boolean(
+    page &&
+      page.render === "ssg" &&
+      page.rendering.html === "static" &&
+      page.rendering.prerender === "full",
+  );
+}
+
+async function prerenderStaticPageHtml(options: {
+  doc: ReturnType<typeof generateHtml>;
+  output: BuildOutput;
+  html: Extract<HtmlDocumentInfo, { kind: "page" }>;
+  frameworkRuntime: ReturnType<typeof createFrameworkRuntime>;
+  serverDir: string;
+}): Promise<void> {
+  const { doc, output, html, frameworkRuntime, serverDir } = options;
+  const page = output.pages[html.pageId];
+  const pathname = findStaticPagePath(output, html.pageId, page);
+  if (!page || !pathname) return;
+
+  const framework = createReactFrameworkServer({
+    runtime: frameworkRuntime,
+    loadModule: async (asset) =>
+      normalizeServerModule(
+        await import(pathToFileURL(path.resolve(serverDir, asset)).href),
+      ),
+    react: {
+      renderDocument(appHtml) {
+        return appHtml;
+      },
+    },
+  });
+  if (!framework?.render) {
+    throw new Error(
+      `[evjs] Unable to prerender SSG page "${html.pageId}" because no server renderer was emitted.`,
+    );
+  }
+
+  const app = createApp({ framework });
+  const response = await app.fetch(
+    new Request(new URL(pathname, "http://evjs.local").toString(), {
+      method: "GET",
+    }),
+  );
+  if (!response.ok) {
+    throw new Error(
+      `[evjs] Failed to prerender SSG page "${html.pageId}": ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const mount = doc.querySelector(page.mount ?? "#app");
+  if (!mount) {
+    throw new Error(
+      `[evjs] Unable to prerender SSG page "${html.pageId}" because mount target "${page.mount ?? "#app"}" was not found.`,
+    );
+  }
+  mount.innerHTML = await response.text();
+}
+
+function findStaticPagePath(
+  output: BuildOutput,
+  pageId: string,
+  page: BuildOutput["pages"][string] | undefined,
+): string | undefined {
+  const routePath = output.routes.find(
+    (route) => route.pageId === pageId,
+  )?.path;
+  const pathname = routePath ?? page?.path;
+  if (!pathname || !isStaticPagePath(pathname)) return undefined;
+  return pathname;
+}
+
+function isStaticPagePath(pathname: string): boolean {
+  return !/(^|\/)(?:[$:]|[*])/.test(pathname);
+}
+
+function normalizeServerModule(mod: unknown): Record<string, unknown> {
+  const nested =
+    mod && typeof mod === "object" && "default" in mod
+      ? (mod as { default?: unknown }).default
+      : undefined;
+  return nested &&
+    typeof nested === "object" &&
+    ("default" in nested || "render" in nested || "fetch" in nested)
+    ? (nested as Record<string, unknown>)
+    : (mod as Record<string, unknown>);
 }
 
 function embedClientRuntime(
@@ -1474,6 +1583,7 @@ async function linkAndEmitBuildOutput<TBundlerCfg>(options: {
     options.pluginCtx,
     output,
     options.plan,
+    frameworkRuntime,
     options.isRebuild,
   );
 

--- a/packages/ev/src/commands.ts
+++ b/packages/ev/src/commands.ts
@@ -80,7 +80,7 @@ const DEV_DIST_LOCK_FILE = ".evjs-dev.lock";
 const MANIFEST_FILE = "manifest.json";
 const CLIENT_RUNTIME_SCRIPT_ID = "__EVJS_CLIENT_RUNTIME__";
 const LEGACY_RUNTIME_FILE = "runtime.json";
-const FRAMEWORK_RUNTIME_FILE = "framework-runtime.json";
+const LEGACY_FRAMEWORK_RUNTIME_FILE = "framework-runtime.json";
 const BUILD_OUTPUT_FILE = "build-output.json";
 const RUNTIME_ONLY_BUNDLER_MANIFEST_FILES = [
   "react-client-manifest.json",
@@ -1211,9 +1211,6 @@ function getFrameworkOutputPaths(
 async function emitFrameworkManifest(
   cwd: string,
   output: BuildOutput,
-  options: {
-    frameworkRuntime?: ReturnType<typeof createFrameworkRuntime>;
-  } = {},
 ): Promise<void> {
   const { rootDir, clientDir, serverDir } = getFrameworkOutputPaths(
     cwd,
@@ -1265,13 +1262,11 @@ async function emitFrameworkManifest(
   );
   await removeFrameworkOutputFileIfInactive(
     path.join(rootDir, "server"),
-    FRAMEWORK_RUNTIME_FILE,
+    LEGACY_FRAMEWORK_RUNTIME_FILE,
     [clientDir, serverDir],
   );
 
   const publicManifest = createPublicManifest(output);
-  const frameworkRuntime =
-    options.frameworkRuntime ?? createFrameworkRuntime(output);
   await fs.promises.mkdir(clientDir, { recursive: true });
   await fs.promises.writeFile(
     path.join(clientDir, MANIFEST_FILE),
@@ -1283,19 +1278,13 @@ async function emitFrameworkManifest(
   });
   if (output.server.entry) {
     await fs.promises.mkdir(serverDir, { recursive: true });
-    await fs.promises.writeFile(
-      path.join(serverDir, FRAMEWORK_RUNTIME_FILE),
-      JSON.stringify(frameworkRuntime, null, 2),
-      "utf-8",
-    );
     await fs.promises.rm(path.join(serverDir, LEGACY_RUNTIME_FILE), {
       force: true,
     });
-  } else {
-    await fs.promises.rm(path.join(serverDir, FRAMEWORK_RUNTIME_FILE), {
-      force: true,
-    });
   }
+  await fs.promises.rm(path.join(serverDir, LEGACY_FRAMEWORK_RUNTIME_FILE), {
+    force: true,
+  });
   await removeRuntimeOnlyBundlerManifests(clientDir);
 }
 
@@ -1477,7 +1466,7 @@ async function linkAndEmitBuildOutput<TBundlerCfg>(options: {
   const frameworkRuntime = createFrameworkRuntime(output, {
     rscManifests: options.bundlerFacts.rscManifests,
   });
-  await emitFrameworkManifest(options.cwd, output, { frameworkRuntime });
+  await emitFrameworkManifest(options.cwd, output);
   await emitFrameworkHtml(
     options.cwd,
     options.config,
@@ -1588,29 +1577,6 @@ function readServerEntryFromManifest(
     logger.warn`Failed to parse build manifest for server entry: ${err}`;
     return undefined;
   }
-}
-
-function readFrameworkRuntime(
-  cwd: string,
-  distDir: string,
-): ReturnType<typeof createFrameworkRuntime> | undefined {
-  const runtimePath = path.resolve(
-    cwd,
-    distDir,
-    "server",
-    FRAMEWORK_RUNTIME_FILE,
-  );
-  if (fs.existsSync(runtimePath)) {
-    try {
-      return JSON.parse(fs.readFileSync(runtimePath, "utf-8")) as ReturnType<
-        typeof createFrameworkRuntime
-      >;
-    } catch (err) {
-      logger.warn`Failed to parse framework runtime: ${err}`;
-      return undefined;
-    }
-  }
-  return undefined;
 }
 
 function readServerEntryFromStats(
@@ -2312,6 +2278,9 @@ export async function dev<TBundlerCfg = DefaultBundlerConfig>(
   let releaseDevDistLock: (() => Promise<void>) | undefined;
   let stopWatchingDevDependencies = () => {};
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  let activeFrameworkRuntime:
+    | ReturnType<typeof createFrameworkRuntime>
+    | undefined;
   const expectedApiExits = new WeakSet<ApiProcess>();
   let resolveShutdown: (() => void) | undefined;
   const waitForShutdown = new Promise<void>((resolve) => {
@@ -2356,7 +2325,6 @@ export async function dev<TBundlerCfg = DefaultBundlerConfig>(
     const bootstrapPath = path.join(devRootDir, "_dev_start.cjs");
     try {
       const serverBundlePath = path.join(devRootDir, "server", serverEntry);
-      const frameworkRuntime = readFrameworkRuntime(cwd, activePlan.distDir);
 
       if (!fs.existsSync(path.dirname(bootstrapPath))) {
         fs.mkdirSync(path.dirname(bootstrapPath), { recursive: true });
@@ -2367,7 +2335,7 @@ export async function dev<TBundlerCfg = DefaultBundlerConfig>(
           `(async () => {`,
           `const path = require("node:path");`,
           `const { pathToFileURL } = require("node:url");`,
-          `globalThis.__EVJS_FRAMEWORK_RUNTIME__ = ${JSON.stringify(frameworkRuntime, null, 2)};`,
+          `globalThis.__EVJS_FRAMEWORK_RUNTIME__ = ${JSON.stringify(activeFrameworkRuntime, null, 2)};`,
           `globalThis.__EVJS_DEV_PAGE_RENDER_PROXY_HEADER__ = ${JSON.stringify(DEV_PAGE_RENDER_PROXY_HEADER)};`,
           `const serverDir = path.dirname(${JSON.stringify(serverBundlePath)});`,
           `globalThis.__EVJS_SERVER_MODULE_LOADER__ = async (asset) => { const mod = await import(pathToFileURL(path.resolve(serverDir, asset)).href); const nested = mod && typeof mod.default === "object" ? mod.default : undefined; return nested && ("default" in nested || "render" in nested) ? nested : mod; };`,
@@ -2593,7 +2561,7 @@ export async function dev<TBundlerCfg = DefaultBundlerConfig>(
         plan: activePlan,
         callbacks: {
           async onBuildFacts(bundlerFacts, options) {
-            await linkAndEmitBuildOutput({
+            const { frameworkRuntime } = await linkAndEmitBuildOutput({
               bundlerFacts,
               graph: activeAnalysis.graph,
               plan: activePlan,
@@ -2603,6 +2571,7 @@ export async function dev<TBundlerCfg = DefaultBundlerConfig>(
               pluginCtx,
               isRebuild: options?.isRebuild ?? false,
             });
+            activeFrameworkRuntime = frameworkRuntime;
           },
           onServerBundleReady: handleServerBundleReady,
         },

--- a/packages/ev/src/config.ts
+++ b/packages/ev/src/config.ts
@@ -55,9 +55,7 @@ export type {
   PluginContext,
   PluginHooks,
   RouteEntry,
-  ServerFnEntry,
   ServerManifest,
-  ServerRouteEntry,
 } from "./plugin.js";
 
 /** Resolved dev server configuration (all defaults applied). */

--- a/packages/ev/src/deployment.ts
+++ b/packages/ev/src/deployment.ts
@@ -71,7 +71,7 @@ export interface DeploymentArtifact {
   paths: BuildOutput["paths"];
   publicPath: PublicPathOutput;
   assets?: Record<string, AssetGroup>;
-  apps: Record<string, DeploymentApp>;
+  app?: DeploymentApp;
   pages: Record<string, DeploymentPage>;
   routes: DeploymentRoute[];
   server: DeploymentServer;
@@ -103,7 +103,6 @@ export interface DeploymentPage {
 export interface DeploymentRoute {
   id: string;
   path: string;
-  appId?: string;
   pageId?: string;
 }
 
@@ -157,20 +156,11 @@ export function createDeploymentArtifact(
     paths: getDeploymentOutputPaths(output),
     publicPath: output.publicPath,
     ...(includeAssets ? { assets: output.assets } : {}),
-    apps: Object.fromEntries(
-      Object.entries(output.apps).map(([id, app]) => [
-        id,
-        {
-          ...(includeAssets ? { assets: app.assets } : {}),
-          document: app.document,
-          mount: app.mount,
-        },
-      ]),
-    ),
+    app: createDeploymentApp(output, includeAssets),
     pages: Object.fromEntries(
       Object.entries(output.pages).map(([id, page]) => [
         id,
-        {
+        pruneUndefined({
           ...(includeAssets ? { assets: page.assets } : {}),
           document: page.document,
           path: page.path,
@@ -179,15 +169,16 @@ export function createDeploymentArtifact(
           componentModel: page.componentModel,
           hydrate: page.hydrate,
           mount: page.mount,
-        },
+        }),
       ]),
     ),
-    routes: output.routes.map((route) => ({
-      id: route.id,
-      path: route.path,
-      appId: route.appId,
-      pageId: route.pageId,
-    })),
+    routes: output.routes.map((route) =>
+      pruneUndefined({
+        id: route.id,
+        path: route.path,
+        pageId: route.pageId,
+      }),
+    ),
     server: {
       entry: output.server.entry,
       basePath: output.runtime.server.basePath,
@@ -217,6 +208,26 @@ export function createDeploymentArtifact(
   };
 
   return artifact;
+}
+
+function createDeploymentApp(
+  output: BuildOutput,
+  includeAssets: boolean,
+): DeploymentApp | undefined {
+  const app = output.apps.default ?? Object.values(output.apps)[0];
+  if (!app) return undefined;
+  return pruneUndefined({
+    ...(includeAssets ? { assets: app.assets } : {}),
+    document: app.document,
+    mount: app.mount,
+  });
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(value: T): T {
+  for (const key of Object.keys(value)) {
+    if (value[key] === undefined) delete value[key];
+  }
+  return value;
 }
 
 export function createNodeDeploymentFiles(

--- a/packages/ev/src/deployment.ts
+++ b/packages/ev/src/deployment.ts
@@ -8,7 +8,10 @@ import type {
   RenderMode,
   RuntimeOutput,
 } from "@evjs/shared/manifest";
-import { createFrameworkRuntime } from "./framework-runtime.js";
+import {
+  createFrameworkRuntime,
+  type FrameworkRuntimeOutput,
+} from "./framework-runtime.js";
 import type { Plugin } from "./plugin.js";
 
 export interface DeploymentArtifactOptions {
@@ -22,6 +25,7 @@ export interface NodeDeploymentAdapterOptions
   serverFileName?: string;
   portEnv?: string;
   defaultPort?: number;
+  frameworkRuntime?: FrameworkRuntimeOutput;
 }
 
 export interface StaticDeploymentAdapterOptions
@@ -35,6 +39,7 @@ export interface EdgeDeploymentAdapterOptions
   artifactFileName?: string;
   workerFileName?: string;
   assetsBinding?: string;
+  frameworkRuntime?: FrameworkRuntimeOutput;
 }
 
 export interface NodeDeploymentFiles {
@@ -63,8 +68,7 @@ export interface DeploymentArtifact {
   version: 1;
   platform?: string;
   buildId: string;
-  distDir: string;
-  paths?: BuildOutput["paths"];
+  paths: BuildOutput["paths"];
   publicPath: PublicPathOutput;
   assets?: Record<string, AssetGroup>;
   apps: Record<string, DeploymentApp>;
@@ -80,7 +84,6 @@ export interface DeploymentApp {
   document?: {
     fileName: string;
   };
-  entry?: string;
   mount?: string;
 }
 
@@ -123,8 +126,6 @@ export interface DeploymentServer {
 export interface DeploymentRsc {
   endpoint?: string;
   pages: string[];
-  clientReferences: string[];
-  serverReferences: string[];
 }
 
 interface StaticDocumentRoute {
@@ -153,7 +154,6 @@ export function createDeploymentArtifact(
     version: 1,
     ...(options.platform ? { platform: options.platform } : {}),
     buildId: output.buildId,
-    distDir: output.distDir,
     paths: getDeploymentOutputPaths(output),
     publicPath: output.publicPath,
     ...(includeAssets ? { assets: output.assets } : {}),
@@ -163,7 +163,6 @@ export function createDeploymentArtifact(
         {
           ...(includeAssets ? { assets: app.assets } : {}),
           document: app.document,
-          entry: app.entry,
           mount: app.mount,
         },
       ]),
@@ -209,10 +208,8 @@ export function createDeploymentArtifact(
     ...(output.rsc
       ? {
           rsc: {
-            endpoint: output.rsc.endpoint,
+            endpoint: output.runtime.server.rsc,
             pages: Object.keys(output.rsc.pages ?? {}),
-            clientReferences: Object.keys(output.rsc.clientReferences ?? {}),
-            serverReferences: Object.keys(output.rsc.serverReferences ?? {}),
           },
         }
       : {}),
@@ -253,8 +250,11 @@ export function nodeDeploymentAdapter(
     name: "node-deployment-adapter",
     setup() {
       return {
-        async buildEnd({ output }) {
-          const files = createNodeDeploymentFiles(output, options);
+        async buildEnd({ output, frameworkRuntime }) {
+          const files = createNodeDeploymentFiles(output, {
+            ...options,
+            frameworkRuntime,
+          });
           const rootDir = resolveOutputDir(output, "rootDir");
           await fs.mkdir(rootDir, { recursive: true });
           await fs.writeFile(
@@ -358,8 +358,11 @@ export function edgeDeploymentAdapter(
     name: "edge-deployment-adapter",
     setup() {
       return {
-        async buildEnd({ output }) {
-          const files = createEdgeDeploymentFiles(output, options);
+        async buildEnd({ output, frameworkRuntime }) {
+          const files = createEdgeDeploymentFiles(output, {
+            ...options,
+            frameworkRuntime,
+          });
           const rootDir = resolveOutputDir(output, "rootDir");
           await fs.mkdir(rootDir, { recursive: true });
           await fs.writeFile(
@@ -383,13 +386,7 @@ export function edgeDeploymentAdapter(
 function getDeploymentOutputPaths(
   output: BuildOutput,
 ): NonNullable<BuildOutput["paths"]> {
-  if (output.paths) return output.paths;
-
-  return {
-    rootDir: output.distDir,
-    publicDir: joinManifestPath(output.distDir, "client"),
-    serverDir: joinManifestPath(output.distDir, "server"),
-  };
+  return output.paths;
 }
 
 function resolveOutputDir(
@@ -404,15 +401,6 @@ function getPublicDirRelativeToRoot(output: BuildOutput): string {
   const paths = getDeploymentOutputPaths(output);
   const relative = path.relative(paths.rootDir, paths.publicDir);
   return relative || ".";
-}
-
-function joinManifestPath(...parts: string[]): string {
-  return parts
-    .map((part, index) =>
-      index === 0 ? part.replace(/\/+$/, "") : part.replace(/^\/+|\/+$/g, ""),
-    )
-    .filter(Boolean)
-    .join("/");
 }
 
 function createNodeServerModule(
@@ -433,7 +421,8 @@ function createNodeServerModule(
   const clientRoot = getPublicDirRelativeToRoot(output);
   const portEnv = options.portEnv ?? "PORT";
   const defaultPort = options.defaultPort ?? 3000;
-  const frameworkRuntime = createFrameworkRuntime(output);
+  const frameworkRuntime =
+    options.frameworkRuntime ?? createFrameworkRuntime(output);
 
   return `import { readFile } from "node:fs/promises";
 import path from "node:path";
@@ -612,7 +601,8 @@ function createEdgeWorkerModule(
   const frameworkRequestCondition = serverEntry
     ? "isFrameworkRequest(url.pathname)"
     : "false";
-  const frameworkRuntime = createFrameworkRuntime(output);
+  const frameworkRuntime =
+    options.frameworkRuntime ?? createFrameworkRuntime(output);
 
   return [
     `globalThis.__EVJS_FRAMEWORK_RUNTIME__ = ${JSON.stringify(frameworkRuntime, null, 2)};`,

--- a/packages/ev/src/deployment.ts
+++ b/packages/ev/src/deployment.ts
@@ -1,13 +1,13 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type {
-  AssetGroup,
   BuildOutput,
-  ComponentModel,
-  PublicPathOutput,
-  RenderMode,
-  RuntimeOutput,
+  DeploymentDocumentOutput,
+  DeploymentMetadata,
+  DeploymentRouteOutput,
+  DeploymentServerOutput,
 } from "@evjs/shared/manifest";
+import { createDeploymentMetadata } from "@evjs/shared/manifest";
 import {
   createFrameworkRuntime,
   type FrameworkRuntimeOutput,
@@ -64,68 +64,13 @@ export interface EdgeDeploymentFiles {
   workerModule?: string;
 }
 
-export interface DeploymentArtifact {
-  version: 1;
+export interface DeploymentArtifact extends DeploymentMetadata {
   platform?: string;
-  buildId: string;
-  paths: BuildOutput["paths"];
-  publicPath: PublicPathOutput;
-  assets?: Record<string, AssetGroup>;
-  app?: DeploymentApp;
-  pages: Record<string, DeploymentPage>;
-  routes: DeploymentRoute[];
-  server: DeploymentServer;
-  rsc?: DeploymentRsc;
-  metadata?: Record<string, unknown>;
 }
 
-export interface DeploymentApp {
-  assets?: AssetGroup;
-  document?: {
-    fileName: string;
-  };
-  mount?: string;
-}
-
-export interface DeploymentPage {
-  assets?: AssetGroup;
-  document?: {
-    fileName: string;
-  };
-  path?: string;
-  routeId?: string;
-  render: RenderMode;
-  componentModel?: ComponentModel;
-  hydrate?: string;
-  mount?: string;
-}
-
-export interface DeploymentRoute {
-  id: string;
-  path: string;
-  pageId?: string;
-}
-
-export interface DeploymentServer {
-  entry?: string;
-  basePath?: string;
-  fn?: string;
-  ppr?: string;
-  rsc?: string;
-  transport?: RuntimeOutput["transport"];
-  assets?: AssetGroup;
-  renderers: string[];
-  functions: string[];
-  routes: Array<{
-    path: string;
-    methods: string[];
-  }>;
-}
-
-export interface DeploymentRsc {
-  endpoint?: string;
-  pages: string[];
-}
+export type DeploymentDocument = DeploymentDocumentOutput;
+export type DeploymentRoute = DeploymentRouteOutput;
+export type DeploymentServer = DeploymentServerOutput;
 
 interface StaticDocumentRoute {
   path: string;
@@ -148,79 +93,12 @@ export function createDeploymentArtifact(
   output: BuildOutput,
   options: DeploymentArtifactOptions = {},
 ): DeploymentArtifact {
-  const includeAssets = options.includeAssets ?? true;
-  const artifact: DeploymentArtifact = {
-    version: 1,
-    ...(options.platform ? { platform: options.platform } : {}),
-    buildId: output.buildId,
-    paths: getDeploymentOutputPaths(output),
-    publicPath: output.publicPath,
-    ...(includeAssets ? { assets: output.assets } : {}),
-    app: createDeploymentApp(output, includeAssets),
-    pages: Object.fromEntries(
-      Object.entries(output.pages).map(([id, page]) => [
-        id,
-        pruneUndefined({
-          ...(includeAssets ? { assets: page.assets } : {}),
-          document: page.document,
-          path: page.path,
-          routeId: page.routeId,
-          render: page.render,
-          componentModel: page.componentModel,
-          hydrate: page.hydrate,
-          mount: page.mount,
-        }),
-      ]),
-    ),
-    routes: output.routes.map((route) =>
-      pruneUndefined({
-        id: route.id,
-        path: route.path,
-        pageId: route.pageId,
-      }),
-    ),
-    server: {
-      entry: output.server.entry,
-      basePath: output.runtime.server.basePath,
-      fn: output.runtime.server.fn,
-      ppr: output.runtime.server.ppr,
-      rsc: output.runtime.server.rsc,
-      ...(output.runtime.transport
-        ? { transport: output.runtime.transport }
-        : {}),
-      ...(includeAssets ? { assets: output.server.assets } : {}),
-      renderers: Object.keys(output.server.renderers ?? {}),
-      functions: Object.keys(output.server.functions),
-      routes: output.server.routes.map((route) => ({
-        path: route.path,
-        methods: route.methods,
-      })),
-    },
-    ...(output.rsc
-      ? {
-          rsc: {
-            endpoint: output.runtime.server.rsc,
-            pages: Object.keys(output.rsc.pages ?? {}),
-          },
-        }
-      : {}),
-    ...(output.deployment ? { metadata: output.deployment } : {}),
-  };
-
-  return artifact;
-}
-
-function createDeploymentApp(
-  output: BuildOutput,
-  includeAssets: boolean,
-): DeploymentApp | undefined {
-  const app = output.apps.default ?? Object.values(output.apps)[0];
-  if (!app) return undefined;
   return pruneUndefined({
-    ...(includeAssets ? { assets: app.assets } : {}),
-    document: app.document,
-    mount: app.mount,
-  });
+    ...createDeploymentMetadata(output, {
+      includeAssets: options.includeAssets,
+    }),
+    ...(options.platform ? { platform: options.platform } : {}),
+  }) as DeploymentArtifact;
 }
 
 function pruneUndefined<T extends Record<string, unknown>>(value: T): T {
@@ -900,7 +778,7 @@ function getFrameworkServerRoutes(output: BuildOutput): string[] {
 }
 
 function getStaticAssetPrefix(
-  publicPath: PublicPathOutput,
+  publicPath: BuildOutput["publicPath"],
 ): string | undefined {
   if (!publicPath.startsWith("/") || publicPath.startsWith("//")) {
     return undefined;

--- a/packages/ev/src/framework-runtime.ts
+++ b/packages/ev/src/framework-runtime.ts
@@ -2,7 +2,7 @@ import type { BuildOutput } from "@evjs/shared/manifest";
 
 export type ClientRuntimeOutput = Pick<BuildOutput, "version" | "buildId"> & {
   runtime: ClientRuntimeOutputRuntime;
-  apps: Record<string, ClientRuntimeTargetOutput>;
+  app?: ClientRuntimeTargetOutput;
   pages: Record<string, ClientRuntimeTargetOutput>;
   routes: ClientRuntimeRouteOutput[];
 };
@@ -23,7 +23,7 @@ export type ClientRuntimeTargetOutput = Pick<
 
 export type ClientRuntimeRouteOutput = Pick<
   BuildOutput["routes"][number],
-  "id" | "path" | "appId" | "pageId"
+  "id" | "path" | "pageId"
 >;
 
 export interface FrameworkRuntimeOutput {
@@ -100,15 +100,7 @@ export function createClientRuntime(output: BuildOutput): ClientRuntimeOutput {
     version: output.version,
     buildId: output.buildId,
     runtime: createClientRuntimeRuntime(output.runtime),
-    apps: Object.fromEntries(
-      Object.entries(output.apps).map(([id, app]) => [
-        id,
-        pruneUndefined({
-          mount: app.mount,
-          module: app.module,
-        }),
-      ]),
-    ),
+    app: createClientRuntimeApp(output),
     pages: Object.fromEntries(
       Object.entries(output.pages).map(([id, page]) => [
         id,
@@ -122,10 +114,20 @@ export function createClientRuntime(output: BuildOutput): ClientRuntimeOutput {
       pruneUndefined({
         id: route.id,
         path: route.path,
-        appId: route.appId,
         pageId: route.pageId,
       }),
     ),
+  });
+}
+
+function createClientRuntimeApp(
+  output: BuildOutput,
+): ClientRuntimeTargetOutput | undefined {
+  const app = output.apps.default ?? Object.values(output.apps)[0];
+  if (!app) return undefined;
+  return pruneUndefined({
+    mount: app.mount,
+    module: app.module,
   });
 }
 

--- a/packages/ev/src/framework-runtime.ts
+++ b/packages/ev/src/framework-runtime.ts
@@ -16,8 +16,10 @@ export interface ClientRuntimeOutputRuntime {
 
 export type ClientRuntimeTargetOutput = Pick<
   BuildOutput["apps"][string],
-  "mount" | "module"
->;
+  "mount"
+> & {
+  module?: BuildOutput["apps"][string]["module"];
+};
 
 export type ClientRuntimeRouteOutput = Pick<
   BuildOutput["routes"][number],
@@ -82,6 +84,12 @@ export interface FrameworkRuntimeRsc {
   clientReferenceManifest?: Record<string, unknown>;
 }
 
+export interface FrameworkRuntimeOptions {
+  rscManifests?: {
+    clientReferenceManifest?: Record<string, unknown>;
+  };
+}
+
 export type FrameworkRuntimeRscPage = Pick<
   NonNullable<NonNullable<BuildOutput["rsc"]>["pages"]>[string],
   "renderer" | "assets" | "routeId"
@@ -136,6 +144,7 @@ function createClientRuntimeRuntime(
 
 export function createFrameworkRuntime(
   output: BuildOutput,
+  options: FrameworkRuntimeOptions = {},
 ): FrameworkRuntimeOutput {
   return pruneUndefined({
     version: 1 as const,
@@ -193,12 +202,13 @@ export function createFrameworkRuntime(
           )
         : undefined,
     }),
-    rsc: createFrameworkRuntimeRsc(output.rsc),
+    rsc: createFrameworkRuntimeRsc(output.rsc, options.rscManifests),
   });
 }
 
 function createFrameworkRuntimeRsc(
   rsc: BuildOutput["rsc"],
+  rscManifests: FrameworkRuntimeOptions["rscManifests"],
 ): FrameworkRuntimeRsc | undefined {
   if (!rsc) return undefined;
   const runtimeRsc = pruneUndefined({
@@ -214,7 +224,7 @@ function createFrameworkRuntimeRsc(
           ]),
         )
       : undefined,
-    clientReferenceManifest: rsc.clientReferenceManifest,
+    clientReferenceManifest: rscManifests?.clientReferenceManifest,
   });
   return Object.keys(runtimeRsc).length > 0 ? runtimeRsc : undefined;
 }

--- a/packages/ev/src/framework-runtime.ts
+++ b/packages/ev/src/framework-runtime.ts
@@ -3,8 +3,7 @@ import type { BuildOutput } from "@evjs/shared/manifest";
 export type ClientRuntimeOutput = Pick<BuildOutput, "version" | "buildId"> & {
   runtime: ClientRuntimeOutputRuntime;
   app?: ClientRuntimeTargetOutput;
-  pages: Record<string, ClientRuntimeTargetOutput>;
-  routes: ClientRuntimeRouteOutput[];
+  routing: ClientRuntimeRoutingOutput;
 };
 
 export interface ClientRuntimeOutputRuntime {
@@ -21,18 +20,30 @@ export type ClientRuntimeTargetOutput = Pick<
   module?: BuildOutput["apps"][string]["module"];
 };
 
+export type ClientRuntimePageOutput = ClientRuntimeTargetOutput &
+  Pick<BuildOutput["pages"][string], "path" | "routeId">;
+
 export type ClientRuntimeRouteOutput = Pick<
   BuildOutput["routes"][number],
   "id" | "path" | "pageId"
 >;
+
+export type ClientRuntimeRoutingOutput =
+  | {
+      kind: "spa";
+      routes: ClientRuntimeRouteOutput[];
+    }
+  | {
+      kind: "mpa";
+      pages: Record<string, ClientRuntimePageOutput>;
+    };
 
 export interface FrameworkRuntimeOutput {
   version: 1;
   buildId: string;
   publicPath: string;
   runtime: BuildOutput["runtime"];
-  pages: Record<string, FrameworkRuntimePage>;
-  routes: FrameworkRuntimeRoute[];
+  routing: FrameworkRuntimeRouting;
   server: {
     renderers?: Record<string, FrameworkRuntimeRenderer>;
   };
@@ -68,6 +79,16 @@ export type FrameworkRuntimeRoute = Pick<
   "id" | "path" | "pageId"
 >;
 
+export type FrameworkRuntimeRouting =
+  | {
+      kind: "spa";
+      routes: FrameworkRuntimeRoute[];
+    }
+  | {
+      kind: "mpa";
+      pages: Record<string, FrameworkRuntimePage>;
+    };
+
 export interface FrameworkRuntimeRenderer {
   kind: NonNullable<BuildOutput["server"]["renderers"]>[string]["kind"];
   owner?: FrameworkRuntimeOwner;
@@ -101,15 +122,27 @@ export function createClientRuntime(output: BuildOutput): ClientRuntimeOutput {
     buildId: output.buildId,
     runtime: createClientRuntimeRuntime(output.runtime),
     app: createClientRuntimeApp(output),
-    pages: Object.fromEntries(
-      Object.entries(output.pages).map(([id, page]) => [
-        id,
-        pruneUndefined({
-          mount: page.mount,
-          module: page.module,
-        }),
-      ]),
-    ),
+    routing: createClientRuntimeRouting(output),
+  });
+}
+
+function createClientRuntimeRouting(
+  output: BuildOutput,
+): ClientRuntimeRoutingOutput {
+  if (Object.keys(output.pages).length > 0) {
+    return {
+      kind: "mpa",
+      pages: Object.fromEntries(
+        Object.entries(output.pages).map(([id, page]) => [
+          id,
+          createClientRuntimePage(output, id, page),
+        ]),
+      ),
+    };
+  }
+
+  return {
+    kind: "spa",
     routes: output.routes.map((route) =>
       pruneUndefined({
         id: route.id,
@@ -117,6 +150,20 @@ export function createClientRuntime(output: BuildOutput): ClientRuntimeOutput {
         pageId: route.pageId,
       }),
     ),
+  };
+}
+
+function createClientRuntimePage(
+  output: BuildOutput,
+  id: string,
+  page: BuildOutput["pages"][string],
+): ClientRuntimePageOutput {
+  const route = findOutputRouteForPage(output, id);
+  return pruneUndefined({
+    mount: page.mount,
+    module: page.module,
+    path: page.path ?? route?.path,
+    routeId: page.routeId ?? route?.id,
   });
 }
 
@@ -153,43 +200,7 @@ export function createFrameworkRuntime(
     buildId: output.buildId,
     publicPath: output.publicPath,
     runtime: output.runtime,
-    pages: Object.fromEntries(
-      Object.entries(output.pages).map(([id, page]) => [
-        id,
-        pruneUndefined({
-          assets: page.assets,
-          render: page.render,
-          rendering: page.rendering,
-          path: page.path,
-          routeId: page.routeId,
-          componentModel: page.componentModel,
-          mount: page.mount,
-          ppr: page.ppr
-            ? {
-                delivery: page.ppr.delivery,
-                shell: page.ppr.shell,
-                regions: Object.fromEntries(
-                  Object.entries(page.ppr.regions).map(([regionId, region]) => [
-                    regionId,
-                    pruneUndefined({
-                      id: region.id,
-                      assets: region.assets,
-                      cache: region.cache,
-                    }),
-                  ]),
-                ),
-              }
-            : undefined,
-        }),
-      ]),
-    ),
-    routes: output.routes.map((route) =>
-      pruneUndefined({
-        id: route.id,
-        path: route.path,
-        pageId: route.pageId,
-      }),
-    ),
+    routing: createFrameworkRuntimeRouting(output),
     server: pruneUndefined({
       renderers: output.server.renderers
         ? Object.fromEntries(
@@ -206,6 +217,73 @@ export function createFrameworkRuntime(
     }),
     rsc: createFrameworkRuntimeRsc(output.rsc, options.rscManifests),
   });
+}
+
+function createFrameworkRuntimeRouting(
+  output: BuildOutput,
+): FrameworkRuntimeRouting {
+  if (Object.keys(output.pages).length === 0) {
+    return {
+      kind: "spa",
+      routes: output.routes.map((route) =>
+        pruneUndefined({
+          id: route.id,
+          path: route.path,
+          pageId: route.pageId,
+        }),
+      ),
+    };
+  }
+
+  return {
+    kind: "mpa",
+    pages: Object.fromEntries(
+      Object.entries(output.pages).map(([id, page]) => [
+        id,
+        createFrameworkRuntimePage(output, id, page),
+      ]),
+    ),
+  };
+}
+
+function createFrameworkRuntimePage(
+  output: BuildOutput,
+  id: string,
+  page: BuildOutput["pages"][string],
+): FrameworkRuntimePage {
+  const route = findOutputRouteForPage(output, id);
+  return pruneUndefined({
+    assets: page.assets,
+    render: page.render,
+    rendering: page.rendering,
+    path: page.path ?? route?.path,
+    routeId: page.routeId ?? route?.id,
+    componentModel: page.componentModel,
+    mount: page.mount,
+    ppr: page.ppr
+      ? {
+          delivery: page.ppr.delivery,
+          shell: page.ppr.shell,
+          regions: Object.fromEntries(
+            Object.entries(page.ppr.regions).map(([regionId, region]) => [
+              regionId,
+              pruneUndefined({
+                id: region.id,
+                assets: region.assets,
+                cache: region.cache,
+              }),
+            ]),
+          ),
+        }
+      : undefined,
+  });
+}
+
+function findOutputRouteForPage(
+  output: BuildOutput,
+  pageId: string,
+): BuildOutput["routes"][number] | undefined {
+  return output.routes.find((route) => route.pageId === pageId);
 }
 
 function createFrameworkRuntimeRsc(

--- a/packages/ev/src/framework-runtime.ts
+++ b/packages/ev/src/framework-runtime.ts
@@ -44,6 +44,7 @@ export interface FrameworkRuntimeOutput {
   publicPath: string;
   runtime: BuildOutput["runtime"];
   routing: FrameworkRuntimeRouting;
+  pages?: Record<string, FrameworkRuntimePage>;
   server: {
     renderers?: Record<string, FrameworkRuntimeRenderer>;
   };
@@ -129,7 +130,7 @@ export function createClientRuntime(output: BuildOutput): ClientRuntimeOutput {
 function createClientRuntimeRouting(
   output: BuildOutput,
 ): ClientRuntimeRoutingOutput {
-  if (Object.keys(output.pages).length > 0) {
+  if (!hasSpaRoutes(output) && Object.keys(output.pages).length > 0) {
     return {
       kind: "mpa",
       pages: Object.fromEntries(
@@ -195,12 +196,17 @@ export function createFrameworkRuntime(
   output: BuildOutput,
   options: FrameworkRuntimeOptions = {},
 ): FrameworkRuntimeOutput {
+  const routing = createFrameworkRuntimeRouting(output);
   return pruneUndefined({
     version: 1 as const,
     buildId: output.buildId,
     publicPath: output.publicPath,
     runtime: output.runtime,
-    routing: createFrameworkRuntimeRouting(output),
+    routing,
+    pages:
+      routing.kind === "spa" && Object.keys(output.pages).length > 0
+        ? createFrameworkRuntimePages(output)
+        : undefined,
     server: pruneUndefined({
       renderers: output.server.renderers
         ? Object.fromEntries(
@@ -219,10 +225,21 @@ export function createFrameworkRuntime(
   });
 }
 
+function createFrameworkRuntimePages(
+  output: BuildOutput,
+): Record<string, FrameworkRuntimePage> {
+  return Object.fromEntries(
+    Object.entries(output.pages).map(([id, page]) => [
+      id,
+      createFrameworkRuntimePage(output, id, page),
+    ]),
+  );
+}
+
 function createFrameworkRuntimeRouting(
   output: BuildOutput,
 ): FrameworkRuntimeRouting {
-  if (Object.keys(output.pages).length === 0) {
+  if (hasSpaRoutes(output) || Object.keys(output.pages).length === 0) {
     return {
       kind: "spa",
       routes: output.routes.map((route) =>
@@ -237,13 +254,12 @@ function createFrameworkRuntimeRouting(
 
   return {
     kind: "mpa",
-    pages: Object.fromEntries(
-      Object.entries(output.pages).map(([id, page]) => [
-        id,
-        createFrameworkRuntimePage(output, id, page),
-      ]),
-    ),
+    pages: createFrameworkRuntimePages(output),
   };
+}
+
+function hasSpaRoutes(output: BuildOutput): boolean {
+  return output.routes.some((route) => route.appId);
 }
 
 function createFrameworkRuntimePage(

--- a/packages/ev/src/index.ts
+++ b/packages/ev/src/index.ts
@@ -4,6 +4,7 @@
 
 export type * from "@evjs/shared/manifest";
 export {
+  createDeploymentMetadata,
   createPublicManifest,
   createServerManifest,
   getClientRouteMatches,
@@ -97,9 +98,7 @@ export {
   resolveConfig,
   type ServerConfig,
   type ServerDevConfig,
-  type ServerFnEntry,
   type ServerManifest,
-  type ServerRouteEntry,
   type ServerRoutingConfig,
   type ServerRscConfig,
   type TransportConfig,
@@ -109,12 +108,10 @@ export {
   createEdgeDeploymentFiles,
   createNodeDeploymentFiles,
   createStaticDeploymentFiles,
-  type DeploymentApp,
   type DeploymentArtifact,
   type DeploymentArtifactOptions,
-  type DeploymentPage,
+  type DeploymentDocument,
   type DeploymentRoute,
-  type DeploymentRsc,
   type DeploymentServer,
   type EdgeDeploymentAdapterOptions,
   type EdgeDeploymentFiles,

--- a/packages/ev/src/plugin.ts
+++ b/packages/ev/src/plugin.ts
@@ -6,6 +6,7 @@ import type {
 import { createServerManifest } from "@evjs/shared/manifest";
 import type { Logger } from "@logtape/logtape";
 import type { Config, DefaultBundlerConfig, ResolvedConfig } from "./config.js";
+import type { FrameworkRuntimeOutput } from "./framework-runtime.js";
 
 /**
  * Minimal DOM element / document interface for plugin HTML manipulation.
@@ -433,6 +434,8 @@ export interface EvBuildResult {
 export interface BuildResult extends EvBuildResult {
   /** Single framework build output. */
   output: BuildOutput;
+  /** Server runtime contract generated from BuildOutput plus runtime-only facts. */
+  frameworkRuntime?: FrameworkRuntimeOutput;
 }
 
 export type HtmlDocumentInfo =
@@ -482,9 +485,13 @@ const EMPTY_ASSETS: ManifestAssets = { js: [], css: [] };
 export function createBuildResult(
   output: BuildOutput,
   isRebuild: boolean,
+  options: { frameworkRuntime?: FrameworkRuntimeOutput } = {},
 ): BuildResult {
   return {
     output,
+    ...(options.frameworkRuntime
+      ? { frameworkRuntime: options.frameworkRuntime }
+      : {}),
     clientManifest: createClientManifest(output),
     serverManifest: createServerManifest(output),
     isRebuild,

--- a/packages/ev/src/plugin.ts
+++ b/packages/ev/src/plugin.ts
@@ -6,6 +6,7 @@ import type {
   PublicManifestOutput,
   PublicPageOutput,
   PublicRouteOutput,
+  ServerManifestOutput,
 } from "@evjs/shared/manifest";
 import {
   createDeploymentMetadata,
@@ -114,12 +115,7 @@ export type PageManifestEntry = PublicPageOutput;
 export type ClientManifest = PublicManifestOutput;
 
 /** Server-focused manifest view derived from the linked framework output. */
-export interface ServerManifest {
-  /** Schema version for this manifest view. */
-  version: 1;
-  /** Server bundle entry filename. */
-  entry?: string;
-}
+export type ServerManifest = ServerManifestOutput;
 
 /** Base context passed to plugin bundler hooks. */
 export interface EvBundlerCtx<TBundlerCfg = DefaultBundlerConfig> {

--- a/packages/ev/src/plugin.ts
+++ b/packages/ev/src/plugin.ts
@@ -2,8 +2,16 @@ import type {
   AssetGroup,
   BuildEnvironment,
   BuildOutput,
+  DeploymentMetadata,
+  PublicManifestOutput,
+  PublicPageOutput,
+  PublicRouteOutput,
 } from "@evjs/shared/manifest";
-import { createServerManifest } from "@evjs/shared/manifest";
+import {
+  createDeploymentMetadata,
+  createPublicManifest,
+  createServerManifest,
+} from "@evjs/shared/manifest";
 import type { Logger } from "@logtape/logtape";
 import type { Config, DefaultBundlerConfig, ResolvedConfig } from "./config.js";
 import type { FrameworkRuntimeOutput } from "./framework-runtime.js";
@@ -94,64 +102,16 @@ export interface HtmlDocument {
 }
 
 /** JavaScript and CSS assets exposed to plugin manifest views. */
-export interface ManifestAssets {
-  /** JavaScript bundle paths. */
-  js: string[];
-  /** CSS bundle paths. */
-  css: string[];
-}
+export type ManifestAssets = AssetGroup;
 
 /** A discovered client route exposed to plugin manifest views. */
-export interface RouteEntry {
-  /** Route path, e.g. "/", "/posts/$postId", or "*". */
-  path: string;
-}
+export type RouteEntry = PublicRouteOutput;
 
 /** Per-page client manifest entry exposed to plugin hooks. */
-export interface PageManifestEntry {
-  /** Bundle asset paths for this page. */
-  assets: ManifestAssets;
-  /** Discovered routes for this page. */
-  routes?: RouteEntry[];
-}
+export type PageManifestEntry = PublicPageOutput;
 
-/** Client-focused manifest view derived from the linked framework output. */
-export type ClientManifest = SpaClientManifest | MpaClientManifest;
-
-/** Shared client manifest fields exposed to plugin hooks. */
-export interface BaseClientManifest {
-  /** Schema version for this manifest view. */
-  version: 1;
-  /** Bundle asset paths for SPA HTML injection. */
-  assets: ManifestAssets;
-}
-
-/** SPA client manifest view exposed to plugin hooks. */
-export interface SpaClientManifest extends BaseClientManifest {
-  /** Client output shape. */
-  kind: "spa";
-  /** Discovered client routes. */
-  routes?: RouteEntry[];
-}
-
-/** MPA/page-output client manifest view exposed to plugin hooks. */
-export interface MpaClientManifest extends BaseClientManifest {
-  /** Client output shape. */
-  kind: "mpa";
-  /** Per-page assets for page-style outputs. */
-  pages: Record<string, PageManifestEntry>;
-}
-
-/** Server function id exposed to plugin manifest views. */
-export type ServerFnEntry = string;
-
-/** Server route entry exposed to plugin manifest views. */
-export interface ServerRouteEntry {
-  /** URL path pattern handled by this route. */
-  path: string;
-  /** HTTP methods explicitly handled by this route. */
-  methods: string[];
-}
+/** Client-focused deployment manifest view derived from the linked output. */
+export type ClientManifest = PublicManifestOutput;
 
 /** Server-focused manifest view derived from the linked framework output. */
 export interface ServerManifest {
@@ -159,10 +119,6 @@ export interface ServerManifest {
   version: 1;
   /** Server bundle entry filename. */
   entry?: string;
-  /** Registered server functions. */
-  functions: ServerFnEntry[];
-  /** Registered server route handlers. */
-  routes: ServerRouteEntry[];
 }
 
 /** Base context passed to plugin bundler hooks. */
@@ -383,11 +339,12 @@ export interface PluginHooks<TBundlerCfg = DefaultBundlerConfig>
     | ((ctx: BuildStartContext<TBundlerCfg>) => void | Promise<void>);
 
   /**
-   * Inspect or mutate the linked framework build output before it is emitted
-   * as the framework manifest and before HTML documents are transformed.
+   * Inspect or mutate the linked framework build output before deployment
+   * metadata is projected and before HTML documents are transformed.
    *
-   * Deployment adapters should use this hook to add deployment metadata to the
-   * BuildOutput emitted as `dist/build-output.json`.
+   * Deployment adapters should prefer buildEnd().deploymentMetadata for the
+   * canonical deployable artifact shape, and use this hook only when they need
+   * to add data to the in-memory BuildOutput before projection.
    */
   buildOutput?: (
     output: BuildOutput,
@@ -432,6 +389,8 @@ export interface EvBuildResult {
   clientManifest: ClientManifest;
   /** Server-focused manifest view derived from `output`. */
   serverManifest: ServerManifest;
+  /** Deployment metadata projection for adapters and tooling. */
+  deploymentMetadata: DeploymentMetadata;
   /** True if this is a rebuild triggered by file change (dev watch mode only). */
   isRebuild: boolean;
 }
@@ -488,8 +447,6 @@ export type BuildOutputHookContext<TBundlerCfg = DefaultBundlerConfig> =
 
 export type EvDocument = HtmlDocument;
 
-const EMPTY_ASSETS: ManifestAssets = { js: [], css: [] };
-
 export function createBuildResult(
   output: BuildOutput,
   isRebuild: boolean,
@@ -500,68 +457,9 @@ export function createBuildResult(
     ...(options.frameworkRuntime
       ? { frameworkRuntime: options.frameworkRuntime }
       : {}),
-    clientManifest: createClientManifest(output),
+    clientManifest: createPublicManifest(output),
     serverManifest: createServerManifest(output),
+    deploymentMetadata: createDeploymentMetadata(output),
     isRebuild,
-  };
-}
-
-function createClientManifest(output: BuildOutput): ClientManifest {
-  const pageEntries = Object.entries(output.pages).filter(
-    ([, page]) => page.document,
-  );
-  const routes = createRouteEntries(output);
-  if (pageEntries.length > 0) {
-    const pages = Object.fromEntries(
-      pageEntries.map(([pageId, page]) => {
-        const pageRoutes = createRouteEntries(output, pageId);
-        return [
-          pageId,
-          {
-            assets: cloneAssets(page.assets),
-            ...(pageRoutes.length > 0 ? { routes: pageRoutes } : {}),
-          },
-        ];
-      }),
-    );
-
-    return {
-      version: 1,
-      kind: "mpa",
-      assets: cloneAssets(EMPTY_ASSETS),
-      pages,
-    };
-  }
-
-  return {
-    version: 1,
-    kind: "spa",
-    assets: cloneAssets(getAppAssets(output)),
-    ...(routes.length > 0 ? { routes } : {}),
-  };
-}
-
-function createRouteEntries(
-  output: BuildOutput,
-  pageId?: string,
-): RouteEntry[] {
-  return output.routes
-    .filter((route) => pageId === undefined || route.pageId === pageId)
-    .map((route) => ({ path: route.path }));
-}
-
-function getAppAssets(output: BuildOutput): AssetGroup {
-  return (
-    output.apps.default?.assets ??
-    Object.values(output.apps)[0]?.assets ??
-    Object.values(output.assets)[0] ??
-    EMPTY_ASSETS
-  );
-}
-
-function cloneAssets(assets: AssetGroup): ManifestAssets {
-  return {
-    js: [...assets.js],
-    css: [...assets.css],
   };
 }

--- a/packages/ev/src/plugin.ts
+++ b/packages/ev/src/plugin.ts
@@ -116,15 +116,30 @@ export interface PageManifestEntry {
 }
 
 /** Client-focused manifest view derived from the linked framework output. */
-export interface ClientManifest {
+export type ClientManifest = SpaClientManifest | MpaClientManifest;
+
+/** Shared client manifest fields exposed to plugin hooks. */
+export interface BaseClientManifest {
   /** Schema version for this manifest view. */
   version: 1;
   /** Bundle asset paths for SPA HTML injection. */
   assets: ManifestAssets;
+}
+
+/** SPA client manifest view exposed to plugin hooks. */
+export interface SpaClientManifest extends BaseClientManifest {
+  /** Client output shape. */
+  kind: "spa";
   /** Discovered client routes. */
   routes?: RouteEntry[];
+}
+
+/** MPA/page-output client manifest view exposed to plugin hooks. */
+export interface MpaClientManifest extends BaseClientManifest {
+  /** Client output shape. */
+  kind: "mpa";
   /** Per-page assets for page-style outputs. */
-  pages?: Record<string, PageManifestEntry>;
+  pages: Record<string, PageManifestEntry>;
 }
 
 /** Server function id exposed to plugin manifest views. */
@@ -496,29 +511,33 @@ function createClientManifest(output: BuildOutput): ClientManifest {
     ([, page]) => page.document,
   );
   const routes = createRouteEntries(output);
-  const pages =
-    pageEntries.length > 0
-      ? Object.fromEntries(
-          pageEntries.map(([pageId, page]) => {
-            const pageRoutes = createRouteEntries(output, pageId);
-            return [
-              pageId,
-              {
-                assets: cloneAssets(page.assets),
-                ...(pageRoutes.length > 0 ? { routes: pageRoutes } : {}),
-              },
-            ];
-          }),
-        )
-      : undefined;
+  if (pageEntries.length > 0) {
+    const pages = Object.fromEntries(
+      pageEntries.map(([pageId, page]) => {
+        const pageRoutes = createRouteEntries(output, pageId);
+        return [
+          pageId,
+          {
+            assets: cloneAssets(page.assets),
+            ...(pageRoutes.length > 0 ? { routes: pageRoutes } : {}),
+          },
+        ];
+      }),
+    );
+
+    return {
+      version: 1,
+      kind: "mpa",
+      assets: cloneAssets(EMPTY_ASSETS),
+      pages,
+    };
+  }
 
   return {
     version: 1,
-    assets: pages
-      ? cloneAssets(EMPTY_ASSETS)
-      : cloneAssets(getAppAssets(output)),
+    kind: "spa",
+    assets: cloneAssets(getAppAssets(output)),
     ...(routes.length > 0 ? { routes } : {}),
-    ...(pages ? { pages } : {}),
   };
 }
 

--- a/packages/ev/src/plugin.ts
+++ b/packages/ev/src/plugin.ts
@@ -127,11 +127,8 @@ export interface ClientManifest {
   pages?: Record<string, PageManifestEntry>;
 }
 
-/** Server function entry exposed to plugin manifest views. */
-export interface ServerFnEntry {
-  /** Emitted assets containing this function. */
-  assets: ManifestAssets;
-}
+/** Server function id exposed to plugin manifest views. */
+export type ServerFnEntry = string;
 
 /** Server route entry exposed to plugin manifest views. */
 export interface ServerRouteEntry {
@@ -139,8 +136,6 @@ export interface ServerRouteEntry {
   path: string;
   /** HTTP methods explicitly handled by this route. */
   methods: string[];
-  /** Emitted assets containing this route handler. */
-  assets: ManifestAssets;
 }
 
 /** Server-focused manifest view derived from the linked framework output. */
@@ -149,10 +144,8 @@ export interface ServerManifest {
   version: 1;
   /** Server bundle entry filename. */
   entry?: string;
-  /** Server bundle asset paths. */
-  assets: ManifestAssets;
   /** Registered server functions. */
-  functions: Record<string, ServerFnEntry>;
+  functions: ServerFnEntry[];
   /** Registered server route handlers. */
   routes: ServerRouteEntry[];
 }

--- a/packages/ev/tests/build-tools-graph-plan.test.ts
+++ b/packages/ev/tests/build-tools-graph-plan.test.ts
@@ -4461,7 +4461,7 @@ describe("createAppGraph and createBuildPlan", () => {
     ]);
   });
 
-  it("keeps route-derived SSG pages on the SPA framework route", async () => {
+  it("emits static route-derived SSG pages as independent documents", async () => {
     const cwd = await createFixture({
       "src/pages/index.tsx": "export default function Home() { return null; }",
       "src/pages/pricing.tsx": `
@@ -4523,6 +4523,12 @@ describe("createAppGraph and createBuildPlan", () => {
         template: "./index.html",
         fileName: "index.html",
         owner: { appId: "default" },
+      },
+      {
+        id: "pricing",
+        template: "./index.html",
+        fileName: "pricing.html",
+        owner: { pageId: "pricing" },
       },
     ]);
   });

--- a/packages/ev/tests/build-tools-graph-plan.test.ts
+++ b/packages/ev/tests/build-tools-graph-plan.test.ts
@@ -3242,30 +3242,8 @@ describe("createAppGraph and createBuildPlan", () => {
         exportName: "saveInsight",
       },
     ]);
-    expect(output.rsc?.clientReferences).toEqual({
-      "src/pages/ClientCard.tsx#default": {
-        module: "src/pages/ClientCard.tsx",
-        exportName: "default",
-      },
-      "src/pages/ClientCard.tsx#ClientWidget": {
-        module: "src/pages/ClientCard.tsx",
-        exportName: "ClientWidget",
-      },
-      "src/pages/ClientCard.tsx#ClientNamespace": {
-        module: "src/pages/ClientCard.tsx",
-        exportName: "ClientNamespace",
-      },
-      "src/pages/ClientCard.tsx#client-widget": {
-        module: "src/pages/ClientCard.tsx",
-        exportName: "client-widget",
-      },
-    });
-    expect(output.rsc?.serverReferences).toEqual({
-      [hashServerFunction("src/actions.ts", "saveInsight")]: {
-        module: "src/actions.ts",
-        exportName: "saveInsight",
-      },
-    });
+    expect(output.rsc).not.toHaveProperty("clientReferences");
+    expect(output.rsc).not.toHaveProperty("serverReferences");
     expect(relativeFileDependencies(cwd, analysis.fileDependencies)).toEqual([
       "src/actions.ts",
       "src/pages/ClientCard.tsx",

--- a/packages/ev/tests/build-tools-graph-plan.test.ts
+++ b/packages/ev/tests/build-tools-graph-plan.test.ts
@@ -907,6 +907,7 @@ describe("createAppGraph and createBuildPlan", () => {
       environment: "server",
       runtime: "node",
       kind: "page-server",
+      phase: "build",
       owner: { pageId: "pricing", routeId: "pricing" },
     });
     expect(
@@ -1103,6 +1104,8 @@ describe("createAppGraph and createBuildPlan", () => {
   it("rejects build entry names that collide across client and server outputs", async () => {
     const cwd = await createFixture({
       "src/main.tsx": "console.log('app');",
+      "src/apis/health.ts":
+        "export const GET = async () => Response.json({ ok: true });",
       "index.html": '<div id="app"></div>',
     });
     const config = createConfig({
@@ -1110,6 +1113,19 @@ describe("createAppGraph and createBuildPlan", () => {
         server: {
           entry: "./src/main.tsx",
           html: "./index.html",
+        },
+      },
+      server: {
+        routing: {
+          dir: "./src/apis",
+          routes: [
+            {
+              id: "src/apis/health.ts:/health:GET",
+              module: "src/apis/health.ts",
+              path: "/health",
+              methods: ["GET"],
+            },
+          ],
         },
       },
     });
@@ -1177,7 +1193,7 @@ describe("createAppGraph and createBuildPlan", () => {
     );
   });
 
-  it("adds the server runtime entry", async () => {
+  it("omits the server runtime entry when no server surface is present", async () => {
     const cwd = await createFixture({
       "src/main.tsx": "console.log('app');",
     });
@@ -1191,16 +1207,10 @@ describe("createAppGraph and createBuildPlan", () => {
       mode: "production",
     });
 
-    expect(plan.server).toEqual({
-      entry: "@evjs/ev/internal/server/fetch",
-    });
-    expect(plan.entries).toContainEqual({
-      name: "server",
-      import: "@evjs/ev/internal/server/fetch",
-      environment: "server",
-      runtime: "node",
-      kind: "server-runtime",
-    });
+    expect(plan.server).toEqual({});
+    expect(
+      plan.entries.filter((entry) => entry.kind === "server-runtime"),
+    ).toEqual([]);
   });
 
   it("carries the RSC endpoint into the runtime plan", async () => {
@@ -1506,6 +1516,7 @@ describe("createAppGraph and createBuildPlan", () => {
           environment: "server",
           runtime: "node",
           kind: "page-server",
+          phase: "build",
           owner: { pageId: "pricing" },
         },
         {
@@ -1920,12 +1931,13 @@ describe("createAppGraph and createBuildPlan", () => {
     const plan = createBuildPlan(config, analysis.graph, {
       mode: "production",
     });
-    expect(plan.server.entry).toBe("@evjs/ev/internal/server/fetch");
+    expect(plan.server.entry).toBeUndefined();
     expect(plan.server.renderers).toEqual([
       {
         name: "pricing-server",
         import: "./src/pages/pricing.tsx",
         kind: "page-server",
+        phase: "build",
         owner: { pageId: "pricing" },
       },
     ]);
@@ -1938,8 +1950,12 @@ describe("createAppGraph and createBuildPlan", () => {
       environment: "server",
       runtime: "node",
       kind: "page-server",
+      phase: "build",
       owner: { pageId: "pricing" },
     });
+    expect(
+      plan.entries.filter((entry) => entry.kind === "server-runtime"),
+    ).toEqual([]);
     await expect(fs.access(path.join(cwd, ".evjs"))).rejects.toThrow();
   });
 
@@ -4510,6 +4526,7 @@ describe("createAppGraph and createBuildPlan", () => {
       environment: "server",
       runtime: "node",
       kind: "page-server",
+      phase: "build",
       owner: { pageId: "pricing", routeId: "pricing" },
     });
     expect(
@@ -4529,6 +4546,72 @@ describe("createAppGraph and createBuildPlan", () => {
         template: "./index.html",
         fileName: "pricing.html",
         owner: { pageId: "pricing" },
+      },
+    ]);
+  });
+
+  it("omits the SPA shell for static-only SSG routes", async () => {
+    const cwd = await createFixture({
+      "src/pages/report.tsx": `
+        export const render = "ssg";
+        export default function Report() { return null; }
+      `,
+      "index.html": '<div id="app"></div>',
+    });
+    const config = createConfig({
+      entry: "./src/pages/report.tsx",
+      routing: {
+        mode: "spa",
+        dir: "./src/pages",
+        entry: "./src/pages/report.tsx",
+        html: "./index.html",
+        mount: "#app",
+        routes: [
+          {
+            id: "report",
+            path: "/report",
+            module: "./src/pages/report.tsx",
+          },
+        ],
+      },
+    });
+
+    const analysis = await createAppGraph(config, cwd);
+    const plan = createBuildPlan(config, analysis.graph, {
+      mode: "production",
+    });
+
+    expect(plan.server.entry).toBeUndefined();
+    expect(plan.server.renderers).toEqual([
+      {
+        name: "report-server",
+        import: "./src/pages/report.tsx",
+        kind: "page-server",
+        phase: "build",
+        owner: { pageId: "report", routeId: "report" },
+      },
+    ]);
+    expect(plan.entries.filter((entry) => entry.kind === "app-client")).toEqual(
+      [],
+    );
+    expect(
+      plan.entries.filter((entry) => entry.kind === "server-runtime"),
+    ).toEqual([]);
+    expect(plan.entries).toContainEqual({
+      name: "report-server",
+      import: "./src/pages/report.tsx",
+      environment: "server",
+      runtime: "node",
+      kind: "page-server",
+      phase: "build",
+      owner: { pageId: "report", routeId: "report" },
+    });
+    expect(plan.html).toEqual([
+      {
+        id: "report",
+        template: "./index.html",
+        fileName: "report.html",
+        owner: { pageId: "report" },
       },
     ]);
   });

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -1497,9 +1497,10 @@ describe("build", () => {
       entry: "server.js",
       routes: [
         {
-          kind: "page-server",
+          kind: "server-page",
           path: "/dashboard",
           pageId: "dashboard",
+          render: "ssr",
           methods: ["GET", "HEAD"],
         },
       ],
@@ -1511,9 +1512,10 @@ describe("build", () => {
     expect(serverManifest).not.toContain("./src/pages/Dashboard.tsx");
     expect(buildOutputJson.server?.entry).toBe("server.js");
     expect(buildOutputJson.routes).toContainEqual({
-      kind: "page-server",
+      kind: "server-page",
       path: "/dashboard",
       pageId: "dashboard",
+      render: "ssr",
       methods: ["GET", "HEAD"],
     });
     expect("renderers" in (buildOutputJson.server ?? {})).toBe(false);

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -27,6 +27,19 @@ const devStartupTimeoutMs = 10_000;
 const devUpdateTimeoutMs = 10_000;
 const routeTypeCheckTimeoutMs = 30_000;
 
+interface EmbeddedClientRuntime {
+  runtime: {
+    server?: Record<string, unknown>;
+  };
+  app?: Record<string, unknown>;
+  routing: {
+    kind: string;
+    pages?: Record<string, Record<string, unknown>>;
+    routes?: Array<Record<string, unknown>>;
+  };
+  [key: string]: unknown;
+}
+
 async function createProject() {
   const cwd = await fs.promises.mkdtemp(path.join(os.tmpdir(), "evjs-"));
   await fs.promises.writeFile(
@@ -35,6 +48,16 @@ async function createProject() {
     "utf-8",
   );
   return cwd;
+}
+
+function readEmbeddedClientRuntime(html: string): EmbeddedClientRuntime {
+  const match = html.match(
+    /<script\b(?=[^>]*\bid="__EVJS_CLIENT_RUNTIME__")(?=[^>]*\btype="application\/json")[^>]*>([\s\S]*?)<\/script>/,
+  );
+  if (!match) {
+    throw new Error("Expected embedded client runtime script.");
+  }
+  return JSON.parse(match[1]) as EmbeddedClientRuntime;
 }
 
 async function createWorkspaceProject() {
@@ -451,6 +474,8 @@ describe("build", () => {
     const cwd = await createProject();
     const events: string[] = [];
     const bundler = createMockBundler(events);
+    const firstClientJs = (result: EvBuildResult) =>
+      Object.values(result.clientManifest.assets ?? {})[0]?.js[0] ?? "none";
     const plugin: EvPlugin<Record<string, never>> = {
       name: "manifest-result",
       setup() {
@@ -459,12 +484,12 @@ describe("build", () => {
             events.push("manifest:buildStart");
           },
           transformHtml(doc: HtmlDocument, result: EvBuildResult) {
-            events.push(`manifest:html:${result.clientManifest.assets.js[0]}`);
+            events.push(`manifest:html:${firstClientJs(result)}`);
             doc.head?.appendChild(doc.createComment(" manifest html "));
           },
           buildEnd(result: EvBuildResult) {
             events.push(
-              `manifest:buildEnd:${result.clientManifest.assets.js[0]}:${result.serverManifest.entry ?? "none"}`,
+              `manifest:buildEnd:${firstClientJs(result)}:${result.serverManifest.entry ?? "none"}`,
             );
           },
         };
@@ -479,9 +504,16 @@ describe("build", () => {
       },
     );
 
-    await expect(
-      fs.promises.readFile(path.join(cwd, "dist/index.html"), "utf-8"),
-    ).resolves.toContain("manifest html");
+    const html = await fs.promises.readFile(
+      path.join(cwd, "dist/index.html"),
+      "utf-8",
+    );
+    const clientRuntime = readEmbeddedClientRuntime(html);
+
+    expect(html).toContain("manifest html");
+    expect(clientRuntime.routing.kind).toBe("spa");
+    expect(clientRuntime).not.toHaveProperty("assets");
+    expect(fs.existsSync(path.join(cwd, "dist/runtime.json"))).toBe(false);
     expect(events).toEqual([
       "manifest:buildStart",
       "bundler.build",
@@ -1397,6 +1429,7 @@ describe("build", () => {
       {
         pages: {
           dashboard: {
+            path: "/dashboard",
             component: "./src/pages/Dashboard.tsx",
             html: "./index.html",
           },
@@ -1423,12 +1456,12 @@ describe("build", () => {
       path.join(cwd, "dist/client/manifest.json"),
       "utf-8",
     );
-    const clientRuntime = fs.readFileSync(
-      path.join(cwd, "dist/client/runtime.json"),
-      "utf-8",
-    );
     const serverManifest = fs.readFileSync(
       path.join(cwd, "dist/server/manifest.json"),
+      "utf-8",
+    );
+    const frameworkRuntime = fs.readFileSync(
+      path.join(cwd, "dist/server/framework-runtime.json"),
       "utf-8",
     );
     const buildOutput = fs.readFileSync(
@@ -1437,7 +1470,7 @@ describe("build", () => {
     );
     const publicManifestJson = JSON.parse(publicManifest);
     const serverManifestJson = JSON.parse(serverManifest);
-    const clientRuntimeJson = JSON.parse(clientRuntime);
+    const frameworkRuntimeJson = JSON.parse(frameworkRuntime);
     const buildOutputJson = JSON.parse(buildOutput);
 
     expect(rawOutputModules).toEqual(["react-component"]);
@@ -1452,53 +1485,33 @@ describe("build", () => {
         Object.keys(page as Record<string, unknown>),
       ),
     ).not.toEqual(expect.arrayContaining(["component", "source", "runtime"]));
-    expect(clientRuntime).not.toContain(".tsx");
-    expect(clientRuntime).not.toContain("server.js");
-    expect(clientRuntimeJson).not.toHaveProperty("publicPath");
-    expect(clientRuntimeJson).not.toHaveProperty("assets");
-    expect(clientRuntimeJson).not.toHaveProperty("pages");
-    expect(clientRuntimeJson).not.toHaveProperty("routes");
-    expect(clientRuntimeJson.routing.kind).toBe("mpa");
-    expect(Object.keys(clientRuntimeJson.runtime.server ?? {})).not.toEqual(
-      expect.arrayContaining(["basePath", "fn", "ppr"]),
-    );
-    expect(Object.keys(clientRuntimeJson.app ?? {})).not.toEqual(
-      expect.arrayContaining(["assets", "document", "entry"]),
-    );
-    expect(
-      Object.values(clientRuntimeJson.routing.pages).flatMap((page) =>
-        Object.keys(page as Record<string, unknown>),
-      ),
-    ).not.toEqual(
-      expect.arrayContaining([
-        "assets",
-        "document",
-        "render",
-        "rendering",
-        "path",
-        "routeId",
-        "componentModel",
-        "hydrate",
-        "ppr",
-      ]),
-    );
-    expect(clientRuntimeJson).not.toHaveProperty("rsc");
     expect(serverManifestJson).toEqual({
       version: 1,
       entry: "server.js",
-      functions: [],
-      routes: [],
     });
     expect(serverManifestJson.server).toBeUndefined();
     expect(serverManifest).not.toContain("./src/pages/Dashboard.tsx");
     expect(buildOutputJson.server?.entry).toBe("server.js");
-    expect(buildOutputJson.server?.renderers).toHaveProperty(
+    expect(buildOutputJson.routes).toContainEqual({
+      kind: "page-server",
+      path: "/dashboard",
+      pageId: "dashboard",
+      methods: ["GET", "HEAD"],
+    });
+    expect("renderers" in (buildOutputJson.server ?? {})).toBe(false);
+    expect(frameworkRuntimeJson.server?.renderers).toHaveProperty(
       "dashboard-server",
     );
     expect(buildOutput).not.toContain("./src/pages/Dashboard.tsx");
     expect(buildOutput).toContain("server.js");
     expect(fs.existsSync(path.join(cwd, "dist/manifest.json"))).toBe(false);
     expect(fs.existsSync(path.join(cwd, "dist/runtime.json"))).toBe(false);
+    expect(fs.existsSync(path.join(cwd, "dist/client/runtime.json"))).toBe(
+      false,
+    );
+    expect(fs.existsSync(path.join(cwd, "dist/server/runtime.json"))).toBe(
+      false,
+    );
     expect(fs.existsSync(path.join(cwd, "dist/build-output.json"))).toBe(true);
     expect(fs.existsSync(path.join(cwd, "dist/server/build-output.json"))).toBe(
       false,
@@ -1515,13 +1528,13 @@ describe("build", () => {
       true,
     );
     expect(fs.existsSync(path.join(cwd, "dist/client/runtime.json"))).toBe(
-      true,
+      false,
     );
 
     await build({ output: { client: "dist" } }, { cwd, bundler });
 
     expect(fs.existsSync(path.join(cwd, "dist/manifest.json"))).toBe(true);
-    expect(fs.existsSync(path.join(cwd, "dist/runtime.json"))).toBe(true);
+    expect(fs.existsSync(path.join(cwd, "dist/runtime.json"))).toBe(false);
     expect(fs.existsSync(path.join(cwd, "dist/client/manifest.json"))).toBe(
       false,
     );
@@ -2404,7 +2417,7 @@ describe("build", () => {
     );
     expect(events).toContain("bundler.build");
     expect(fs.existsSync(path.join(cwd, "dist/manifest.json"))).toBe(true);
-    expect(fs.existsSync(path.join(cwd, "dist/runtime.json"))).toBe(true);
+    expect(fs.existsSync(path.join(cwd, "dist/runtime.json"))).toBe(false);
     expect(fs.existsSync(path.join(cwd, "dist/server/manifest.json"))).toBe(
       true,
     );

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -474,8 +474,16 @@ describe("build", () => {
     const cwd = await createProject();
     const events: string[] = [];
     const bundler = createMockBundler(events);
-    const firstClientJs = (result: EvBuildResult) =>
-      Object.values(result.clientManifest.assets ?? {})[0]?.js[0] ?? "none";
+    const firstClientJs = (result: EvBuildResult) => {
+      const { clientManifest } = result;
+      if (clientManifest.routing.kind === "mpa") {
+        return (
+          Object.values(clientManifest.routing.pages)[0]?.assets.js[0] ?? "none"
+        );
+      }
+      const assets = "assets" in clientManifest ? clientManifest.assets : {};
+      return Object.values(assets ?? {})[0]?.js[0] ?? "none";
+    };
     const plugin: EvPlugin<Record<string, never>> = {
       name: "manifest-result",
       setup() {
@@ -1479,6 +1487,7 @@ describe("build", () => {
     expect(publicManifestJson).not.toHaveProperty("runtime");
     expect(publicManifestJson).not.toHaveProperty("pages");
     expect(publicManifestJson).not.toHaveProperty("routes");
+    expect(publicManifestJson).not.toHaveProperty("assets");
     expect(publicManifestJson.routing.kind).toBe("mpa");
     expect(
       Object.values(publicManifestJson.routing.pages).flatMap((page) =>
@@ -1488,8 +1497,19 @@ describe("build", () => {
     expect(serverManifestJson).toEqual({
       version: 1,
       entry: "server.js",
+      routes: [
+        {
+          kind: "page-server",
+          path: "/dashboard",
+          pageId: "dashboard",
+          methods: ["GET", "HEAD"],
+        },
+      ],
     });
     expect(serverManifestJson.server).toBeUndefined();
+    expect(serverManifestJson.assets).toBeUndefined();
+    expect(serverManifestJson.functions).toBeUndefined();
+    expect(serverManifestJson.renderers).toBeUndefined();
     expect(serverManifest).not.toContain("./src/pages/Dashboard.tsx");
     expect(buildOutputJson.server?.entry).toBe("server.js");
     expect(buildOutputJson.routes).toContainEqual({

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -1495,8 +1495,7 @@ describe("build", () => {
     expect(serverManifestJson).toEqual({
       version: 1,
       entry: "server.js",
-      assets: { js: ["server.js"], css: [] },
-      functions: {},
+      functions: [],
       routes: [],
     });
     expect(serverManifestJson.server).toBeUndefined();

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -1458,11 +1458,9 @@ describe("build", () => {
     expect(Object.keys(clientRuntimeJson.runtime.server ?? {})).not.toEqual(
       expect.arrayContaining(["basePath", "fn", "ppr"]),
     );
-    expect(
-      Object.values(clientRuntimeJson.apps).flatMap((app) =>
-        Object.keys(app as Record<string, unknown>),
-      ),
-    ).not.toEqual(expect.arrayContaining(["assets", "document", "entry"]));
+    expect(Object.keys(clientRuntimeJson.app ?? {})).not.toEqual(
+      expect.arrayContaining(["assets", "document", "entry"]),
+    );
     expect(
       Object.values(clientRuntimeJson.pages).flatMap((page) =>
         Object.keys(page as Record<string, unknown>),

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -5,7 +5,7 @@ import type { BuildPlan } from "@evjs/shared/manifest";
 import { execa } from "execa";
 import { describe, expect, it } from "vitest";
 import { PAGE_ROUTE_CONVENTION_SUMMARY } from "../src/build-tools/page-route-conventions.js";
-import type { BundlerAdapter } from "../src/bundler.js";
+import type { BundlerAdapter, BundlerBuildFacts } from "../src/bundler.js";
 import {
   type BuildResult,
   build,
@@ -142,7 +142,7 @@ function createMockBundler(
           main: { js: ["main.js"], css: [] },
         },
         firstClientEntryAssets: { js: ["main.js"], css: [] },
-        ...serverBuildFacts(),
+        ...serverBuildFacts(plan),
       };
     },
     async dev() {
@@ -151,13 +151,26 @@ function createMockBundler(
   };
 }
 
-function serverBuildFacts() {
+function serverBuildFacts(
+  plan: BuildPlan,
+): Pick<
+  BundlerBuildFacts,
+  "serverEntryAssets" | "serverEntry" | "serverAssets"
+> {
+  const serverRuntimeEntry = plan.entries.find(
+    (entry) => entry.kind === "server-runtime",
+  );
+  if (!serverRuntimeEntry) return {};
+
   return {
     serverEntryAssets: {
-      server: { js: ["server.js"], css: [] },
+      [serverRuntimeEntry.name]: {
+        js: [`${serverRuntimeEntry.name}.js`],
+        css: [],
+      },
     },
-    serverEntry: "server.js",
-    serverAssets: { js: ["server.js"], css: [] },
+    serverEntry: `${serverRuntimeEntry.name}.js`,
+    serverAssets: { js: [`${serverRuntimeEntry.name}.js`], css: [] },
   };
 }
 
@@ -421,8 +434,8 @@ describe("build", () => {
       "setup:production",
       "buildStart",
       "bundler.build",
-      "bundler.entries:main,server",
-      "buildOutput:main,server",
+      "bundler.entries:main",
+      "buildOutput:main",
       "buildEnd:main.patched.js",
       "dispose:production",
     ]);
@@ -465,7 +478,7 @@ describe("build", () => {
     expect(fs.existsSync(path.join(cwd, "dist/runtime.json"))).toBe(false);
     expect(events).toEqual([
       "bundler.build",
-      "bundler.entries:main,server",
+      "bundler.entries:main",
       "buildOutput",
       "dispose",
     ]);
@@ -477,7 +490,10 @@ describe("build", () => {
     const bundler = createMockBundler(events);
     const firstClientJs = (result: EvBuildResult) => {
       const { clientManifest } = result;
-      if (clientManifest.routing.kind === "mpa") {
+      if (
+        "routing" in clientManifest &&
+        clientManifest.routing.kind === "mpa"
+      ) {
         return (
           Object.values(clientManifest.routing.pages)[0]?.assets.js[0] ?? "none"
         );
@@ -526,9 +542,9 @@ describe("build", () => {
     expect(events).toEqual([
       "manifest:buildStart",
       "bundler.build",
-      "bundler.entries:main,server",
+      "bundler.entries:main",
       "manifest:html:main.js",
-      "manifest:buildEnd:main.js:server.js",
+      "manifest:buildEnd:main.js:none",
     ]);
   });
 
@@ -536,17 +552,13 @@ describe("build", () => {
     const cwd = await createProject();
     const bundler: BundlerAdapter<Record<string, never>> = {
       name: "mock-crossorigin-assets",
-      async build() {
+      async build({ plan }) {
         return {
           clientEntryAssets: {
             main: { js: ["main.js"], css: ["main.css"] },
           },
           firstClientEntryAssets: { js: ["main.js"], css: ["main.css"] },
-          serverEntryAssets: {
-            server: { js: ["server.js"], css: [] },
-          },
-          serverEntry: "server.js",
-          serverAssets: { js: ["server.js"], css: [] },
+          ...serverBuildFacts(plan),
         };
       },
       async dev() {},
@@ -608,7 +620,7 @@ describe("build", () => {
       "entry:evjs:pages-app",
       "metadata:pages-app",
       "bundler.build",
-      "bundler.entries:main,server",
+      "bundler.entries:main",
     ]);
     expect(fs.existsSync(path.join(cwd, ".evjs"))).toBe(false);
     await expect(
@@ -1024,7 +1036,7 @@ describe("build", () => {
       "entry:evjs:pages-app",
       "metadata:pages-app",
       "bundler.build",
-      "bundler.entries:main,server",
+      "bundler.entries:main",
     ]);
   });
 
@@ -1209,7 +1221,7 @@ describe("build", () => {
             about: { js: ["about.js"], css: [] },
           },
           firstClientEntryAssets: { js: ["index.js"], css: [] },
-          ...serverBuildFacts(),
+          ...serverBuildFacts(plan),
         };
       },
       async dev() {},
@@ -1229,8 +1241,8 @@ describe("build", () => {
     );
 
     expect(events).toEqual([
-      "entries:index:page-client,about:page-client,server:server-runtime",
-      "metadata:react-component-page,react-component-page,none",
+      "entries:index:page-client,about:page-client",
+      "metadata:react-component-page,react-component-page",
       "html:index:./index.html,about:./src/pages/about.html",
     ]);
     expect(fs.existsSync(path.join(cwd, ".evjs"))).toBe(false);
@@ -1265,7 +1277,7 @@ describe("build", () => {
             product: { js: ["product.js"], css: [] },
           },
           firstClientEntryAssets: { js: ["product.js"], css: [] },
-          ...serverBuildFacts(),
+          ...serverBuildFacts(plan),
         };
       },
       async dev() {},
@@ -1367,13 +1379,13 @@ describe("build", () => {
     const events: string[] = [];
     const bundler: BundlerAdapter<Record<string, never>> = {
       name: "memory-output",
-      async build() {
+      async build({ plan }) {
         return {
           clientEntryAssets: {
             main: { js: ["memory.js"], css: [] },
           },
           firstClientEntryAssets: { js: ["memory.js"], css: [] },
-          ...serverBuildFacts(),
+          ...serverBuildFacts(plan),
         };
       },
       async dev() {},
@@ -1418,18 +1430,19 @@ describe("build", () => {
     let frameworkRuntime: BuildResult["frameworkRuntime"];
     const bundler: BundlerAdapter<Record<string, never>> = {
       name: "memory-output",
-      async build() {
+      async build({ plan }) {
+        const serverFacts = serverBuildFacts(plan);
         return {
           clientEntryAssets: {
             dashboard: { js: ["dashboard.js"], css: [] },
           },
           firstClientEntryAssets: { js: ["dashboard.js"], css: [] },
           serverEntryAssets: {
-            server: { js: ["server.js"], css: [] },
+            ...serverFacts.serverEntryAssets,
             "dashboard-server": { js: ["dashboard-server.js"], css: [] },
           },
-          serverEntry: "server.js",
-          serverAssets: { js: ["server.js"], css: [] },
+          serverEntry: serverFacts.serverEntry,
+          serverAssets: serverFacts.serverAssets,
         };
       },
       async dev() {},
@@ -1555,32 +1568,24 @@ describe("build", () => {
 
     const bundler: BundlerAdapter<Record<string, never>> = {
       name: "ssg-mock",
-      async build({ cwd, plan }) {
-        const serverDir = path.resolve(cwd, plan.output.serverDir);
-        await fs.promises.mkdir(serverDir, { recursive: true });
-        await fs.promises.writeFile(
-          path.join(serverDir, "server.js"),
-          'export default { fetch() { return new Response("ok"); } };',
-          "utf-8",
-        );
-        await fs.promises.writeFile(
-          path.join(serverDir, "report-server.js"),
-          [
-            "export function render(ctx) {",
-            "  return '<main data-page=\"' + ctx.pageId + '\"><h1>Prerendered Report</h1><p>' + ctx.request.url + '</p></main>';",
-            "}",
-          ].join("\n"),
-          "utf-8",
-        );
+      async build() {
         return {
           clientEntryAssets: {},
           firstClientEntryAssets: { js: [], css: [] },
-          serverEntry: "server.js",
           serverEntryAssets: {
-            server: { js: ["server.js"], css: [] },
             "report-server": { js: ["report-server.js"], css: [] },
           },
-          serverAssets: { js: ["server.js"], css: [] },
+          serverAssets: { js: [], css: [] },
+          async loadServerModule(asset) {
+            if (asset !== "report-server.js") {
+              throw new Error(`Unexpected server module asset: ${asset}`);
+            }
+            return {
+              render(ctx: { pageId: string; request: Request }) {
+                return `<main data-page="${ctx.pageId}"><h1>Prerendered Report</h1><p>${ctx.request.url}</p></main>`;
+              },
+            };
+          },
         };
       },
       async dev() {
@@ -1613,13 +1618,17 @@ describe("build", () => {
     expect(html).toContain("Prerendered Report");
     expect(html).toContain("http://evjs.local/report");
     expect(html).not.toMatch(/<script[^>]+src=/);
-    expect(buildOutput.routes).toContainEqual({
-      kind: "static-page",
+    expect(html).not.toContain("__EVJS_CLIENT_RUNTIME__");
+    expect(buildOutput.server).toEqual({});
+    expect(buildOutput.documents).toContainEqual({
+      kind: "page",
+      id: "report",
+      fileName: "report.html",
       path: "/report",
-      documentId: "report",
       render: "ssg",
-      methods: ["GET", "HEAD"],
     });
+    expect(buildOutput.routes).toEqual([]);
+    expect(fs.existsSync(path.join(cwd, "dist/server"))).toBe(false);
   });
 
   it("removes stale split client manifests when rebuilding with flat client output", async () => {
@@ -1679,7 +1688,7 @@ describe("build", () => {
       "config:production",
       "setup:/api/fn",
       "bundler.build",
-      "bundler.entries:main,server",
+      "bundler.entries:main",
       "bundler.endpoint:/api/fn",
     ]);
   });
@@ -1833,7 +1842,7 @@ describe("build", () => {
       "setup",
       "buildStart",
       "bundler.build",
-      "bundler.entries:main,server",
+      "bundler.entries:main",
     ]);
   });
 
@@ -3308,7 +3317,7 @@ describe("build", () => {
       "buildStart:a",
       "buildStart:b",
       "bundler.build",
-      "bundler.entries:main,server",
+      "bundler.entries:main",
       "buildEnd:a",
       "buildEnd:b",
     ]);
@@ -3352,7 +3361,7 @@ describe("build", () => {
       "setup:plugin-c",
       "setup:plugin-a",
       "bundler.build",
-      "bundler.entries:main,server",
+      "bundler.entries:main",
     ]);
   });
 
@@ -3398,7 +3407,7 @@ describe("build", () => {
       "setup:normal",
       "setup:post",
       "bundler.build",
-      "bundler.entries:main,server",
+      "bundler.entries:main",
     ]);
   });
 
@@ -3446,7 +3455,7 @@ describe("build", () => {
       "setup:plugin-a",
       "setup:plugin-b",
       "bundler.build",
-      "bundler.entries:main,server",
+      "bundler.entries:main",
     ]);
   });
 
@@ -3485,7 +3494,7 @@ describe("build", () => {
       "setup:plugin-c",
       "setup:plugin-b",
       "bundler.build",
-      "bundler.entries:main,server",
+      "bundler.entries:main",
     ]);
   });
 

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -1373,7 +1373,7 @@ describe("build", () => {
       "utf-8",
     );
 
-    const rawOutputComponents: Array<string | undefined> = [];
+    const rawOutputModules: Array<string | undefined> = [];
     const bundler: BundlerAdapter<Record<string, never>> = {
       name: "memory-output",
       async build() {
@@ -1407,8 +1407,8 @@ describe("build", () => {
             setup() {
               return {
                 buildEnd(result) {
-                  rawOutputComponents.push(
-                    result.output.pages.dashboard.component,
+                  rawOutputModules.push(
+                    result.output.pages.dashboard.module?.type,
                   );
                 },
               };
@@ -1440,7 +1440,7 @@ describe("build", () => {
     const clientRuntimeJson = JSON.parse(clientRuntime);
     const buildOutputJson = JSON.parse(buildOutput);
 
-    expect(rawOutputComponents).toEqual(["./src/pages/Dashboard.tsx"]);
+    expect(rawOutputModules).toEqual(["react-component"]);
     expect(publicManifest).not.toContain(".tsx");
     expect(publicManifest).not.toContain("server.js");
     expect(publicManifestJson).not.toHaveProperty("runtime");
@@ -1507,7 +1507,7 @@ describe("build", () => {
     expect(buildOutputJson.server?.renderers).toHaveProperty(
       "dashboard-server",
     );
-    expect(buildOutput).toContain("./src/pages/Dashboard.tsx");
+    expect(buildOutput).not.toContain("./src/pages/Dashboard.tsx");
     expect(buildOutput).toContain("server.js");
     expect(fs.existsSync(path.join(cwd, "dist/manifest.json"))).toBe(false);
     expect(fs.existsSync(path.join(cwd, "dist/runtime.json"))).toBe(false);

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -1541,6 +1541,87 @@ describe("build", () => {
     );
   });
 
+  it("prerenders SSG page HTML during production builds", async () => {
+    const cwd = await createProject();
+    await fs.promises.mkdir(path.join(cwd, "src/pages"), { recursive: true });
+    await fs.promises.writeFile(
+      path.join(cwd, "src/pages/Report.tsx"),
+      [
+        'export const render = "ssg";',
+        "export default function Report() { return null; }",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const bundler: BundlerAdapter<Record<string, never>> = {
+      name: "ssg-mock",
+      async build({ cwd, plan }) {
+        const serverDir = path.resolve(cwd, plan.output.serverDir);
+        await fs.promises.mkdir(serverDir, { recursive: true });
+        await fs.promises.writeFile(
+          path.join(serverDir, "server.js"),
+          'export default { fetch() { return new Response("ok"); } };',
+          "utf-8",
+        );
+        await fs.promises.writeFile(
+          path.join(serverDir, "report-server.js"),
+          [
+            "export function render(ctx) {",
+            "  return '<main data-page=\"' + ctx.pageId + '\"><h1>Prerendered Report</h1><p>' + ctx.request.url + '</p></main>';",
+            "}",
+          ].join("\n"),
+          "utf-8",
+        );
+        return {
+          clientEntryAssets: {},
+          firstClientEntryAssets: { js: [], css: [] },
+          serverEntry: "server.js",
+          serverEntryAssets: {
+            server: { js: ["server.js"], css: [] },
+            "report-server": { js: ["report-server.js"], css: [] },
+          },
+          serverAssets: { js: ["server.js"], css: [] },
+        };
+      },
+      async dev() {
+        return undefined;
+      },
+    };
+
+    await build(
+      {
+        pages: {
+          report: {
+            path: "/report",
+            component: "./src/pages/Report.tsx",
+            html: "./index.html",
+            mount: "#app",
+          },
+        },
+      },
+      { cwd, bundler },
+    );
+
+    const html = fs.readFileSync(
+      path.join(cwd, "dist/client/report.html"),
+      "utf-8",
+    );
+    const buildOutput = JSON.parse(
+      fs.readFileSync(path.join(cwd, "dist/build-output.json"), "utf-8"),
+    );
+
+    expect(html).toContain("Prerendered Report");
+    expect(html).toContain("http://evjs.local/report");
+    expect(html).not.toMatch(/<script[^>]+src=/);
+    expect(buildOutput.routes).toContainEqual({
+      kind: "static-page",
+      path: "/report",
+      documentId: "report",
+      render: "ssg",
+      methods: ["GET", "HEAD"],
+    });
+  });
+
   it("removes stale split client manifests when rebuilding with flat client output", async () => {
     const cwd = await createProject();
     const events: string[] = [];
@@ -2413,7 +2494,9 @@ describe("build", () => {
     await fs.promises.writeFile(
       path.join(cwd, "src/pages/campaign.tsx"),
       [
-        'export const render = "ssg";',
+        'export const render = "ssr";',
+        'export const hydrate = "none";',
+        "export const prerender = true;",
         "export default function Campaign() { return null; }",
       ].join("\n"),
       "utf-8",

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { PAGE_ROUTE_CONVENTION_SUMMARY } from "../src/build-tools/page-route-conventions.js";
 import type { BundlerAdapter } from "../src/bundler.js";
 import {
+  type BuildResult,
   build,
   type Config,
   dev,
@@ -1414,6 +1415,7 @@ describe("build", () => {
     );
 
     const rawOutputModules: Array<string | undefined> = [];
+    let frameworkRuntime: BuildResult["frameworkRuntime"];
     const bundler: BundlerAdapter<Record<string, never>> = {
       name: "memory-output",
       async build() {
@@ -1451,6 +1453,7 @@ describe("build", () => {
                   rawOutputModules.push(
                     result.output.pages.dashboard.module?.type,
                   );
+                  frameworkRuntime = result.frameworkRuntime;
                 },
               };
             },
@@ -1468,17 +1471,12 @@ describe("build", () => {
       path.join(cwd, "dist/server/manifest.json"),
       "utf-8",
     );
-    const frameworkRuntime = fs.readFileSync(
-      path.join(cwd, "dist/server/framework-runtime.json"),
-      "utf-8",
-    );
     const buildOutput = fs.readFileSync(
       path.join(cwd, "dist/build-output.json"),
       "utf-8",
     );
     const publicManifestJson = JSON.parse(publicManifest);
     const serverManifestJson = JSON.parse(serverManifest);
-    const frameworkRuntimeJson = JSON.parse(frameworkRuntime);
     const buildOutputJson = JSON.parse(buildOutput);
 
     expect(rawOutputModules).toEqual(["react-component"]);
@@ -1519,7 +1517,7 @@ describe("build", () => {
       methods: ["GET", "HEAD"],
     });
     expect("renderers" in (buildOutputJson.server ?? {})).toBe(false);
-    expect(frameworkRuntimeJson.server?.renderers).toHaveProperty(
+    expect(frameworkRuntime?.server?.renderers).toHaveProperty(
       "dashboard-server",
     );
     expect(buildOutput).not.toContain("./src/pages/Dashboard.tsx");
@@ -1532,6 +1530,9 @@ describe("build", () => {
     expect(fs.existsSync(path.join(cwd, "dist/server/runtime.json"))).toBe(
       false,
     );
+    expect(
+      fs.existsSync(path.join(cwd, "dist/server/framework-runtime.json")),
+    ).toBe(false);
     expect(fs.existsSync(path.join(cwd, "dist/build-output.json"))).toBe(true);
     expect(fs.existsSync(path.join(cwd, "dist/server/build-output.json"))).toBe(
       false,

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -1444,17 +1444,21 @@ describe("build", () => {
     expect(publicManifest).not.toContain(".tsx");
     expect(publicManifest).not.toContain("server.js");
     expect(publicManifestJson).not.toHaveProperty("runtime");
+    expect(publicManifestJson).not.toHaveProperty("pages");
+    expect(publicManifestJson).not.toHaveProperty("routes");
+    expect(publicManifestJson.routing.kind).toBe("mpa");
     expect(
-      publicManifestJson.routes.flatMap((route: Record<string, unknown>) =>
-        Object.keys(route),
+      Object.values(publicManifestJson.routing.pages).flatMap((page) =>
+        Object.keys(page as Record<string, unknown>),
       ),
-    ).not.toEqual(
-      expect.arrayContaining(["module", "render", "hydrate", "runtime"]),
-    );
+    ).not.toEqual(expect.arrayContaining(["component", "source", "runtime"]));
     expect(clientRuntime).not.toContain(".tsx");
     expect(clientRuntime).not.toContain("server.js");
     expect(clientRuntimeJson).not.toHaveProperty("publicPath");
     expect(clientRuntimeJson).not.toHaveProperty("assets");
+    expect(clientRuntimeJson).not.toHaveProperty("pages");
+    expect(clientRuntimeJson).not.toHaveProperty("routes");
+    expect(clientRuntimeJson.routing.kind).toBe("mpa");
     expect(Object.keys(clientRuntimeJson.runtime.server ?? {})).not.toEqual(
       expect.arrayContaining(["basePath", "fn", "ppr"]),
     );
@@ -1462,7 +1466,7 @@ describe("build", () => {
       expect.arrayContaining(["assets", "document", "entry"]),
     );
     expect(
-      Object.values(clientRuntimeJson.pages).flatMap((page) =>
+      Object.values(clientRuntimeJson.routing.pages).flatMap((page) =>
         Object.keys(page as Record<string, unknown>),
       ),
     ).not.toEqual(
@@ -1479,19 +1483,6 @@ describe("build", () => {
       ]),
     );
     expect(clientRuntimeJson).not.toHaveProperty("rsc");
-    expect(
-      clientRuntimeJson.routes.flatMap((route: Record<string, unknown>) =>
-        Object.keys(route),
-      ),
-    ).not.toEqual(
-      expect.arrayContaining([
-        "parentId",
-        "kind",
-        "render",
-        "hydrate",
-        "runtime",
-      ]),
-    );
     expect(serverManifestJson).toEqual({
       version: 1,
       entry: "server.js",

--- a/packages/ev/tests/deployment.test.ts
+++ b/packages/ev/tests/deployment.test.ts
@@ -142,7 +142,8 @@ describe("createDeploymentArtifact", () => {
           kind: "server-page",
           path: "/insights",
           pageId: "insights",
-          render: "rsc",
+          render: "ssr",
+          rsc: true,
           methods: ["GET", "HEAD"],
         },
         {
@@ -669,7 +670,7 @@ describe("createDeploymentArtifact", () => {
     expect(files.redirects).toBe("\n");
   });
 
-  it("does not create static redirects for route-owned SSG pages without emitted documents", () => {
+  it("creates static redirects for route-owned SSG pages with emitted documents", () => {
     const output: BuildOutput = {
       version: 1,
       buildId: "build-1",
@@ -695,6 +696,7 @@ describe("createDeploymentArtifact", () => {
       pages: {
         pricing: {
           assets: { js: [], css: [] },
+          document: { fileName: "pricing.html" },
           render: "ssg",
           rendering: {
             component: "server",
@@ -726,7 +728,9 @@ describe("createDeploymentArtifact", () => {
       includeAssets: false,
     });
 
-    expect(files.redirects).toBe(["/* /index.html 200", ""].join("\n"));
+    expect(files.redirects).toBe(
+      ["/pricing /pricing.html 200", "/* /index.html 200", ""].join("\n"),
+    );
   });
 
   it("creates Edge deployment files from BuildOutput", () => {

--- a/packages/ev/tests/deployment.test.ts
+++ b/packages/ev/tests/deployment.test.ts
@@ -136,47 +136,32 @@ describe("createDeploymentArtifact", () => {
         serverDir: "dist/server",
       },
       publicPath: "auto",
-      app: {
-        mount: "#app",
-      },
-      pages: {
-        insights: {
-          path: "/insights",
-          routeId: "insights",
-          render: "ssr",
-          componentModel: "rsc",
-          hydrate: "none",
-          mount: "#app",
-        },
-      },
+      documents: [],
       routes: [
         {
-          id: "insights",
+          kind: "page-server",
           path: "/insights",
           pageId: "insights",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "framework-function",
+          path: "/framework/fn",
+          methods: ["POST"],
+        },
+        {
+          kind: "framework-rsc",
+          path: "/framework/rsc",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "server-route",
+          path: "/api/webhooks/payment",
+          methods: ["POST"],
         },
       ],
       server: {
         entry: "server.js",
-        basePath: "/framework",
-        fn: "/framework/fn",
-        ppr: "/framework/ppr",
-        rsc: "/framework/rsc",
-        transport: {
-          baseUrl: "https://api.example.com",
-        },
-        renderers: ["insights-rsc"],
-        functions: ["search"],
-        routes: [
-          {
-            path: "/api/webhooks/payment",
-            methods: ["POST"],
-          },
-        ],
-      },
-      rsc: {
-        endpoint: "/framework/rsc",
-        pages: ["insights"],
       },
       metadata: {
         extra: true,

--- a/packages/ev/tests/deployment.test.ts
+++ b/packages/ev/tests/deployment.test.ts
@@ -34,7 +34,11 @@ describe("createDeploymentArtifact", () => {
     const output: BuildOutput = {
       version: 1,
       buildId: "build-1",
-      distDir: "dist",
+      paths: {
+        rootDir: "dist",
+        publicDir: "dist/client",
+        serverDir: "dist/server",
+      },
       publicPath: "auto",
       runtime: {
         server: {
@@ -53,7 +57,6 @@ describe("createDeploymentArtifact", () => {
       apps: {
         default: {
           assets: { js: ["main.js"], css: ["main.css"] },
-          entry: "./src/main.tsx",
           mount: "#app",
         },
       },
@@ -70,7 +73,6 @@ describe("createDeploymentArtifact", () => {
           },
           path: "/insights",
           routeId: "insights",
-          component: "./src/pages/Insights.tsx",
           hydrate: "none",
           mount: "#app",
         },
@@ -89,13 +91,11 @@ describe("createDeploymentArtifact", () => {
           "insights-rsc": {
             kind: "rsc-page",
             owner: { pageId: "insights" },
-            module: "./src/pages/Insights.tsx",
             assets: { js: ["insights-rsc.js"], css: [] },
           },
         },
         functions: {
           search: {
-            module: "src/actions.ts",
             exportName: "search",
             assets: { js: ["server.js"], css: [] },
           },
@@ -109,23 +109,10 @@ describe("createDeploymentArtifact", () => {
         ],
       },
       rsc: {
-        endpoint: "/framework/rsc",
         pages: {
           insights: {
             renderer: "insights-rsc",
             assets: { js: ["insights-rsc.js"], css: [] },
-          },
-        },
-        clientReferences: {
-          "src/Client.tsx#default": {
-            module: "src/Client.tsx",
-            exportName: "default",
-          },
-        },
-        serverReferences: {
-          ref: {
-            module: "src/actions.ts",
-            exportName: "search",
           },
         },
       },
@@ -143,7 +130,6 @@ describe("createDeploymentArtifact", () => {
       version: 1,
       platform: "node-example",
       buildId: "build-1",
-      distDir: "dist",
       paths: {
         rootDir: "dist",
         publicDir: "dist/client",
@@ -152,8 +138,6 @@ describe("createDeploymentArtifact", () => {
       publicPath: "auto",
       apps: {
         default: {
-          entry: "./src/main.tsx",
-          routes: undefined,
           mount: "#app",
         },
       },
@@ -196,8 +180,6 @@ describe("createDeploymentArtifact", () => {
       rsc: {
         endpoint: "/framework/rsc",
         pages: ["insights"],
-        clientReferences: ["src/Client.tsx#default"],
-        serverReferences: ["ref"],
       },
       metadata: {
         extra: true,
@@ -209,7 +191,11 @@ describe("createDeploymentArtifact", () => {
     const output: BuildOutput = {
       version: 1,
       buildId: "build-1",
-      distDir: "dist",
+      paths: {
+        rootDir: "dist",
+        publicDir: "dist/client",
+        serverDir: "dist/server",
+      },
       publicPath: "/",
       runtime: {
         server: {
@@ -222,7 +208,6 @@ describe("createDeploymentArtifact", () => {
       apps: {
         default: {
           assets: { js: ["main.js"], css: [] },
-          entry: "./src/main.tsx",
         },
       },
       pages: {
@@ -306,7 +291,11 @@ describe("createDeploymentArtifact", () => {
     const output: BuildOutput = {
       version: 1,
       buildId: "build-1",
-      distDir: "dist",
+      paths: {
+        rootDir: "dist",
+        publicDir: "dist/client",
+        serverDir: "dist/server",
+      },
       publicPath: "/",
       runtime: {
         server: {
@@ -319,7 +308,6 @@ describe("createDeploymentArtifact", () => {
         default: {
           assets: { js: ["main.js"], css: [] },
           document: { fileName: "index.html" },
-          entry: "./src/main.tsx",
         },
       },
       pages: {
@@ -503,7 +491,11 @@ describe("createDeploymentArtifact", () => {
     const output: BuildOutput = {
       version: 1,
       buildId: "build-1",
-      distDir: "dist",
+      paths: {
+        rootDir: "dist",
+        publicDir: "dist/client",
+        serverDir: "dist/server",
+      },
       publicPath: "/",
       runtime: {
         server: {
@@ -518,7 +510,6 @@ describe("createDeploymentArtifact", () => {
         default: {
           assets: { js: ["main.js"], css: [] },
           document: { fileName: "index.html" },
-          entry: "./src/main.tsx",
         },
       },
       pages: {
@@ -594,7 +585,6 @@ describe("createDeploymentArtifact", () => {
         renderers: {},
         functions: {
           search: {
-            module: "src/actions.ts",
             exportName: "search",
             assets: { js: ["server.js"], css: [] },
           },
@@ -608,15 +598,12 @@ describe("createDeploymentArtifact", () => {
         ],
       },
       rsc: {
-        endpoint: "/framework/rsc",
         pages: {
           insights: {
             renderer: "insights-rsc",
             assets: { js: ["insights-rsc.js"], css: [] },
           },
         },
-        clientReferences: {},
-        serverReferences: {},
       },
     };
 
@@ -644,7 +631,11 @@ describe("createDeploymentArtifact", () => {
     const output: BuildOutput = {
       version: 1,
       buildId: "build-1",
-      distDir: "dist",
+      paths: {
+        rootDir: "dist",
+        publicDir: "dist/client",
+        serverDir: "dist/server",
+      },
       publicPath: "/",
       runtime: {
         server: {
@@ -699,7 +690,11 @@ describe("createDeploymentArtifact", () => {
     const output: BuildOutput = {
       version: 1,
       buildId: "build-1",
-      distDir: "dist",
+      paths: {
+        rootDir: "dist",
+        publicDir: "dist/client",
+        serverDir: "dist/server",
+      },
       publicPath: "/",
       runtime: {
         server: {
@@ -712,7 +707,6 @@ describe("createDeploymentArtifact", () => {
         default: {
           assets: { js: ["main.js"], css: [] },
           document: { fileName: "index.html" },
-          entry: "./src/main.tsx",
         },
       },
       pages: {
@@ -756,7 +750,11 @@ describe("createDeploymentArtifact", () => {
     const output: BuildOutput = {
       version: 1,
       buildId: "build-1",
-      distDir: "dist",
+      paths: {
+        rootDir: "dist",
+        publicDir: "dist/client",
+        serverDir: "dist/server",
+      },
       publicPath: "/",
       runtime: {
         server: {
@@ -769,7 +767,6 @@ describe("createDeploymentArtifact", () => {
       apps: {
         default: {
           assets: { js: ["main.js"], css: [] },
-          entry: "./src/main.tsx",
         },
       },
       pages: {
@@ -914,7 +911,11 @@ function createMpaStaticDeploymentOutput(): BuildOutput {
   return {
     version: 1,
     buildId: "build-1",
-    distDir: "dist",
+    paths: {
+      rootDir: "dist",
+      publicDir: "dist/client",
+      serverDir: "dist/server",
+    },
     publicPath: "/",
     runtime: {
       server: {
@@ -1001,7 +1002,6 @@ function createServerDeploymentOutput(paths: {
   return {
     version: 1,
     buildId: "build-1",
-    distDir: paths.rootDir,
     paths,
     publicPath: "/",
     runtime: {
@@ -1014,7 +1014,6 @@ function createServerDeploymentOutput(paths: {
     apps: {
       default: {
         assets: { js: ["main.js"], css: [] },
-        entry: "./src/main.tsx",
       },
     },
     pages: {},

--- a/packages/ev/tests/deployment.test.ts
+++ b/packages/ev/tests/deployment.test.ts
@@ -139,23 +139,24 @@ describe("createDeploymentArtifact", () => {
       documents: [],
       routes: [
         {
-          kind: "page-server",
+          kind: "server-page",
           path: "/insights",
           pageId: "insights",
+          render: "rsc",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "framework-function",
+          kind: "server-function",
           path: "/framework/fn",
           methods: ["POST"],
         },
         {
-          kind: "framework-rsc",
+          kind: "rsc-endpoint",
           path: "/framework/rsc",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "server-route",
+          kind: "api-route",
           path: "/api/webhooks/payment",
           methods: ["POST"],
         },

--- a/packages/ev/tests/deployment.test.ts
+++ b/packages/ev/tests/deployment.test.ts
@@ -136,10 +136,8 @@ describe("createDeploymentArtifact", () => {
         serverDir: "dist/server",
       },
       publicPath: "auto",
-      apps: {
-        default: {
-          mount: "#app",
-        },
+      app: {
+        mount: "#app",
       },
       pages: {
         insights: {
@@ -155,7 +153,6 @@ describe("createDeploymentArtifact", () => {
         {
           id: "insights",
           path: "/insights",
-          appId: undefined,
           pageId: "insights",
         },
       ],

--- a/packages/ev/tests/package-surface.test.ts
+++ b/packages/ev/tests/package-surface.test.ts
@@ -140,6 +140,7 @@ const allowedSampleBundlerDependencies = {
   "@evjs/bundler-webpack": [
     "examples/deployment-adapters",
     "examples/render-modes",
+    "examples/ssg",
   ],
 } as const satisfies Record<string, readonly string[]>;
 

--- a/packages/server/src/framework.ts
+++ b/packages/server/src/framework.ts
@@ -549,27 +549,36 @@ function assertFrameworkRuntimeRouting(
   routes: FrameworkRouteRuntime[];
 } {
   if (value.routing !== undefined) {
-    if (value.pages !== undefined || value.routes !== undefined) {
+    if (value.routes !== undefined) {
       throw new Error(
-        `[evjs] ${source} must not define both routing and pages/routes.`,
+        `[evjs] ${source} must not define both routing and routes.`,
       );
     }
     assertObject(value.routing, `${source}.routing`);
     if (value.routing.kind === "spa") {
+      const pages =
+        value.pages === undefined
+          ? {}
+          : assertFrameworkRuntimePageRecord(value.pages, `${source}.pages`);
       if (!Array.isArray(value.routing.routes)) {
         throw new Error(`[evjs] ${source}.routing.routes must be an array.`);
       }
       assertFrameworkRuntimeRoutes(
         value.routing.routes,
         `${source}.routing.routes`,
-        {},
+        pages,
       );
       return {
-        pages: {},
+        pages,
         routes: value.routing.routes as FrameworkRouteRuntime[],
       };
     }
     if (value.routing.kind === "mpa") {
+      if (value.pages !== undefined) {
+        throw new Error(
+          `[evjs] ${source} must not define both routing.kind "mpa" and pages.`,
+        );
+      }
       assertObject(value.routing.pages, `${source}.routing.pages`);
       assertFrameworkRuntimePages(
         value.routing.pages,
@@ -596,6 +605,15 @@ function assertFrameworkRuntimeRouting(
     pages: value.pages,
     routes: value.routes as FrameworkRouteRuntime[],
   };
+}
+
+function assertFrameworkRuntimePageRecord(
+  value: unknown,
+  source: string,
+): Record<string, unknown> {
+  assertObject(value, source);
+  assertFrameworkRuntimePages(value, source);
+  return value;
 }
 
 function assertBuildIdentifier(value: unknown, source: string): void {

--- a/packages/server/src/framework.ts
+++ b/packages/server/src/framework.ts
@@ -33,8 +33,11 @@ export interface FrameworkRuntime {
     server: FrameworkRuntimeServer;
     transport?: FrameworkRuntimeTransport;
   };
-  pages: Record<string, FrameworkPageRuntime>;
-  routes: FrameworkRouteRuntime[];
+  routing?: FrameworkRuntimeRouting;
+  /** @deprecated Use routing.kind === "mpa".pages. */
+  pages?: Record<string, FrameworkPageRuntime>;
+  /** @deprecated Use routing.kind === "spa".routes or page route metadata. */
+  routes?: FrameworkRouteRuntime[];
   server: FrameworkServerRuntime;
   rsc?: FrameworkRscRuntime;
 }
@@ -91,6 +94,16 @@ export interface FrameworkRouteRuntime {
   path: string;
   pageId?: string;
 }
+
+export type FrameworkRuntimeRouting =
+  | {
+      kind: "spa";
+      routes: FrameworkRouteRuntime[];
+    }
+  | {
+      kind: "mpa";
+      pages: Record<string, FrameworkPageRuntime>;
+    };
 
 export interface FrameworkServerRuntime {
   renderers?: Record<string, FrameworkServerRenderer>;
@@ -490,12 +503,7 @@ export function assertFrameworkRuntime(
       `${source}.runtime.transport.baseUrl`,
     );
   }
-  assertObject(value.pages, `${source}.pages`);
-  assertFrameworkRuntimePages(value.pages, `${source}.pages`);
-  if (!Array.isArray(value.routes)) {
-    throw new Error(`[evjs] ${source}.routes must be an array.`);
-  }
-  assertFrameworkRuntimeRoutes(value.routes, `${source}.routes`, value.pages);
+  const { pages, routes } = assertFrameworkRuntimeRouting(value, source);
   assertObject(value.server, `${source}.server`);
   if (
     value.server.renderers !== undefined &&
@@ -507,13 +515,87 @@ export function assertFrameworkRuntime(
     assertFrameworkRuntimeRenderers(
       value.server.renderers,
       `${source}.server.renderers`,
-      value.pages,
-      value.routes,
+      pages,
+      routes,
     );
   }
   if (value.rsc !== undefined) {
-    assertFrameworkRuntimeRsc(value.rsc, `${source}.rsc`, value.pages);
+    assertFrameworkRuntimeRsc(value.rsc, `${source}.rsc`, pages);
   }
+}
+
+export function getFrameworkRuntimePages(
+  runtime: FrameworkRuntime,
+): Record<string, FrameworkPageRuntime> {
+  if (runtime.routing?.kind === "mpa") return runtime.routing.pages;
+  return runtime.pages ?? {};
+}
+
+export function getFrameworkRuntimeRoutes(
+  runtime: FrameworkRuntime,
+): FrameworkRouteRuntime[] {
+  if (runtime.routing?.kind === "spa") return runtime.routing.routes;
+  if (runtime.routing?.kind === "mpa") {
+    return createRoutesFromFrameworkPages(runtime.routing.pages);
+  }
+  return runtime.routes ?? [];
+}
+
+function assertFrameworkRuntimeRouting(
+  value: Record<string, unknown>,
+  source: string,
+): {
+  pages: Record<string, unknown>;
+  routes: FrameworkRouteRuntime[];
+} {
+  if (value.routing !== undefined) {
+    if (value.pages !== undefined || value.routes !== undefined) {
+      throw new Error(
+        `[evjs] ${source} must not define both routing and pages/routes.`,
+      );
+    }
+    assertObject(value.routing, `${source}.routing`);
+    if (value.routing.kind === "spa") {
+      if (!Array.isArray(value.routing.routes)) {
+        throw new Error(`[evjs] ${source}.routing.routes must be an array.`);
+      }
+      assertFrameworkRuntimeRoutes(
+        value.routing.routes,
+        `${source}.routing.routes`,
+        {},
+      );
+      return {
+        pages: {},
+        routes: value.routing.routes as FrameworkRouteRuntime[],
+      };
+    }
+    if (value.routing.kind === "mpa") {
+      assertObject(value.routing.pages, `${source}.routing.pages`);
+      assertFrameworkRuntimePages(
+        value.routing.pages,
+        `${source}.routing.pages`,
+      );
+      const routes = createRoutesFromFrameworkPages(value.routing.pages);
+      assertFrameworkRuntimeRoutes(
+        routes,
+        `${source}.routing.pages`,
+        value.routing.pages,
+      );
+      return { pages: value.routing.pages, routes };
+    }
+    throw new Error(`[evjs] ${source}.routing.kind must be "spa" or "mpa".`);
+  }
+
+  assertObject(value.pages, `${source}.pages`);
+  assertFrameworkRuntimePages(value.pages, `${source}.pages`);
+  if (!Array.isArray(value.routes)) {
+    throw new Error(`[evjs] ${source}.routes must be an array.`);
+  }
+  assertFrameworkRuntimeRoutes(value.routes, `${source}.routes`, value.pages);
+  return {
+    pages: value.pages,
+    routes: value.routes as FrameworkRouteRuntime[],
+  };
 }
 
 function assertBuildIdentifier(value: unknown, source: string): void {
@@ -571,6 +653,24 @@ function assertFrameworkRuntimePages(
       assertPprPageRuntimeContract(page, pageSource);
     }
   }
+}
+
+function createRoutesFromFrameworkPages(
+  pages: Record<string, unknown>,
+): FrameworkRouteRuntime[] {
+  return Object.entries(pages).flatMap(([pageId, page]) => {
+    if (!isRecord(page)) return [];
+    if (typeof page.path !== "string" || typeof page.routeId !== "string") {
+      return [];
+    }
+    return [
+      {
+        id: page.routeId,
+        path: page.path,
+        pageId,
+      },
+    ];
+  });
 }
 
 function assertPageRendering(value: unknown, source: string): void {
@@ -1089,9 +1189,11 @@ export async function handleFrameworkRenderRequest(
   }
 
   const url = new URL(request.url);
-  const route = matchRoute(options.runtime.routes, url.pathname);
+  const routes = getFrameworkRuntimeRoutes(options.runtime);
+  const pages = getFrameworkRuntimePages(options.runtime);
+  const route = matchRoute(routes, url.pathname);
   const pageId = route?.pageId ?? inferPageId(options.runtime, url.pathname);
-  const page = pageId ? options.runtime.pages[pageId] : undefined;
+  const page = pageId ? pages[pageId] : undefined;
 
   if (!route && !page) return undefined;
 
@@ -1202,7 +1304,7 @@ export async function handlePprRegionRequest(
   }
   if (!match) return undefined;
 
-  const page = options.runtime.pages[match.pageId];
+  const page = getFrameworkRuntimePages(options.runtime)[match.pageId];
   if (!page?.ppr) return undefined;
   const region = page.ppr?.regions[match.regionId];
   if (!region) return undefined;
@@ -1226,7 +1328,9 @@ async function renderPprPageResponse(
   coordinator: ServerRenderCoordinator,
 ): Promise<Response> {
   const pageId = ctx.pageId;
-  const page = pageId ? options.runtime.pages[pageId] : undefined;
+  const page = pageId
+    ? getFrameworkRuntimePages(options.runtime)[pageId]
+    : undefined;
   if (!pageId || !page?.ppr) {
     return request.method === "HEAD" ? withoutResponseBody(response) : response;
   }
@@ -1270,7 +1374,7 @@ async function renderPprMergedPageResponse(
   response: Response,
   coordinator: ServerRenderCoordinator,
 ): Promise<Response> {
-  const page = options.runtime.pages[pageId];
+  const page = getFrameworkRuntimePages(options.runtime)[pageId];
   if (!page?.ppr) return response;
 
   let html = await response.text();
@@ -1322,7 +1426,7 @@ async function renderPprStreamingPageResponse(
   response: Response,
   coordinator: ServerRenderCoordinator,
 ): Promise<Response> {
-  const page = options.runtime.pages[pageId];
+  const page = getFrameworkRuntimePages(options.runtime)[pageId];
   if (!page?.ppr) return response;
 
   const html = await response.text();
@@ -1380,7 +1484,7 @@ async function renderPprRegionResponse(
   match: PprRegionMatch,
   coordinator: ServerRenderCoordinator,
 ): Promise<Response | undefined> {
-  const page = options.runtime.pages[match.pageId];
+  const page = getFrameworkRuntimePages(options.runtime)[match.pageId];
   if (!page?.ppr) return undefined;
   const region = page.ppr?.regions[match.regionId];
   if (!region) return undefined;
@@ -1443,7 +1547,7 @@ async function renderFreshPprRegionResponse(
   match: PprRegionMatch,
   coordinator: ServerRenderCoordinator,
 ): Promise<Response | undefined> {
-  const page = options.runtime.pages[match.pageId];
+  const page = getFrameworkRuntimePages(options.runtime)[match.pageId];
   if (!page?.ppr) return undefined;
   const ctx: ServerRenderContext = {
     request,
@@ -1576,7 +1680,7 @@ function createRscFlightPageContext(
   "pageUrl" | "pageId" | "page" | "rscPage" | "renderer"
 > {
   const pageId = url.searchParams.get("page") ?? undefined;
-  const page = pageId ? runtime.pages[pageId] : undefined;
+  const page = pageId ? getFrameworkRuntimePages(runtime)[pageId] : undefined;
   const rscPage = pageId ? runtime.rsc?.pages?.[pageId] : undefined;
   const renderer = rscPage?.renderer
     ? runtime.server?.renderers?.[rscPage.renderer]
@@ -1607,7 +1711,7 @@ function withPprRegionPageUrl(
   match: PprRegionMatch,
   url: URL,
 ): PprRegionMatch {
-  const page = runtime.pages[match.pageId];
+  const page = getFrameworkRuntimePages(runtime)[match.pageId];
   const explicitPageUrl = resolvePprRegionPageUrl(url);
   const pageUrl =
     explicitPageUrl ?? inferStaticPprRegionPageUrl(runtime, match, page, url);
@@ -1652,7 +1756,7 @@ function getPprRegionPagePaths(
   pageId: string,
   page: FrameworkPageRuntime | undefined,
 ): string[] {
-  const routePaths = runtime.routes
+  const routePaths = getFrameworkRuntimeRoutes(runtime)
     .filter((route) => route.pageId === pageId)
     .map((route) => route.path);
   return routePaths.length > 0 ? routePaths : page?.path ? [page.path] : [];
@@ -1764,7 +1868,9 @@ function pageUrlMatchesPage(
   pageUrl: string,
 ): boolean {
   const pathname = normalizeRoutePathname(new URL(pageUrl).pathname);
-  const pageRoutes = runtime.routes.filter((route) => route.pageId === pageId);
+  const pageRoutes = getFrameworkRuntimeRoutes(runtime).filter(
+    (route) => route.pageId === pageId,
+  );
 
   if (pageRoutes.length > 0) {
     return pageRoutes.some((route) =>
@@ -2054,12 +2160,13 @@ function inferPageId(
   const normalized = normalizeRoutePathname(pathname);
   const directId = normalized === "/" ? "index" : normalized.slice(1);
   const withoutHtml = directId.replace(/\.html$/, "");
+  const pages = getFrameworkRuntimePages(runtime);
 
-  if (runtime.pages[withoutHtml]) return withoutHtml;
-  if (runtime.pages[directId]) return directId;
+  if (pages[withoutHtml]) return withoutHtml;
+  if (pages[directId]) return directId;
 
   const dotted = withoutHtml.replaceAll("/", ".");
-  return runtime.pages[dotted] ? dotted : undefined;
+  return pages[dotted] ? dotted : undefined;
 }
 
 function matchPprRegion(

--- a/packages/server/src/react-renderer.ts
+++ b/packages/server/src/react-renderer.ts
@@ -18,6 +18,7 @@ import type {
   RscCoordinator,
   RscFlightContext,
 } from "./framework.js";
+import { getFrameworkRuntimeRoutes } from "./framework.js";
 import { textResponse } from "./responses.js";
 import {
   formatUnknownError,
@@ -568,7 +569,7 @@ function findRouteForPage(
 ): { id: string; path: string } | undefined {
   if (!pageId) return undefined;
 
-  const pageRoutes = runtime.routes.filter(
+  const pageRoutes = getFrameworkRuntimeRoutes(runtime).filter(
     (candidate) => candidate.pageId === pageId,
   );
   const route = pathname

--- a/packages/server/tests/app.test.ts
+++ b/packages/server/tests/app.test.ts
@@ -2,6 +2,8 @@ import { ServerError } from "@evjs/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../src/app.js";
 import type {
+  FrameworkPageRuntime,
+  FrameworkRouteRuntime,
   FrameworkRuntime,
   PprRegionCacheEntry,
   ServerRenderContext,
@@ -16,6 +18,11 @@ import {
 } from "../src/functions/register.js";
 import { requestLogger } from "../src/index.js";
 import { createReactFrameworkServer } from "../src/react.js";
+
+type LegacyFrameworkRuntime = FrameworkRuntime & {
+  pages: Record<string, FrameworkPageRuntime>;
+  routes: FrameworkRouteRuntime[];
+};
 
 describe("createApp", () => {
   beforeEach(() => {
@@ -3757,7 +3764,7 @@ describe("createApp", () => {
   });
 });
 
-function createManifest(): FrameworkRuntime {
+function createManifest(): LegacyFrameworkRuntime {
   return {
     version: 1,
     buildId: "test",
@@ -3800,7 +3807,7 @@ function createManifest(): FrameworkRuntime {
   };
 }
 
-function configureRscManifest(manifest: FrameworkRuntime): void {
+function configureRscManifest(manifest: LegacyFrameworkRuntime): void {
   configureRscPage(manifest);
   manifest.rsc = {
     pages: {
@@ -3827,7 +3834,7 @@ function configureRscManifest(manifest: FrameworkRuntime): void {
 }
 
 function addRscManifestPage(
-  manifest: FrameworkRuntime,
+  manifest: LegacyFrameworkRuntime,
   options: {
     pageId: string;
     path: string;
@@ -3873,7 +3880,7 @@ function addRscManifestPage(
   };
 }
 
-function configureRscPage(manifest: FrameworkRuntime): void {
+function configureRscPage(manifest: LegacyFrameworkRuntime): void {
   manifest.pages.dashboard.render = "ssr";
   manifest.pages.dashboard.componentModel = "rsc";
   manifest.pages.dashboard.rendering = {
@@ -3884,7 +3891,7 @@ function configureRscPage(manifest: FrameworkRuntime): void {
   };
 }
 
-function configurePprRendering(manifest: FrameworkRuntime): void {
+function configurePprRendering(manifest: LegacyFrameworkRuntime): void {
   const delivery = manifest.pages.dashboard.ppr?.delivery ?? "merge";
   manifest.pages.dashboard.rendering = {
     component: "server",

--- a/packages/server/tests/context.test.ts
+++ b/packages/server/tests/context.test.ts
@@ -9,12 +9,21 @@ import {
   setCookie,
   waitUntil,
 } from "../src/context.js";
-import type { FrameworkRuntime } from "../src/framework.js";
+import type {
+  FrameworkPageRuntime,
+  FrameworkRouteRuntime,
+  FrameworkRuntime,
+} from "../src/framework.js";
 import {
   registerServerReference,
   registry,
 } from "../src/functions/register.js";
 import { createRoute } from "../src/routes/index.js";
+
+type LegacyFrameworkRuntime = FrameworkRuntime & {
+  pages: Record<string, FrameworkPageRuntime>;
+  routes: FrameworkRouteRuntime[];
+};
 
 describe("Server Request Context", () => {
   beforeEach(() => {
@@ -225,7 +234,7 @@ describe("Server Request Context", () => {
   });
 });
 
-function createFrameworkManifest(): FrameworkRuntime {
+function createFrameworkManifest(): LegacyFrameworkRuntime {
   return {
     version: 1,
     buildId: "test",
@@ -268,7 +277,7 @@ function createFrameworkManifest(): FrameworkRuntime {
   };
 }
 
-function configurePprManifest(manifest: FrameworkRuntime): void {
+function configurePprManifest(manifest: LegacyFrameworkRuntime): void {
   manifest.pages.dashboard.ppr = {
     delivery: "merge",
     shell: { js: ["dashboard-ppr-shell.js"], css: [] },
@@ -288,7 +297,7 @@ function configurePprManifest(manifest: FrameworkRuntime): void {
   };
 }
 
-function configureRscManifest(manifest: FrameworkRuntime): void {
+function configureRscManifest(manifest: LegacyFrameworkRuntime): void {
   manifest.pages.dashboard.componentModel = "rsc";
   manifest.pages.dashboard.rendering = {
     component: "rsc",

--- a/packages/server/tests/react-renderer.test.ts
+++ b/packages/server/tests/react-renderer.test.ts
@@ -9,6 +9,8 @@ import {
 import { describe, expect, it } from "vitest";
 import {
   assertFrameworkRuntime,
+  type FrameworkPageRuntime,
+  type FrameworkRouteRuntime,
   type FrameworkRuntime,
 } from "../src/framework.js";
 import {
@@ -21,6 +23,11 @@ interface PageProps {
   search: Record<string, unknown>;
   loaderData: unknown;
 }
+
+type LegacyFrameworkRuntime = FrameworkRuntime & {
+  pages: Record<string, FrameworkPageRuntime>;
+  routes: FrameworkRouteRuntime[];
+};
 
 interface PageProviderProps {
   value: PageProps;
@@ -1094,7 +1101,7 @@ describe("createReactRscFlightAdapter", () => {
   });
 });
 
-function createManifest(): FrameworkRuntime {
+function createManifest(): LegacyFrameworkRuntime {
   return {
     version: 1,
     buildId: "test",

--- a/packages/shared/src/manifest/index.ts
+++ b/packages/shared/src/manifest/index.ts
@@ -477,6 +477,7 @@ export type DeploymentDocumentOutput =
       kind: "app";
       id: string;
       fileName: string;
+      fallback?: string;
       assets?: AssetGroup;
     }
   | {
@@ -486,42 +487,40 @@ export type DeploymentDocumentOutput =
       assets?: AssetGroup;
     };
 
+export type DeploymentPageRenderOutput = RenderMode | "ppr" | "rsc";
+
 export type DeploymentRouteOutput =
   | {
-      kind: "static-document";
+      kind: "static-page";
       path: string;
       documentId: string;
+      render: Extract<DeploymentPageRenderOutput, "csr" | "ssg">;
       methods: ["GET", "HEAD"];
     }
   | {
-      kind: "spa-fallback";
-      path: string;
-      documentId: string;
-      methods: ["GET", "HEAD"];
-    }
-  | {
-      kind: "page-server";
+      kind: "server-page";
       path: string;
       pageId: string;
+      render: Exclude<DeploymentPageRenderOutput, "csr">;
       methods: ["GET", "HEAD"];
     }
   | {
-      kind: "framework-function";
+      kind: "server-function";
       path: string;
       methods: ["POST"];
     }
   | {
-      kind: "framework-ppr";
+      kind: "ppr-endpoint";
       path: string;
       methods: ["GET", "HEAD"];
     }
   | {
-      kind: "framework-rsc";
+      kind: "rsc-endpoint";
       path: string;
       methods: ["GET", "HEAD"];
     }
   | {
-      kind: "server-route";
+      kind: "api-route";
       path: string;
       methods: string[];
     };

--- a/packages/shared/src/manifest/index.ts
+++ b/packages/shared/src/manifest/index.ts
@@ -3,10 +3,10 @@
  *
  * Shared manifest schemas for the ev framework build system.
  *
- * Bundler adapters emit framework manifests under the configured output
- * directories. By default, the public client manifest is written to
- * `dist/client/manifest.json`, the server bundle manifest to
- * `dist/server/manifest.json`, and the full private BuildOutput handoff to
+ * Bundler adapters emit framework metadata under the configured output
+ * directories. By default, the lightweight client deployment manifest is
+ * written to `dist/client/manifest.json`, the entry-only server manifest to
+ * `dist/server/manifest.json`, and canonical deployment metadata to
  * `dist/build-output.json`. `output.client` and `output.server` can point to
  * alternate directories when an adapter or deployment target needs a different
  * artifact layout.
@@ -335,9 +335,7 @@ export interface PublicManifestOutput {
   buildId: string;
   publicPath: PublicPathOutput;
   assets?: Record<string, AssetGroup>;
-  app?: PublicAppOutput;
   routing: PublicRoutingOutput;
-  rsc?: PublicRscOutput;
 }
 
 export type PublicRoutingOutput =
@@ -379,10 +377,6 @@ export interface AppOutput {
   module?: RuntimeModuleOutput;
 }
 
-export interface PublicAppOutput extends Omit<AppOutput, "module"> {
-  module?: PublicRuntimeModuleOutput;
-}
-
 export interface PageOutput {
   assets: AssetGroup;
   document?: HtmlDocumentOutput;
@@ -398,9 +392,11 @@ export interface PageOutput {
   ppr?: PprPageOutput;
 }
 
-export interface PublicPageOutput extends Omit<PageOutput, "module" | "ppr"> {
-  module?: PublicRuntimeModuleOutput;
-  ppr?: PublicPprPageOutput;
+export interface PublicPageOutput {
+  assets: AssetGroup;
+  document?: HtmlDocumentOutput;
+  path?: string;
+  routeId?: string;
 }
 
 export interface HtmlDocumentOutput {
@@ -426,10 +422,6 @@ export interface PprPageOutput {
   regions: Record<string, PprRegionOutput>;
 }
 
-export interface PublicPprPageOutput extends Omit<PprPageOutput, "regions"> {
-  regions: Record<string, PublicPprRegionOutput>;
-}
-
 export interface PprRegionOutput {
   id: string;
   assets: AssetGroup;
@@ -437,14 +429,10 @@ export interface PprRegionOutput {
   hydrate?: HydrationMode;
 }
 
-export type PublicPprRegionOutput = PprRegionOutput;
-
 export interface RuntimeModuleOutput {
   type: "entry" | "lifecycle" | "react-component";
   href?: string;
 }
-
-export type PublicRuntimeModuleOutput = RuntimeModuleOutput;
 
 export interface RouteOutput {
   id: string;
@@ -456,6 +444,76 @@ export interface RouteOutput {
 }
 
 export type PublicRouteOutput = Pick<RouteOutput, "id" | "path" | "pageId">;
+
+export interface DeploymentMetadata {
+  version: 1;
+  buildId: string;
+  paths: BuildOutputPaths;
+  publicPath: PublicPathOutput;
+  assets?: Record<string, AssetGroup>;
+  documents: DeploymentDocumentOutput[];
+  routes: DeploymentRouteOutput[];
+  server: DeploymentServerOutput;
+  metadata?: Record<string, unknown>;
+}
+
+export type DeploymentDocumentOutput =
+  | {
+      kind: "app";
+      id: string;
+      fileName: string;
+      assets?: AssetGroup;
+    }
+  | {
+      kind: "page";
+      id: string;
+      fileName: string;
+      assets?: AssetGroup;
+    };
+
+export type DeploymentRouteOutput =
+  | {
+      kind: "static-document";
+      path: string;
+      documentId: string;
+      methods: ["GET", "HEAD"];
+    }
+  | {
+      kind: "spa-fallback";
+      path: string;
+      documentId: string;
+      methods: ["GET", "HEAD"];
+    }
+  | {
+      kind: "page-server";
+      path: string;
+      pageId: string;
+      methods: ["GET", "HEAD"];
+    }
+  | {
+      kind: "framework-function";
+      path: string;
+      methods: ["POST"];
+    }
+  | {
+      kind: "framework-ppr";
+      path: string;
+      methods: ["GET", "HEAD"];
+    }
+  | {
+      kind: "framework-rsc";
+      path: string;
+      methods: ["GET", "HEAD"];
+    }
+  | {
+      kind: "server-route";
+      path: string;
+      methods: string[];
+    };
+
+export interface DeploymentServerOutput {
+  entry?: string;
+}
 
 export interface ServerOutput {
   entry?: string;
@@ -486,17 +544,11 @@ export interface RscOutput {
   pages?: Record<string, RscPageOutput>;
 }
 
-export interface PublicRscOutput {
-  pages?: Record<string, PublicRscPageOutput>;
-}
-
 export interface RscPageOutput {
   renderer: string;
   assets: AssetGroup;
   routeId?: string;
 }
-
-export type PublicRscPageOutput = RscPageOutput;
 
 // ── Route resolution ────────────────────────────────────────────────────
 
@@ -858,7 +910,7 @@ function assertManifestRoutingProjection(
     }
     if (value.routing.kind === "mpa") {
       assertObject(value.routing.pages, `${source}.routing.pages`);
-      assertPageOutputs(value.routing.pages, `${source}.routing.pages`);
+      assertPublicPageOutputs(value.routing.pages, `${source}.routing.pages`);
       const routes = createRoutesFromManifestPages(value.routing.pages);
       assertRouteOutputs(
         routes,
@@ -1193,6 +1245,22 @@ function assertPageOutputs(
     assertPageRenderingOutput(output.rendering, `${source}.${name}.rendering`);
     assertPprPageOutputContract(output, `${source}.${name}`);
     assertRscPageOutputContract(output, `${source}.${name}`);
+  }
+}
+
+function assertPublicPageOutputs(
+  value: Record<string, unknown>,
+  source: string,
+): void {
+  for (const [name, output] of Object.entries(value)) {
+    assertManifestBuildIdentifierKey(name, source);
+    assertObject(output, `${source}.${name}`);
+    assertAssetGroup(output.assets, `${source}.${name}.assets`);
+    assertHtmlDocumentOutput(output.document, `${source}.${name}.document`);
+    assertManifestPathname(output.path, `${source}.${name}.path`);
+    if (output.routeId !== undefined) {
+      assertManifestString(output.routeId, `${source}.${name}.routeId`);
+    }
   }
 }
 
@@ -1986,11 +2054,12 @@ function formatManifestPathnameError(
 export {
   type BuildOutputLinkInput,
   type BuildOutputServerModule,
+  createDeploymentMetadata,
   createPublicManifest,
   createServerManifest,
+  type DeploymentMetadataOptions,
   linkBuildOutput,
   type ServerManifestOutput,
-  type ServerManifestRouteOutput,
 } from "./linker.js";
 export {
   type ClientRouteMatch,

--- a/packages/shared/src/manifest/index.ts
+++ b/packages/shared/src/manifest/index.ts
@@ -487,7 +487,11 @@ export type DeploymentDocumentOutput =
       assets?: AssetGroup;
     };
 
-export type DeploymentPageRenderOutput = RenderMode | "ppr" | "rsc";
+export type DeploymentPageRenderOutput = RenderMode;
+export type DeploymentServerPageRenderOutput = Extract<
+  DeploymentPageRenderOutput,
+  "ssr"
+>;
 
 export type DeploymentRouteOutput =
   | {
@@ -501,7 +505,9 @@ export type DeploymentRouteOutput =
       kind: "server-page";
       path: string;
       pageId: string;
-      render: Exclude<DeploymentPageRenderOutput, "csr">;
+      render: DeploymentServerPageRenderOutput;
+      prerender?: "full" | "partial";
+      rsc?: true;
       methods: ["GET", "HEAD"];
     }
   | {

--- a/packages/shared/src/manifest/index.ts
+++ b/packages/shared/src/manifest/index.ts
@@ -1891,7 +1891,6 @@ export {
   createPublicManifest,
   createServerManifest,
   linkBuildOutput,
-  type ServerManifestFunctionOutput,
   type ServerManifestOutput,
   type ServerManifestRouteOutput,
 } from "./linker.js";

--- a/packages/shared/src/manifest/index.ts
+++ b/packages/shared/src/manifest/index.ts
@@ -187,6 +187,7 @@ export interface BuildEntry {
   import: string;
   environment: BuildEnvironment;
   runtime?: "browser" | ServerRuntime;
+  phase?: BuildEntryPhase;
   kind:
     | "app-client"
     | "page-client"
@@ -199,6 +200,8 @@ export interface BuildEntry {
   owner?: BuildEntryOwner;
   metadata?: BuildEntryMetadata;
 }
+
+export type BuildEntryPhase = "runtime" | "build";
 
 export interface BuildEntryOwner {
   appId?: string;
@@ -273,13 +276,14 @@ export interface HtmlPlan {
 }
 
 export interface ServerBuildPlan {
-  entry: string;
+  entry?: string;
   renderers?: ServerRenderPlan[];
 }
 
 export interface ServerRenderPlan {
   name: string;
   import: string;
+  phase?: BuildEntryPhase;
   kind: "page-server" | "rsc-page" | "ppr-shell" | "ppr-region";
   owner?: BuildEntryOwner;
 }
@@ -332,7 +336,8 @@ export interface FrameworkManifestValidationOptions {
 
 export type PublicManifestOutput =
   | PublicSpaManifestOutput
-  | PublicMpaManifestOutput;
+  | PublicMpaManifestOutput
+  | PublicStaticManifestOutput;
 
 export interface PublicSpaManifestOutput {
   version: 1;
@@ -349,6 +354,13 @@ export interface PublicMpaManifestOutput {
   routing: PublicMpaRoutingOutput;
 }
 
+export interface PublicStaticManifestOutput {
+  version: 1;
+  buildId: string;
+  publicPath: PublicPathOutput;
+  documents: PublicDocumentOutput[];
+}
+
 export type PublicRoutingOutput =
   | PublicSpaRoutingOutput
   | PublicMpaRoutingOutput;
@@ -361,6 +373,14 @@ export interface PublicSpaRoutingOutput {
 export interface PublicMpaRoutingOutput {
   kind: "mpa";
   pages: Record<string, PublicPageOutput>;
+}
+
+export interface PublicDocumentOutput {
+  id: string;
+  path: string;
+  fileName: string;
+  render: Extract<RenderMode, "csr" | "ssg">;
+  assets?: AssetGroup;
 }
 
 export interface BuildOutputPaths {
@@ -412,6 +432,7 @@ export interface PublicPageOutput {
   document?: HtmlDocumentOutput;
   path?: string;
   routeId?: string;
+  render?: RenderMode;
 }
 
 export interface HtmlDocumentOutput {
@@ -458,7 +479,12 @@ export interface RouteOutput {
   pageId?: string;
 }
 
-export type PublicRouteOutput = Pick<RouteOutput, "id" | "path" | "pageId">;
+export interface PublicRouteOutput {
+  id: string;
+  path: string;
+  pageId?: string;
+  render?: RenderMode;
+}
 
 export interface DeploymentMetadata {
   version: 1;
@@ -484,6 +510,8 @@ export type DeploymentDocumentOutput =
       kind: "page";
       id: string;
       fileName: string;
+      path?: string;
+      render?: Extract<DeploymentPageRenderOutput, "csr" | "ssg">;
       assets?: AssetGroup;
     };
 
@@ -494,13 +522,6 @@ export type DeploymentServerPageRenderOutput = Extract<
 >;
 
 export type DeploymentRouteOutput =
-  | {
-      kind: "static-page";
-      path: string;
-      documentId: string;
-      render: Extract<DeploymentPageRenderOutput, "csr" | "ssg">;
-      methods: ["GET", "HEAD"];
-    }
   | {
       kind: "server-page";
       path: string;
@@ -545,6 +566,7 @@ export interface ServerOutput {
 
 export interface ServerRendererOutput {
   kind: ServerRenderPlan["kind"];
+  phase?: BuildEntryPhase;
   owner?: BuildEntryOwner;
   assets: AssetGroup;
 }
@@ -806,6 +828,24 @@ export function assertFrameworkManifestShape(
     assertObject(value.assets, `${source}.assets`);
     assertAssetGroupRecord(value.assets, `${source}.assets`);
   }
+  if (value.documents !== undefined) {
+    if (requireServer) {
+      throw new Error(
+        `[evjs] ${source}.documents is only supported in public manifests.`,
+      );
+    }
+    if (value.routing !== undefined) {
+      throw new Error(
+        `[evjs] ${source} must not define both documents and routing.`,
+      );
+    }
+    if (value.assets !== undefined) {
+      throw new Error(
+        `[evjs] ${source}.assets must be omitted when documents are used.`,
+      );
+    }
+    assertPublicDocumentOutputs(value.documents, `${source}.documents`);
+  }
   const apps = assertManifestAppProjection(value, source, requireServer);
   const { pages, routes } = assertManifestRoutingProjection(
     value,
@@ -907,6 +947,37 @@ export function assertFrameworkManifestShape(
   }
 }
 
+function assertPublicDocumentOutputs(value: unknown, source: string): void {
+  if (!Array.isArray(value)) {
+    throw new Error(`[evjs] ${source} must be an array.`);
+  }
+  const pathOwners = new Map<string, { path: string; source: string }>();
+  for (const [index, document] of value.entries()) {
+    const documentSource = `${source}[${index}]`;
+    assertObject(document, documentSource);
+    assertManifestString(document.id, `${documentSource}.id`);
+    assertManifestPathname(document.path, `${documentSource}.path`, true);
+    assertUniquePageRoutePath(
+      document.path as string,
+      `${documentSource}.path`,
+      pathOwners,
+    );
+    assertHtmlDocumentOutput(
+      { fileName: document.fileName },
+      `${documentSource}`,
+    );
+    assertStaticDocumentRenderMode(document.render, `${documentSource}.render`);
+    if (document.assets !== undefined) {
+      assertAssetGroup(document.assets, `${documentSource}.assets`);
+    }
+  }
+}
+
+function assertStaticDocumentRenderMode(value: unknown, source: string): void {
+  if (value === "csr" || value === "ssg") return;
+  throw new Error(`[evjs] ${source} must be "csr" or "ssg".`);
+}
+
 function assertManifestRoutingProjection(
   value: Record<string, unknown>,
   source: string,
@@ -927,14 +998,15 @@ function assertManifestRoutingProjection(
       if (!Array.isArray(value.routing.routes)) {
         throw new Error(`[evjs] ${source}.routing.routes must be an array.`);
       }
+      const pages = createPagesFromPublicManifestRoutes(value.routing.routes);
       assertRouteOutputs(
         value.routing.routes,
         `${source}.routing.routes`,
-        {},
+        pages,
         apps,
       );
       return {
-        pages: {},
+        pages,
         routes: value.routing.routes as Array<Record<string, unknown>>,
       };
     }
@@ -982,9 +1054,26 @@ function createRoutesFromManifestPages(
         id: page.routeId,
         path: page.path,
         pageId,
+        render: page.render,
       },
     ];
   });
+}
+
+function createPagesFromPublicManifestRoutes(
+  routes: unknown[],
+): Record<string, unknown> {
+  return Object.fromEntries(
+    routes.flatMap((route) => {
+      if (!isRecord(route) || typeof route.pageId !== "string") return [];
+      return [
+        [
+          route.pageId,
+          route.render === undefined ? {} : { render: route.render },
+        ],
+      ];
+    }),
+  );
 }
 
 function getManifestPagesSource(
@@ -1079,6 +1168,9 @@ function assertServerRendererOutputs(
     assertManifestBuildIdentifierKey(name, source);
     assertObject(output, `${source}.${name}`);
     assertServerRendererKind(output.kind, `${source}.${name}.kind`);
+    if (output.phase !== undefined) {
+      assertBuildEntryPhase(output.phase, `${source}.${name}.phase`);
+    }
     assertAssetGroup(output.assets, `${source}.${name}.assets`);
     assertServerRendererOwner(
       output.owner,
@@ -1219,6 +1311,11 @@ function assertServerRendererKind(value: unknown, source: string): void {
   );
 }
 
+function assertBuildEntryPhase(value: unknown, source: string): void {
+  if (value === "runtime" || value === "build") return;
+  throw new Error(`[evjs] ${source} must be "runtime" or "build".`);
+}
+
 function assertServerFunctionOutputs(
   value: Record<string, unknown>,
   source: string,
@@ -1290,6 +1387,9 @@ function assertPublicPageOutputs(
     assertManifestPathname(output.path, `${source}.${name}.path`);
     if (output.routeId !== undefined) {
       assertManifestString(output.routeId, `${source}.${name}.routeId`);
+    }
+    if (output.render !== undefined) {
+      assertRenderMode(output.render, `${source}.${name}.render`);
     }
   }
 }
@@ -1496,6 +1596,9 @@ function assertRouteOutputs(
       "pages",
       pages,
     );
+    if (route.render !== undefined) {
+      assertRenderMode(route.render, `${routeSource}.render`);
+    }
     assertOptionalRecordReference(
       route.appId,
       `${routeSource}.appId`,
@@ -1520,6 +1623,15 @@ function assertPageRouteOutputContract(
   ) {
     throw new Error(
       `[evjs] ${routeSource}.path "${route.path as string}" must match manifest.pages.${route.pageId as string}.path "${page.path}".`,
+    );
+  }
+  if (
+    route.render !== undefined &&
+    page.render !== undefined &&
+    route.render !== page.render
+  ) {
+    throw new Error(
+      `[evjs] ${routeSource}.render "${route.render as string}" must match manifest.pages.${route.pageId as string}.render "${page.render as string}".`,
     );
   }
 }

--- a/packages/shared/src/manifest/index.ts
+++ b/packages/shared/src/manifest/index.ts
@@ -336,10 +336,19 @@ export interface PublicManifestOutput {
   publicPath: PublicPathOutput;
   assets?: Record<string, AssetGroup>;
   app?: PublicAppOutput;
-  pages: Record<string, PublicPageOutput>;
-  routes: PublicRouteOutput[];
+  routing: PublicRoutingOutput;
   rsc?: PublicRscOutput;
 }
+
+export type PublicRoutingOutput =
+  | {
+      kind: "spa";
+      routes: PublicRouteOutput[];
+    }
+  | {
+      kind: "mpa";
+      pages: Record<string, PublicPageOutput>;
+    };
 
 export interface BuildOutputPaths {
   rootDir: string;
@@ -726,12 +735,12 @@ export function assertFrameworkManifestShape(
     assertAssetGroupRecord(value.assets, `${source}.assets`);
   }
   const apps = assertManifestAppProjection(value, source, requireServer);
-  assertObject(value.pages, `${source}.pages`);
-  assertPageOutputs(value.pages, `${source}.pages`);
-  if (!Array.isArray(value.routes)) {
-    throw new Error(`[evjs] ${source}.routes must be an array.`);
-  }
-  assertRouteOutputs(value.routes, `${source}.routes`, value.pages, apps);
+  const { pages, routes } = assertManifestRoutingProjection(
+    value,
+    source,
+    requireServer,
+    apps,
+  );
 
   if (value.runtime !== undefined) {
     assertObject(value.runtime.server, `${source}.runtime.server`);
@@ -775,8 +784,8 @@ export function assertFrameworkManifestShape(
       assertServerRendererOutputs(
         value.server.renderers,
         `${source}.server.renderers`,
-        value.pages,
-        value.routes,
+        pages,
+        routes,
       );
     }
     assertAssetGroup(value.server.assets, `${source}.server.assets`);
@@ -792,15 +801,15 @@ export function assertFrameworkManifestShape(
   }
   const serverRenderers = getServerRendererOutputs(value.server);
   assertPageServerRendererReferences(
-    value.pages,
-    `${source}.pages`,
+    pages,
+    getManifestPagesSource(value, source),
     serverRenderers,
-    value.routes,
+    routes,
     requirePageRendererReferences,
   );
   assertPprPageOutputReferences(
-    value.pages,
-    `${source}.pages`,
+    pages,
+    getManifestPagesSource(value, source),
     serverRenderers,
     requirePprRendererReferences,
   );
@@ -808,12 +817,101 @@ export function assertFrameworkManifestShape(
     assertRscOutput(
       value.rsc,
       `${source}.rsc`,
-      value.pages,
+      pages,
       serverRenderers,
-      value.routes,
+      routes,
       requireRscRendererReferences,
     );
   }
+}
+
+function assertManifestRoutingProjection(
+  value: Record<string, unknown>,
+  source: string,
+  requireLegacyRouting: boolean,
+  apps: Record<string, unknown>,
+): {
+  pages: Record<string, unknown>;
+  routes: Array<Record<string, unknown>>;
+} {
+  if (value.routing !== undefined) {
+    if (value.pages !== undefined || value.routes !== undefined) {
+      throw new Error(
+        `[evjs] ${source} must not define both routing and pages/routes.`,
+      );
+    }
+    assertObject(value.routing, `${source}.routing`);
+    if (value.routing.kind === "spa") {
+      if (!Array.isArray(value.routing.routes)) {
+        throw new Error(`[evjs] ${source}.routing.routes must be an array.`);
+      }
+      assertRouteOutputs(
+        value.routing.routes,
+        `${source}.routing.routes`,
+        {},
+        apps,
+      );
+      return {
+        pages: {},
+        routes: value.routing.routes as Array<Record<string, unknown>>,
+      };
+    }
+    if (value.routing.kind === "mpa") {
+      assertObject(value.routing.pages, `${source}.routing.pages`);
+      assertPageOutputs(value.routing.pages, `${source}.routing.pages`);
+      const routes = createRoutesFromManifestPages(value.routing.pages);
+      assertRouteOutputs(
+        routes,
+        `${source}.routing.pages`,
+        value.routing.pages,
+        apps,
+      );
+      return { pages: value.routing.pages, routes };
+    }
+    throw new Error(`[evjs] ${source}.routing.kind must be "spa" or "mpa".`);
+  }
+
+  if (value.pages === undefined && value.routes === undefined) {
+    if (requireLegacyRouting) {
+      throw new Error(`[evjs] ${source}.pages must be an object.`);
+    }
+    return { pages: {}, routes: [] };
+  }
+
+  assertObject(value.pages, `${source}.pages`);
+  assertPageOutputs(value.pages, `${source}.pages`);
+  if (!Array.isArray(value.routes)) {
+    throw new Error(`[evjs] ${source}.routes must be an array.`);
+  }
+  assertRouteOutputs(value.routes, `${source}.routes`, value.pages, apps);
+  return { pages: value.pages, routes: value.routes };
+}
+
+function createRoutesFromManifestPages(
+  pages: Record<string, unknown>,
+): Array<Record<string, unknown>> {
+  return Object.entries(pages).flatMap(([pageId, page]) => {
+    if (!isRecord(page)) return [];
+    if (typeof page.path !== "string" || typeof page.routeId !== "string") {
+      return [];
+    }
+    return [
+      {
+        id: page.routeId,
+        path: page.path,
+        pageId,
+      },
+    ];
+  });
+}
+
+function getManifestPagesSource(
+  value: Record<string, unknown>,
+  source: string,
+): string {
+  return value.routing !== undefined
+    ? `${source}.routing.pages`
+    : `${source}.pages`;
 }
 
 function assertManifestAppProjection(

--- a/packages/shared/src/manifest/index.ts
+++ b/packages/shared/src/manifest/index.ts
@@ -335,7 +335,7 @@ export interface PublicManifestOutput {
   buildId: string;
   publicPath: PublicPathOutput;
   assets?: Record<string, AssetGroup>;
-  apps: Record<string, PublicAppOutput>;
+  app?: PublicAppOutput;
   pages: Record<string, PublicPageOutput>;
   routes: PublicRouteOutput[];
   rsc?: PublicRscOutput;
@@ -446,10 +446,7 @@ export interface RouteOutput {
   pageId?: string;
 }
 
-export type PublicRouteOutput = Pick<
-  RouteOutput,
-  "id" | "path" | "appId" | "pageId"
->;
+export type PublicRouteOutput = Pick<RouteOutput, "id" | "path" | "pageId">;
 
 export interface ServerOutput {
   entry?: string;
@@ -728,14 +725,13 @@ export function assertFrameworkManifestShape(
     assertObject(value.assets, `${source}.assets`);
     assertAssetGroupRecord(value.assets, `${source}.assets`);
   }
-  assertObject(value.apps, `${source}.apps`);
-  assertAppOutputs(value.apps, `${source}.apps`);
+  const apps = assertManifestAppProjection(value, source, requireServer);
   assertObject(value.pages, `${source}.pages`);
   assertPageOutputs(value.pages, `${source}.pages`);
   if (!Array.isArray(value.routes)) {
     throw new Error(`[evjs] ${source}.routes must be an array.`);
   }
-  assertRouteOutputs(value.routes, `${source}.routes`, value.pages, value.apps);
+  assertRouteOutputs(value.routes, `${source}.routes`, value.pages, apps);
 
   if (value.runtime !== undefined) {
     assertObject(value.runtime.server, `${source}.runtime.server`);
@@ -818,6 +814,29 @@ export function assertFrameworkManifestShape(
       requireRscRendererReferences,
     );
   }
+}
+
+function assertManifestAppProjection(
+  value: Record<string, unknown>,
+  source: string,
+  requireApps: boolean,
+): Record<string, unknown> {
+  if (value.app !== undefined && value.apps !== undefined) {
+    throw new Error(`[evjs] ${source} must not define both app and apps.`);
+  }
+  if (value.apps !== undefined) {
+    assertObject(value.apps, `${source}.apps`);
+    assertAppOutputs(value.apps, `${source}.apps`);
+    return value.apps;
+  }
+  if (value.app !== undefined) {
+    assertAppOutput(value.app, `${source}.app`);
+    return { app: value.app };
+  }
+  if (requireApps) {
+    throw new Error(`[evjs] ${source}.apps must be an object.`);
+  }
+  return {};
 }
 
 function assertObject(
@@ -1038,11 +1057,15 @@ function assertAppOutputs(
 ): void {
   for (const [name, output] of Object.entries(value)) {
     assertManifestBuildIdentifierKey(name, source);
-    assertObject(output, `${source}.${name}`);
-    assertAssetGroup(output.assets, `${source}.${name}.assets`);
-    assertHtmlDocumentOutput(output.document, `${source}.${name}.document`);
-    assertRuntimeModuleOutput(output.module, `${source}.${name}.module`);
+    assertAppOutput(output, `${source}.${name}`);
   }
+}
+
+function assertAppOutput(value: unknown, source: string): void {
+  assertObject(value, source);
+  assertAssetGroup(value.assets, `${source}.assets`);
+  assertHtmlDocumentOutput(value.document, `${source}.document`);
+  assertRuntimeModuleOutput(value.module, `${source}.module`);
 }
 
 function assertPageOutputs(

--- a/packages/shared/src/manifest/index.ts
+++ b/packages/shared/src/manifest/index.ts
@@ -5,11 +5,11 @@
  *
  * Bundler adapters emit framework metadata under the configured output
  * directories. By default, the lightweight client deployment manifest is
- * written to `dist/client/manifest.json`, the entry-only server manifest to
- * `dist/server/manifest.json`, and canonical deployment metadata to
- * `dist/build-output.json`. `output.client` and `output.server` can point to
- * alternate directories when an adapter or deployment target needs a different
- * artifact layout.
+ * written to `dist/client/manifest.json`, the lightweight server deployment
+ * manifest to `dist/server/manifest.json`, and canonical deployment metadata
+ * to `dist/build-output.json`. `output.client` and `output.server` can point
+ * to alternate directories when an adapter or deployment target needs a
+ * different artifact layout.
  */
 
 import {
@@ -330,23 +330,38 @@ export interface FrameworkManifestValidationOptions {
   rscRendererReferences?: "required" | "optional";
 }
 
-export interface PublicManifestOutput {
+export type PublicManifestOutput =
+  | PublicSpaManifestOutput
+  | PublicMpaManifestOutput;
+
+export interface PublicSpaManifestOutput {
   version: 1;
   buildId: string;
   publicPath: PublicPathOutput;
   assets?: Record<string, AssetGroup>;
-  routing: PublicRoutingOutput;
+  routing: PublicSpaRoutingOutput;
+}
+
+export interface PublicMpaManifestOutput {
+  version: 1;
+  buildId: string;
+  publicPath: PublicPathOutput;
+  routing: PublicMpaRoutingOutput;
 }
 
 export type PublicRoutingOutput =
-  | {
-      kind: "spa";
-      routes: PublicRouteOutput[];
-    }
-  | {
-      kind: "mpa";
-      pages: Record<string, PublicPageOutput>;
-    };
+  | PublicSpaRoutingOutput
+  | PublicMpaRoutingOutput;
+
+export interface PublicSpaRoutingOutput {
+  kind: "spa";
+  routes: PublicRouteOutput[];
+}
+
+export interface PublicMpaRoutingOutput {
+  kind: "mpa";
+  pages: Record<string, PublicPageOutput>;
+}
 
 export interface BuildOutputPaths {
   rootDir: string;
@@ -793,6 +808,16 @@ export function assertFrameworkManifestShape(
     requireServer,
     apps,
   );
+  if (
+    !requireServer &&
+    value.assets !== undefined &&
+    isRecord(value.routing) &&
+    value.routing.kind === "mpa"
+  ) {
+    throw new Error(
+      `[evjs] ${source}.assets must be omitted when routing.kind is "mpa".`,
+    );
+  }
 
   if (value.runtime !== undefined) {
     assertObject(value.runtime.server, `${source}.runtime.server`);
@@ -2060,6 +2085,7 @@ export {
   type DeploymentMetadataOptions,
   linkBuildOutput,
   type ServerManifestOutput,
+  type ServerManifestRouteOutput,
 } from "./linker.js";
 export {
   type ClientRouteMatch,

--- a/packages/shared/src/manifest/index.ts
+++ b/packages/shared/src/manifest/index.ts
@@ -310,8 +310,7 @@ export interface BuildPlanUpdate {
 export interface BuildOutput {
   version: 1;
   buildId: string;
-  distDir: string;
-  paths?: BuildOutputPaths;
+  paths: BuildOutputPaths;
   publicPath: PublicPathOutput;
   runtime: RuntimeOutput;
   assets: Record<string, AssetGroup>;
@@ -367,12 +366,11 @@ export interface TransportOutput {
 export interface AppOutput {
   assets: AssetGroup;
   document?: HtmlDocumentOutput;
-  entry?: string;
   mount?: string;
   module?: RuntimeModuleOutput;
 }
 
-export interface PublicAppOutput extends Omit<AppOutput, "entry" | "module"> {
+export interface PublicAppOutput extends Omit<AppOutput, "module"> {
   module?: PublicRuntimeModuleOutput;
 }
 
@@ -383,10 +381,7 @@ export interface PageOutput {
   rendering: PageRenderingOutput;
   path?: string;
   routeId?: string;
-  entry?: string;
-  component?: string;
   componentModel?: ComponentModel;
-  app?: string;
   hydrate?: HydrationMode;
   mount?: string;
   prerender?: PrerenderConfig;
@@ -394,8 +389,7 @@ export interface PageOutput {
   ppr?: PprPageOutput;
 }
 
-export interface PublicPageOutput
-  extends Omit<PageOutput, "entry" | "component" | "app" | "module" | "ppr"> {
+export interface PublicPageOutput extends Omit<PageOutput, "module" | "ppr"> {
   module?: PublicRuntimeModuleOutput;
   ppr?: PublicPprPageOutput;
 }
@@ -430,16 +424,11 @@ export interface PublicPprPageOutput extends Omit<PprPageOutput, "regions"> {
 export interface PprRegionOutput {
   id: string;
   assets: AssetGroup;
-  component: string;
-  fallback?: string;
   cache?: PprCachePolicy;
   hydrate?: HydrationMode;
 }
 
-export type PublicPprRegionOutput = Omit<
-  PprRegionOutput,
-  "component" | "fallback"
->;
+export type PublicPprRegionOutput = PprRegionOutput;
 
 export interface RuntimeModuleOutput {
   type: "entry" | "lifecycle" | "react-component";
@@ -455,7 +444,6 @@ export interface RouteOutput {
   kind?: PageRouteKind;
   appId?: string;
   pageId?: string;
-  module?: string;
 }
 
 export type PublicRouteOutput = Pick<
@@ -474,13 +462,11 @@ export interface ServerOutput {
 export interface ServerRendererOutput {
   kind: ServerRenderPlan["kind"];
   owner?: BuildEntryOwner;
-  module: string;
   assets: AssetGroup;
 }
 
 export interface ServerFunctionOutput {
   assets: AssetGroup;
-  module: string;
   exportName: string;
 }
 
@@ -491,32 +477,20 @@ export interface ServerRouteOutput {
 }
 
 export interface RscOutput {
-  endpoint?: string;
   pages?: Record<string, RscPageOutput>;
-  clientReferences?: Record<string, RscReferenceOutput>;
-  serverReferences?: Record<string, RscReferenceOutput>;
-  clientReferenceManifest?: Record<string, unknown>;
-  serverConsumerManifest?: Record<string, unknown>;
 }
 
 export interface PublicRscOutput {
-  endpoint?: string;
   pages?: Record<string, PublicRscPageOutput>;
 }
 
 export interface RscPageOutput {
   renderer: string;
   assets: AssetGroup;
-  component?: string;
   routeId?: string;
 }
 
-export type PublicRscPageOutput = Omit<RscPageOutput, "component">;
-
-export interface RscReferenceOutput {
-  module: string;
-  exportName?: string;
-}
+export type PublicRscPageOutput = RscPageOutput;
 
 // ── Route resolution ────────────────────────────────────────────────────
 
@@ -724,8 +698,6 @@ export function assertFrameworkManifestShape(
   options: FrameworkManifestValidationOptions = {},
 ): asserts value is BuildOutput | PublicManifestOutput {
   const requireServer = options.server !== "optional";
-  const requireServerFunctionModules =
-    options.serverFunctionModules !== "optional";
   const requirePageRendererReferences =
     options.pageRendererReferences !== "optional";
   const requirePprRendererReferences =
@@ -737,17 +709,14 @@ export function assertFrameworkManifestShape(
     throw new Error(`[evjs] ${source}.version must be 1.`);
   }
   assertManifestBuildId(value.buildId, `${source}.buildId`);
-  if (value.distDir === undefined) {
+  if (value.paths === undefined) {
     if (requireServer) {
-      throw new Error(`[evjs] ${source}.distDir must be a non-empty string.`);
+      throw new Error(`[evjs] ${source}.paths must be an object.`);
     }
   } else {
-    assertManifestString(value.distDir, `${source}.distDir`);
-  }
-  assertPublicPathOutput(value.publicPath, `${source}.publicPath`);
-  if (value.paths !== undefined) {
     assertBuildOutputPaths(value.paths, `${source}.paths`);
   }
+  assertPublicPathOutput(value.publicPath, `${source}.publicPath`);
   if (value.runtime === undefined) {
     if (requireServer) {
       throw new Error(`[evjs] ${source}.runtime must be an object.`);
@@ -819,7 +788,6 @@ export function assertFrameworkManifestShape(
     assertServerFunctionOutputs(
       value.server.functions,
       `${source}.server.functions`,
-      requireServerFunctionModules,
     );
     if (!Array.isArray(value.server.routes)) {
       throw new Error(`[evjs] ${source}.server.routes must be an array.`);
@@ -912,7 +880,6 @@ function assertServerRendererOutputs(
     assertManifestBuildIdentifierKey(name, source);
     assertObject(output, `${source}.${name}`);
     assertServerRendererKind(output.kind, `${source}.${name}.kind`);
-    assertManifestString(output.module, `${source}.${name}.module`);
     assertAssetGroup(output.assets, `${source}.${name}.assets`);
     assertServerRendererOwner(
       output.owner,
@@ -1056,14 +1023,10 @@ function assertServerRendererKind(value: unknown, source: string): void {
 function assertServerFunctionOutputs(
   value: Record<string, unknown>,
   source: string,
-  requireModule: boolean,
 ): void {
   for (const [name, output] of Object.entries(value)) {
     assertManifestServerFunctionIdKey(name, source);
     assertObject(output, `${source}.${name}`);
-    if (requireModule || output.module !== undefined) {
-      assertManifestString(output.module, `${source}.${name}.module`);
-    }
     assertManifestString(output.exportName, `${source}.${name}.exportName`);
     assertAssetGroup(output.assets, `${source}.${name}.assets`);
   }
@@ -1320,9 +1283,6 @@ function assertRouteOutputs(
       "apps",
       apps,
     );
-    if (route.module !== undefined) {
-      assertManifestString(route.module, `${routeSource}.module`);
-    }
     if (page) {
       assertPageRouteOutputContract(route, page, routeSource);
     }
@@ -1515,17 +1475,6 @@ function assertManifestServerFunctionIdKey(key: string, source: string): void {
   );
 }
 
-function assertManifestStringKey(key: string, source: string): void {
-  if (!key.trim()) {
-    throw new Error(`[evjs] ${source} must not contain empty keys.`);
-  }
-  if (key.trim() !== key) {
-    throw new Error(
-      `[evjs] ${source} key "${key}" must not contain leading or trailing whitespace.`,
-    );
-  }
-}
-
 function assertManifestString(
   value: unknown,
   source: string,
@@ -1555,18 +1504,6 @@ function assertPprPageOutput(value: unknown, source: string): void {
       );
     }
     assertAssetGroup(region.assets, `${source}.regions.${name}.assets`);
-    if (region.component !== undefined) {
-      assertManifestString(
-        region.component,
-        `${source}.regions.${name}.component`,
-      );
-    }
-    if (region.fallback !== undefined) {
-      assertManifestString(
-        region.fallback,
-        `${source}.regions.${name}.fallback`,
-      );
-    }
     if (region.cache !== undefined) {
       assertPprRegionCache(region.cache, `${source}.regions.${name}.cache`);
     }
@@ -1728,31 +1665,6 @@ function assertRscOutput(
   requireServerRendererReferences: boolean,
 ): void {
   assertObject(value, source);
-  assertManifestPathname(
-    value.endpoint,
-    `${source}.endpoint`,
-    value.pages !== undefined,
-  );
-  assertRscReferenceOutputs(
-    value.clientReferences,
-    `${source}.clientReferences`,
-  );
-  assertRscReferenceOutputs(
-    value.serverReferences,
-    `${source}.serverReferences`,
-  );
-  if (value.clientReferenceManifest !== undefined) {
-    assertObject(
-      value.clientReferenceManifest,
-      `${source}.clientReferenceManifest`,
-    );
-  }
-  if (value.serverConsumerManifest !== undefined) {
-    assertObject(
-      value.serverConsumerManifest,
-      `${source}.serverConsumerManifest`,
-    );
-  }
   if (value.pages === undefined) return;
 
   assertObject(value.pages, `${source}.pages`);
@@ -1769,23 +1681,6 @@ function assertRscOutput(
       routesById,
       requireServerRendererReferences,
     );
-  }
-}
-
-function assertRscReferenceOutputs(value: unknown, source: string): void {
-  if (value === undefined) return;
-  assertObject(value, source);
-  for (const [id, reference] of Object.entries(value)) {
-    assertManifestStringKey(id, source);
-    const referenceSource = `${source}.${id}`;
-    assertObject(reference, referenceSource);
-    assertManifestString(reference.module, `${referenceSource}.module`);
-    if (reference.exportName !== undefined) {
-      assertManifestString(
-        reference.exportName,
-        `${referenceSource}.exportName`,
-      );
-    }
   }
 }
 
@@ -1825,10 +1720,6 @@ function assertRscPageOutputReferences(
       );
     }
     assertRscServerRendererOwner(renderer, name, `${source}.renderer`);
-  }
-
-  if (page.component !== undefined) {
-    assertManifestString(page.component, `${source}.component`);
   }
 
   if (page.routeId === undefined) return;

--- a/packages/shared/src/manifest/linker.ts
+++ b/packages/shared/src/manifest/linker.ts
@@ -382,12 +382,7 @@ export function createPublicManifest(
     buildId: output.buildId,
     publicPath: output.publicPath,
     assets: clonePublicAssetRecord(output.assets, publicAssetFiles),
-    apps: Object.fromEntries(
-      Object.entries(output.apps).map(([id, app]) => [
-        id,
-        sanitizeAppOutput(app),
-      ]),
-    ),
+    app: createPublicManifestApp(output),
     pages: Object.fromEntries(
       Object.entries(output.pages).map(([id, page]) => [
         id,
@@ -398,7 +393,6 @@ export function createPublicManifest(
       pruneUndefined({
         id: route.id,
         path: route.path,
-        appId: route.appId,
         pageId: route.pageId,
       }),
     ),
@@ -419,6 +413,13 @@ export function createPublicManifest(
         })
       : undefined,
   }) as PublicManifestOutput;
+}
+
+function createPublicManifestApp(
+  output: BuildOutput,
+): PublicAppOutput | undefined {
+  const app = output.apps.default ?? Object.values(output.apps)[0];
+  return app ? sanitizeAppOutput(app) : undefined;
 }
 
 export function createServerManifest(

--- a/packages/shared/src/manifest/linker.ts
+++ b/packages/shared/src/manifest/linker.ts
@@ -16,7 +16,6 @@ import type {
   PublicPageOutput,
   PublicPprRegionOutput,
   PublicRuntimeModuleOutput,
-  RscReferenceOutput,
   ServerFunctionOutput,
   ServerRouteOutput,
 } from "./index.js";
@@ -43,10 +42,6 @@ export interface BuildOutputLinkInput {
   serverEntry?: string;
   serverAssets?: AssetGroup;
   serverModules?: BuildOutputServerModule[];
-  rscManifests?: {
-    clientReferenceManifest?: Record<string, unknown>;
-    serverConsumerManifest?: Record<string, unknown>;
-  };
 }
 
 export interface ServerManifestOutput {
@@ -150,7 +145,6 @@ export function linkBuildOutput(input: BuildOutputLinkInput): BuildOutput {
         {
           assets,
           document: cloneHtmlDocument(htmlDocuments.apps.get(id)),
-          entry: app.entry,
           mount: app.mount,
           module: entry
             ? {
@@ -202,10 +196,7 @@ export function linkBuildOutput(input: BuildOutputLinkInput): BuildOutput {
           rendering: derivePageRendering(page),
           path: page.path,
           routeId: page.routeId,
-          entry: page.entry,
-          component: page.component,
           componentModel: page.componentModel,
-          app: page.app,
           hydrate: effectivePageHydrate(page),
           mount: page.mount,
           prerender: page.prerender,
@@ -242,8 +233,6 @@ export function linkBuildOutput(input: BuildOutputLinkInput): BuildOutput {
                         {
                           id: regionId,
                           assets: serverAssetsForEntry(regionEntry),
-                          component: region.component,
-                          fallback: region.fallback,
                           cache: region.cache,
                           hydrate: region.hydrate,
                         },
@@ -262,7 +251,6 @@ export function linkBuildOutput(input: BuildOutputLinkInput): BuildOutput {
   for (const fn of input.graph.serverFunctions) {
     serverFunctions[fn.id] = {
       assets: assetsForSource(fn.module),
-      module: fn.module,
       exportName: fn.exportName,
     };
   }
@@ -279,7 +267,6 @@ export function linkBuildOutput(input: BuildOutputLinkInput): BuildOutput {
   return {
     version: 1,
     buildId: input.plan.buildId,
-    distDir: input.plan.distDir,
     paths: createBuildOutputPaths(input.plan),
     publicPath: input.plan.runtime.publicPath,
     runtime: {
@@ -297,7 +284,6 @@ export function linkBuildOutput(input: BuildOutputLinkInput): BuildOutput {
           path: route.path,
           appId: route.appId,
           pageId: route.pageId,
-          module: route.module,
         }),
       ),
     server: {
@@ -383,10 +369,9 @@ function assertServerRuntimeEntry(
  * Project the internal build output into the public runtime manifest that is
  * safe to serve to browsers.
  *
- * The internal `BuildOutput` intentionally keeps source modules, server
- * renderer modules, and raw React Flight manifests because the server runtime
- * needs those facts. The public manifest must not expose that implementation
- * metadata.
+ * The public manifest keeps browser-safe deployment metadata. Runtime startup
+ * data lives in `runtime.json`; framework endpoints live under
+ * `BuildOutput.runtime.server`.
  */
 export function createPublicManifest(
   output: BuildOutput,
@@ -419,7 +404,6 @@ export function createPublicManifest(
     ),
     rsc: output.rsc
       ? pruneUndefined({
-          endpoint: output.rsc.endpoint,
           pages: output.rsc.pages
             ? Object.fromEntries(
                 Object.entries(output.rsc.pages).map(([id, page]) => [
@@ -620,30 +604,21 @@ function linkRscOutput(
   input: BuildOutputLinkInput,
   serverAssetsForEntry: (entry: BuildEntry) => AssetGroup,
 ): BuildOutput["rsc"] | undefined {
-  const endpoint = input.plan.runtime.server.rsc;
   const rscRenderers = input.plan.entries.filter(
     (entry) => entry.environment === "server" && entry.kind === "rsc-page",
   );
   const rscPages = Object.values(input.graph.pages).filter(isRscPage);
 
-  if (
-    !endpoint &&
-    rscPages.length === 0 &&
-    !input.graph.clientReferences?.length &&
-    !input.graph.serverReferences?.length &&
-    !input.rscManifests?.clientReferenceManifest &&
-    !input.rscManifests?.serverConsumerManifest
-  ) {
+  if (rscPages.length === 0) {
     return undefined;
   }
-  if (!endpoint && rscPages.length > 0) {
+  if (!input.plan.runtime.server.rsc) {
     throw new Error(
       `[evjs] RSC page "${rscPages[0].id}" requires runtime.server.rsc before RSC manifest emission.`,
     );
   }
 
   return {
-    endpoint,
     pages:
       rscPages.length > 0
         ? Object.fromEntries(
@@ -654,17 +629,12 @@ function linkRscOutput(
                 {
                   renderer: renderer.name,
                   assets: serverAssetsForEntry(renderer),
-                  component: page.component,
                   routeId: page.routeId,
                 },
               ];
             }),
           )
         : undefined,
-    clientReferences: referencesToRecord(input.graph.clientReferences),
-    serverReferences: referencesToRecord(input.graph.serverReferences),
-    clientReferenceManifest: input.rscManifests?.clientReferenceManifest,
-    serverConsumerManifest: input.rscManifests?.serverConsumerManifest,
   };
 }
 
@@ -677,23 +647,6 @@ function findRscRendererForPage(
 
   throw new Error(
     `[evjs] RSC page "${pageId}" did not declare a matching rsc-page server renderer.`,
-  );
-}
-
-function referencesToRecord(
-  references:
-    | Array<{ id: string; module: string; exportName?: string }>
-    | undefined,
-): Record<string, RscReferenceOutput> | undefined {
-  if (!references?.length) return undefined;
-  return Object.fromEntries(
-    references.map((reference) => [
-      reference.id,
-      {
-        module: reference.module,
-        exportName: reference.exportName,
-      },
-    ]),
   );
 }
 
@@ -717,7 +670,6 @@ function linkServerRenderers(
         {
           kind: renderer.kind,
           owner: renderer.owner,
-          module: renderer.import,
           assets: entry
             ? serverAssetsForEntry(entry)
             : assetsForSource(renderer.import),

--- a/packages/shared/src/manifest/linker.ts
+++ b/packages/shared/src/manifest/linker.ts
@@ -389,7 +389,8 @@ function createPublicManifestRouting(
   output: BuildOutput,
   publicAssetFiles: Set<string>,
 ): PublicRoutingOutput {
-  if (Object.keys(output.pages).length > 0) {
+  const hasSpaRoute = output.routes.some((route) => route.appId);
+  if (!hasSpaRoute && Object.keys(output.pages).length > 0) {
     return {
       kind: "mpa",
       pages: Object.fromEntries(

--- a/packages/shared/src/manifest/linker.ts
+++ b/packages/shared/src/manifest/linker.ts
@@ -47,19 +47,13 @@ export interface BuildOutputLinkInput {
 export interface ServerManifestOutput {
   version: 1;
   entry?: string;
-  assets: AssetGroup;
-  functions: Record<string, ServerManifestFunctionOutput>;
+  functions: string[];
   routes: ServerManifestRouteOutput[];
-}
-
-export interface ServerManifestFunctionOutput {
-  assets: AssetGroup;
 }
 
 export interface ServerManifestRouteOutput {
   path: string;
   methods: string[];
-  assets: AssetGroup;
 }
 
 export function linkBuildOutput(input: BuildOutputLinkInput): BuildOutput {
@@ -428,19 +422,12 @@ export function createServerManifest(
   const routes = output.server.routes.map((route) => ({
     path: route.path,
     methods: [...route.methods],
-    assets: cloneAssets(route.assets),
   }));
 
   return {
     version: 1,
     ...(output.server.entry ? { entry: output.server.entry } : {}),
-    assets: cloneAssets(output.server.assets),
-    functions: Object.fromEntries(
-      Object.entries(output.server.functions).map(([id, fn]) => [
-        id,
-        { assets: cloneAssets(fn.assets) },
-      ]),
-    ),
+    functions: Object.keys(output.server.functions),
     routes,
   };
 }

--- a/packages/shared/src/manifest/linker.ts
+++ b/packages/shared/src/manifest/linker.ts
@@ -46,7 +46,15 @@ export interface BuildOutputLinkInput {
 export interface ServerManifestOutput {
   version: 1;
   entry?: string;
+  routes: ServerManifestRouteOutput[];
 }
+
+export type ServerManifestRouteOutput =
+  | Extract<DeploymentRouteOutput, { kind: "page-server" }>
+  | Extract<DeploymentRouteOutput, { kind: "framework-function" }>
+  | Extract<DeploymentRouteOutput, { kind: "framework-ppr" }>
+  | Extract<DeploymentRouteOutput, { kind: "framework-rsc" }>
+  | Extract<DeploymentRouteOutput, { kind: "server-route" }>;
 
 export function linkBuildOutput(input: BuildOutputLinkInput): BuildOutput {
   const clientEntryAssets = input.clientEntryAssets ?? {};
@@ -363,12 +371,16 @@ export function createPublicManifest(
   output: BuildOutput,
 ): PublicManifestOutput {
   const publicAssetFiles = collectPublicAssetFiles(output);
+  const routing = createPublicManifestRouting(output, publicAssetFiles);
   return pruneUndefined({
     version: output.version,
     buildId: output.buildId,
     publicPath: output.publicPath,
-    assets: clonePublicAssetRecord(output.assets, publicAssetFiles),
-    routing: createPublicManifestRouting(output, publicAssetFiles),
+    assets:
+      routing.kind === "spa"
+        ? clonePublicAssetRecord(output.assets, publicAssetFiles)
+        : undefined,
+    routing,
   }) as PublicManifestOutput;
 }
 
@@ -410,7 +422,20 @@ export function createServerManifest(
   return {
     version: 1,
     ...(output.server.entry ? { entry: output.server.entry } : {}),
+    routes: createDeploymentRoutes(output).filter(isServerManifestRoute),
   };
+}
+
+function isServerManifestRoute(
+  route: DeploymentRouteOutput,
+): route is ServerManifestRouteOutput {
+  return (
+    route.kind === "page-server" ||
+    route.kind === "framework-function" ||
+    route.kind === "framework-ppr" ||
+    route.kind === "framework-rsc" ||
+    route.kind === "server-route"
+  );
 }
 
 export interface DeploymentMetadataOptions {

--- a/packages/shared/src/manifest/linker.ts
+++ b/packages/shared/src/manifest/linker.ts
@@ -6,8 +6,8 @@ import type {
   BuildPlan,
   DeploymentDocumentOutput,
   DeploymentMetadata,
-  DeploymentPageRenderOutput,
   DeploymentRouteOutput,
+  DeploymentServerPageRenderOutput,
   HtmlDocumentOutput,
   HydrationMode,
   PageNode,
@@ -538,11 +538,16 @@ function createDeploymentRoutes(output: BuildOutput): DeploymentRouteOutput[] {
         continue;
       }
       if (page.render !== "csr") {
+        const rendering = createDeploymentServerPageRendering(
+          output,
+          route.pageId,
+          page,
+        );
         routes.push({
           kind: "server-page",
           path: route.path,
           pageId: route.pageId,
-          render: createDeploymentPageRender(output, route.pageId, page),
+          ...rendering,
           methods: ["GET", "HEAD"],
         });
       }
@@ -586,19 +591,29 @@ function createDeploymentRoutes(output: BuildOutput): DeploymentRouteOutput[] {
   return routes;
 }
 
-function createDeploymentPageRender(
+function createDeploymentServerPageRendering(
   output: BuildOutput,
   pageId: string,
   page: PageOutput,
-): Exclude<DeploymentPageRenderOutput, "csr"> {
-  if (page.ppr) return "ppr";
-  if (output.rsc?.pages?.[pageId]) return "rsc";
+): {
+  render: DeploymentServerPageRenderOutput;
+  prerender?: "full" | "partial";
+  rsc?: true;
+} {
+  if (page.ppr) return { render: "ssr", prerender: "partial" };
+  if (output.rsc?.pages?.[pageId]) return { render: "ssr", rsc: true };
+  if (page.render === "ssg" || page.rendering.prerender === "full") {
+    return { render: "ssr", prerender: "full" };
+  }
+  if (page.render === "ssr") return { render: "ssr" };
   if (page.render === "csr") {
     throw new Error(
       `[evjs] CSR page "${pageId}" cannot be emitted as a server deployment route.`,
     );
   }
-  return page.render;
+  throw new Error(
+    `[evjs] Page "${pageId}" render mode "${page.render}" cannot be emitted as a server deployment route.`,
+  );
 }
 
 function findOutputRouteForPage(

--- a/packages/shared/src/manifest/linker.ts
+++ b/packages/shared/src/manifest/linker.ts
@@ -6,6 +6,7 @@ import type {
   BuildPlan,
   DeploymentDocumentOutput,
   DeploymentMetadata,
+  DeploymentPageRenderOutput,
   DeploymentRouteOutput,
   HtmlDocumentOutput,
   HydrationMode,
@@ -50,11 +51,11 @@ export interface ServerManifestOutput {
 }
 
 export type ServerManifestRouteOutput =
-  | Extract<DeploymentRouteOutput, { kind: "page-server" }>
-  | Extract<DeploymentRouteOutput, { kind: "framework-function" }>
-  | Extract<DeploymentRouteOutput, { kind: "framework-ppr" }>
-  | Extract<DeploymentRouteOutput, { kind: "framework-rsc" }>
-  | Extract<DeploymentRouteOutput, { kind: "server-route" }>;
+  | Extract<DeploymentRouteOutput, { kind: "server-page" }>
+  | Extract<DeploymentRouteOutput, { kind: "server-function" }>
+  | Extract<DeploymentRouteOutput, { kind: "ppr-endpoint" }>
+  | Extract<DeploymentRouteOutput, { kind: "rsc-endpoint" }>
+  | Extract<DeploymentRouteOutput, { kind: "api-route" }>;
 
 export function linkBuildOutput(input: BuildOutputLinkInput): BuildOutput {
   const clientEntryAssets = input.clientEntryAssets ?? {};
@@ -430,11 +431,11 @@ function isServerManifestRoute(
   route: DeploymentRouteOutput,
 ): route is ServerManifestRouteOutput {
   return (
-    route.kind === "page-server" ||
-    route.kind === "framework-function" ||
-    route.kind === "framework-ppr" ||
-    route.kind === "framework-rsc" ||
-    route.kind === "server-route"
+    route.kind === "server-page" ||
+    route.kind === "server-function" ||
+    route.kind === "ppr-endpoint" ||
+    route.kind === "rsc-endpoint" ||
+    route.kind === "api-route"
   );
 }
 
@@ -495,11 +496,13 @@ function createDeploymentDocuments(
   const documents: DeploymentDocumentOutput[] = [];
   for (const [id, app] of Object.entries(output.apps)) {
     if (!app.document) continue;
+    const fallbackRoute = findOutputRouteForApp(output, id);
     documents.push(
       pruneUndefined({
         kind: "app" as const,
         id,
         fileName: app.document.fileName,
+        fallback: fallbackRoute?.path,
         assets: includeAssets ? app.assets : undefined,
       }),
     );
@@ -526,39 +529,32 @@ function createDeploymentRoutes(output: BuildOutput): DeploymentRouteOutput[] {
       if (!page) continue;
       if (page.document && (page.render === "csr" || page.render === "ssg")) {
         routes.push({
-          kind: "static-document",
+          kind: "static-page",
           path: route.path,
           documentId: route.pageId,
+          render: page.render,
           methods: ["GET", "HEAD"],
         });
         continue;
       }
       if (page.render !== "csr") {
         routes.push({
-          kind: "page-server",
+          kind: "server-page",
           path: route.path,
           pageId: route.pageId,
+          render: createDeploymentPageRender(output, route.pageId, page),
           methods: ["GET", "HEAD"],
         });
       }
       continue;
     }
 
-    if (route.appId) {
-      const app = output.apps[route.appId];
-      if (!app?.document) continue;
-      routes.push({
-        kind: "spa-fallback",
-        path: route.path,
-        documentId: route.appId,
-        methods: ["GET", "HEAD"],
-      });
-    }
+    if (route.appId) continue;
   }
 
   if (Object.keys(output.server.functions).length > 0) {
     routes.push({
-      kind: "framework-function",
+      kind: "server-function",
       path: output.runtime.server.fn,
       methods: ["POST"],
     });
@@ -567,7 +563,7 @@ function createDeploymentRoutes(output: BuildOutput): DeploymentRouteOutput[] {
     const pprPath = output.runtime.server.ppr;
     if (pprPath) {
       routes.push({
-        kind: "framework-ppr",
+        kind: "ppr-endpoint",
         path: `${pprPath}/*`,
         methods: ["GET", "HEAD"],
       });
@@ -575,14 +571,14 @@ function createDeploymentRoutes(output: BuildOutput): DeploymentRouteOutput[] {
   }
   if (output.rsc && output.runtime.server.rsc) {
     routes.push({
-      kind: "framework-rsc",
+      kind: "rsc-endpoint",
       path: output.runtime.server.rsc,
       methods: ["GET", "HEAD"],
     });
   }
   for (const route of output.server.routes) {
     routes.push({
-      kind: "server-route",
+      kind: "api-route",
       path: route.path,
       methods: [...route.methods],
     });
@@ -590,11 +586,33 @@ function createDeploymentRoutes(output: BuildOutput): DeploymentRouteOutput[] {
   return routes;
 }
 
+function createDeploymentPageRender(
+  output: BuildOutput,
+  pageId: string,
+  page: PageOutput,
+): Exclude<DeploymentPageRenderOutput, "csr"> {
+  if (page.ppr) return "ppr";
+  if (output.rsc?.pages?.[pageId]) return "rsc";
+  if (page.render === "csr") {
+    throw new Error(
+      `[evjs] CSR page "${pageId}" cannot be emitted as a server deployment route.`,
+    );
+  }
+  return page.render;
+}
+
 function findOutputRouteForPage(
   output: BuildOutput,
   pageId: string,
 ): BuildOutput["routes"][number] | undefined {
   return output.routes.find((route) => route.pageId === pageId);
+}
+
+function findOutputRouteForApp(
+  output: BuildOutput,
+  appId: string,
+): BuildOutput["routes"][number] | undefined {
+  return output.routes.find((route) => route.appId === appId);
 }
 
 function createHtmlDocumentLookup(html: BuildPlan["html"]): {

--- a/packages/shared/src/manifest/linker.ts
+++ b/packages/shared/src/manifest/linker.ts
@@ -1,22 +1,20 @@
 import type {
   AppGraph,
-  AppOutput,
   AssetGroup,
   BuildEntry,
   BuildOutput,
   BuildPlan,
+  DeploymentDocumentOutput,
+  DeploymentMetadata,
+  DeploymentRouteOutput,
   HtmlDocumentOutput,
   HydrationMode,
   PageNode,
   PageOutput,
   PageRenderingOutput,
-  PprRegionOutput,
-  PublicAppOutput,
   PublicManifestOutput,
   PublicPageOutput,
-  PublicPprRegionOutput,
   PublicRoutingOutput,
-  PublicRuntimeModuleOutput,
   ServerFunctionOutput,
   ServerRouteOutput,
 } from "./index.js";
@@ -48,13 +46,6 @@ export interface BuildOutputLinkInput {
 export interface ServerManifestOutput {
   version: 1;
   entry?: string;
-  functions: string[];
-  routes: ServerManifestRouteOutput[];
-}
-
-export interface ServerManifestRouteOutput {
-  path: string;
-  methods: string[];
 }
 
 export function linkBuildOutput(input: BuildOutputLinkInput): BuildOutput {
@@ -361,12 +352,12 @@ function assertServerRuntimeEntry(
 }
 
 /**
- * Project the internal build output into the public runtime manifest that is
- * safe to serve to browsers.
+ * Project the internal build output into a lightweight public manifest that is
+ * safe for deployment tooling to read.
  *
- * The public manifest keeps browser-safe deployment metadata. Runtime startup
- * data lives in `runtime.json`; framework endpoints live under
- * `BuildOutput.runtime.server`.
+ * The public manifest keeps browser-safe assets plus SPA/MPA routing metadata.
+ * Runtime startup data stays in the generated ClientRuntime contract, and
+ * framework endpoints stay in FrameworkRuntime/deployment metadata.
  */
 export function createPublicManifest(
   output: BuildOutput,
@@ -377,24 +368,7 @@ export function createPublicManifest(
     buildId: output.buildId,
     publicPath: output.publicPath,
     assets: clonePublicAssetRecord(output.assets, publicAssetFiles),
-    app: createPublicManifestApp(output),
     routing: createPublicManifestRouting(output, publicAssetFiles),
-    rsc: output.rsc
-      ? pruneUndefined({
-          pages: output.rsc.pages
-            ? Object.fromEntries(
-                Object.entries(output.rsc.pages).map(([id, page]) => [
-                  id,
-                  pruneUndefined({
-                    renderer: page.renderer,
-                    assets: clonePublicAssets(page.assets, publicAssetFiles),
-                    routeId: page.routeId,
-                  }),
-                ]),
-              )
-            : undefined,
-        })
-      : undefined,
   }) as PublicManifestOutput;
 }
 
@@ -430,27 +404,40 @@ function createPublicManifestRouting(
   };
 }
 
-function createPublicManifestApp(
-  output: BuildOutput,
-): PublicAppOutput | undefined {
-  const app = output.apps.default ?? Object.values(output.apps)[0];
-  return app ? sanitizeAppOutput(app) : undefined;
-}
-
 export function createServerManifest(
   output: BuildOutput,
 ): ServerManifestOutput {
-  const routes = output.server.routes.map((route) => ({
-    path: route.path,
-    methods: [...route.methods],
-  }));
-
   return {
     version: 1,
     ...(output.server.entry ? { entry: output.server.entry } : {}),
-    functions: Object.keys(output.server.functions),
-    routes,
   };
+}
+
+export interface DeploymentMetadataOptions {
+  includeAssets?: boolean;
+}
+
+export function createDeploymentMetadata(
+  output: BuildOutput,
+  options: DeploymentMetadataOptions = {},
+): DeploymentMetadata {
+  const includeAssets = options.includeAssets ?? true;
+  const publicAssetFiles = collectPublicAssetFiles(output);
+  return pruneUndefined({
+    version: 1 as const,
+    buildId: output.buildId,
+    paths: output.paths,
+    publicPath: output.publicPath,
+    assets: includeAssets
+      ? clonePublicAssetRecord(output.assets, publicAssetFiles)
+      : undefined,
+    documents: createDeploymentDocuments(output, includeAssets),
+    routes: createDeploymentRoutes(output),
+    server: pruneUndefined({
+      entry: output.server.entry,
+    }),
+    metadata: output.deployment,
+  }) as DeploymentMetadata;
 }
 
 function createBuildOutputPaths(
@@ -463,15 +450,6 @@ function createBuildOutputPaths(
   };
 }
 
-function sanitizeAppOutput(app: AppOutput): PublicAppOutput {
-  return pruneUndefined({
-    assets: cloneAssets(app.assets),
-    document: cloneHtmlDocument(app.document),
-    mount: app.mount,
-    module: sanitizeRuntimeModule(app.module),
-  }) as PublicAppOutput;
-}
-
 function sanitizePageOutput(
   page: PageOutput,
   publicAssetFiles: Set<string>,
@@ -480,28 +458,111 @@ function sanitizePageOutput(
   return pruneUndefined({
     assets: clonePublicAssets(page.assets, publicAssetFiles),
     document: cloneHtmlDocument(page.document),
-    render: page.render,
-    rendering: page.rendering,
     path: page.path ?? route?.path,
     routeId: page.routeId ?? route?.id,
-    componentModel: page.componentModel,
-    hydrate: page.hydrate,
-    mount: page.mount,
-    prerender: page.prerender,
-    module: sanitizeRuntimeModule(page.module),
-    ppr: page.ppr
-      ? {
-          delivery: page.ppr.delivery ?? "merge",
-          shell: clonePublicAssets(page.ppr.shell, publicAssetFiles),
-          regions: Object.fromEntries(
-            Object.entries(page.ppr.regions).map(([id, region]) => [
-              id,
-              sanitizePprRegion(region, publicAssetFiles),
-            ]),
-          ),
-        }
-      : undefined,
   }) as PublicPageOutput;
+}
+
+function createDeploymentDocuments(
+  output: BuildOutput,
+  includeAssets: boolean,
+): DeploymentDocumentOutput[] {
+  const documents: DeploymentDocumentOutput[] = [];
+  for (const [id, app] of Object.entries(output.apps)) {
+    if (!app.document) continue;
+    documents.push(
+      pruneUndefined({
+        kind: "app" as const,
+        id,
+        fileName: app.document.fileName,
+        assets: includeAssets ? app.assets : undefined,
+      }),
+    );
+  }
+  for (const [id, page] of Object.entries(output.pages)) {
+    if (!page.document) continue;
+    documents.push(
+      pruneUndefined({
+        kind: "page" as const,
+        id,
+        fileName: page.document.fileName,
+        assets: includeAssets ? page.assets : undefined,
+      }),
+    );
+  }
+  return documents;
+}
+
+function createDeploymentRoutes(output: BuildOutput): DeploymentRouteOutput[] {
+  const routes: DeploymentRouteOutput[] = [];
+  for (const route of output.routes) {
+    if (route.pageId) {
+      const page = output.pages[route.pageId];
+      if (!page) continue;
+      if (page.document && (page.render === "csr" || page.render === "ssg")) {
+        routes.push({
+          kind: "static-document",
+          path: route.path,
+          documentId: route.pageId,
+          methods: ["GET", "HEAD"],
+        });
+        continue;
+      }
+      if (page.render !== "csr") {
+        routes.push({
+          kind: "page-server",
+          path: route.path,
+          pageId: route.pageId,
+          methods: ["GET", "HEAD"],
+        });
+      }
+      continue;
+    }
+
+    if (route.appId) {
+      const app = output.apps[route.appId];
+      if (!app?.document) continue;
+      routes.push({
+        kind: "spa-fallback",
+        path: route.path,
+        documentId: route.appId,
+        methods: ["GET", "HEAD"],
+      });
+    }
+  }
+
+  if (Object.keys(output.server.functions).length > 0) {
+    routes.push({
+      kind: "framework-function",
+      path: output.runtime.server.fn,
+      methods: ["POST"],
+    });
+  }
+  if (Object.values(output.pages).some((page) => page.ppr)) {
+    const pprPath = output.runtime.server.ppr;
+    if (pprPath) {
+      routes.push({
+        kind: "framework-ppr",
+        path: `${pprPath}/*`,
+        methods: ["GET", "HEAD"],
+      });
+    }
+  }
+  if (output.rsc && output.runtime.server.rsc) {
+    routes.push({
+      kind: "framework-rsc",
+      path: output.runtime.server.rsc,
+      methods: ["GET", "HEAD"],
+    });
+  }
+  for (const route of output.server.routes) {
+    routes.push({
+      kind: "server-route",
+      path: route.path,
+      methods: [...route.methods],
+    });
+  }
+  return routes;
 }
 
 function findOutputRouteForPage(
@@ -536,28 +597,6 @@ function cloneHtmlDocument(
   return document ? { fileName: document.fileName } : undefined;
 }
 
-function sanitizePprRegion(
-  region: PprRegionOutput,
-  publicAssetFiles: Set<string>,
-): PublicPprRegionOutput {
-  return pruneUndefined({
-    id: region.id,
-    assets: clonePublicAssets(region.assets, publicAssetFiles),
-    cache: region.cache,
-    hydrate: region.hydrate,
-  }) as PublicPprRegionOutput;
-}
-
-function sanitizeRuntimeModule(
-  module: PublicRuntimeModuleOutput | undefined,
-): PublicRuntimeModuleOutput | undefined {
-  if (!module) return undefined;
-  return pruneUndefined({
-    type: module.type,
-    href: module.href,
-  }) as PublicRuntimeModuleOutput;
-}
-
 function clonePublicAssetRecord(
   assets: Record<string, AssetGroup>,
   publicAssetFiles: Set<string>,
@@ -584,13 +623,6 @@ function collectPublicAssetFiles(output: BuildOutput): Set<string> {
   for (const page of Object.values(output.pages)) collect(page.assets);
 
   return files;
-}
-
-function cloneAssets(assets: AssetGroup): AssetGroup {
-  return {
-    js: [...assets.js],
-    css: [...assets.css],
-  };
 }
 
 function clonePublicAssets(

--- a/packages/shared/src/manifest/linker.ts
+++ b/packages/shared/src/manifest/linker.ts
@@ -15,6 +15,7 @@ import type {
   PublicManifestOutput,
   PublicPageOutput,
   PublicPprRegionOutput,
+  PublicRoutingOutput,
   PublicRuntimeModuleOutput,
   ServerFunctionOutput,
   ServerRouteOutput,
@@ -377,19 +378,7 @@ export function createPublicManifest(
     publicPath: output.publicPath,
     assets: clonePublicAssetRecord(output.assets, publicAssetFiles),
     app: createPublicManifestApp(output),
-    pages: Object.fromEntries(
-      Object.entries(output.pages).map(([id, page]) => [
-        id,
-        sanitizePageOutput(page, publicAssetFiles),
-      ]),
-    ),
-    routes: output.routes.map((route) =>
-      pruneUndefined({
-        id: route.id,
-        path: route.path,
-        pageId: route.pageId,
-      }),
-    ),
+    routing: createPublicManifestRouting(output, publicAssetFiles),
     rsc: output.rsc
       ? pruneUndefined({
           pages: output.rsc.pages
@@ -407,6 +396,38 @@ export function createPublicManifest(
         })
       : undefined,
   }) as PublicManifestOutput;
+}
+
+function createPublicManifestRouting(
+  output: BuildOutput,
+  publicAssetFiles: Set<string>,
+): PublicRoutingOutput {
+  if (Object.keys(output.pages).length > 0) {
+    return {
+      kind: "mpa",
+      pages: Object.fromEntries(
+        Object.entries(output.pages).map(([id, page]) => [
+          id,
+          sanitizePageOutput(
+            page,
+            publicAssetFiles,
+            findOutputRouteForPage(output, id),
+          ),
+        ]),
+      ),
+    };
+  }
+
+  return {
+    kind: "spa",
+    routes: output.routes.map((route) =>
+      pruneUndefined({
+        id: route.id,
+        path: route.path,
+        pageId: route.pageId,
+      }),
+    ),
+  };
 }
 
 function createPublicManifestApp(
@@ -454,14 +475,15 @@ function sanitizeAppOutput(app: AppOutput): PublicAppOutput {
 function sanitizePageOutput(
   page: PageOutput,
   publicAssetFiles: Set<string>,
+  route?: BuildOutput["routes"][number],
 ): PublicPageOutput {
   return pruneUndefined({
     assets: clonePublicAssets(page.assets, publicAssetFiles),
     document: cloneHtmlDocument(page.document),
     render: page.render,
     rendering: page.rendering,
-    path: page.path,
-    routeId: page.routeId,
+    path: page.path ?? route?.path,
+    routeId: page.routeId ?? route?.id,
     componentModel: page.componentModel,
     hydrate: page.hydrate,
     mount: page.mount,
@@ -480,6 +502,13 @@ function sanitizePageOutput(
         }
       : undefined,
   }) as PublicPageOutput;
+}
+
+function findOutputRouteForPage(
+  output: BuildOutput,
+  pageId: string,
+): BuildOutput["routes"][number] | undefined {
+  return output.routes.find((route) => route.pageId === pageId);
 }
 
 function createHtmlDocumentLookup(html: BuildPlan["html"]): {

--- a/packages/shared/src/manifest/linker.ts
+++ b/packages/shared/src/manifest/linker.ts
@@ -13,6 +13,7 @@ import type {
   PageNode,
   PageOutput,
   PageRenderingOutput,
+  PublicDocumentOutput,
   PublicManifestOutput,
   PublicPageOutput,
   PublicRoutingOutput,
@@ -81,12 +82,14 @@ export function linkBuildOutput(input: BuildOutputLinkInput): BuildOutput {
   const serverRuntimeAssets = serverRuntimeEntry
     ? serverAssetsForEntry(serverRuntimeEntry)
     : fallbackServerAssets;
-  const serverEntry = assertServerRuntimeEntry(
-    input.serverEntry ?? serverRuntimeAssets.js[0],
-    serverRuntimeAssets,
-    serverRuntimeEntry,
-  );
-  const serverAssets = serverRuntimeAssets;
+  const serverEntry = serverRuntimeEntry
+    ? assertServerRuntimeEntry(
+        input.serverEntry ?? serverRuntimeAssets.js[0],
+        serverRuntimeAssets,
+        serverRuntimeEntry,
+      )
+    : undefined;
+  const serverAssets = serverRuntimeEntry ? serverRuntimeAssets : EMPTY_ASSETS;
 
   const findEntryByOwner = (
     owner: BuildEntry["owner"],
@@ -372,15 +375,25 @@ export function createPublicManifest(
   output: BuildOutput,
 ): PublicManifestOutput {
   const publicAssetFiles = collectPublicAssetFiles(output);
+  const documents = createPublicDocumentManifest(output, publicAssetFiles);
+  if (documents) {
+    return {
+      version: output.version,
+      buildId: output.buildId,
+      publicPath: output.publicPath,
+      documents,
+    };
+  }
   const routing = createPublicManifestRouting(output, publicAssetFiles);
+  const assets =
+    routing.kind === "spa"
+      ? clonePublicAssetRecord(output.assets, publicAssetFiles)
+      : undefined;
   return pruneUndefined({
     version: output.version,
     buildId: output.buildId,
     publicPath: output.publicPath,
-    assets:
-      routing.kind === "spa"
-        ? clonePublicAssetRecord(output.assets, publicAssetFiles)
-        : undefined,
+    assets: assets && hasAssetRecordEntries(assets) ? assets : undefined,
     routing,
   }) as PublicManifestOutput;
 }
@@ -413,9 +426,95 @@ function createPublicManifestRouting(
         id: route.id,
         path: route.path,
         pageId: route.pageId,
+        render: route.pageId ? output.pages[route.pageId]?.render : undefined,
       }),
     ),
   };
+}
+
+function createPublicDocumentManifest(
+  output: BuildOutput,
+  publicAssetFiles: Set<string>,
+): PublicDocumentOutput[] | undefined {
+  if (!isStaticDocumentOnlyOutput(output)) return undefined;
+  const documents = createStaticSsgDocumentRecords(output).map((document) =>
+    pruneUndefined({
+      id: document.id,
+      path: document.path,
+      fileName: document.fileName,
+      render: document.render,
+      assets: optionalAssetGroup(
+        clonePublicAssets(document.assets, publicAssetFiles),
+      ),
+    }),
+  );
+  return documents.length > 0 ? documents : undefined;
+}
+
+function isStaticDocumentOnlyOutput(output: BuildOutput): boolean {
+  const documentIds = new Set(
+    createStaticSsgDocumentRecords(output).map((document) => document.id),
+  );
+  if (documentIds.size === 0) return false;
+  if (
+    Object.keys(output.pages).some((pageId) => !documentIds.has(pageId)) ||
+    output.routes.some(
+      (route) => !route.pageId || !documentIds.has(route.pageId),
+    )
+  ) {
+    return false;
+  }
+  if (output.server.entry) return false;
+  if (Object.keys(output.server.functions).length > 0) return false;
+  if (output.server.routes.length > 0) return false;
+  if (output.rsc && Object.keys(output.rsc.pages ?? {}).length > 0) {
+    return false;
+  }
+  if (
+    Object.values(output.apps).some(
+      (app) =>
+        app.document ||
+        app.assets.js.length > 0 ||
+        app.assets.css.length > 0 ||
+        app.module,
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function createStaticSsgDocumentRecords(output: BuildOutput): Array<{
+  id: string;
+  path: string;
+  fileName: string;
+  render: Extract<PageOutput["render"], "ssg">;
+  assets: AssetGroup;
+}> {
+  return Object.entries(output.pages).flatMap(([id, page]) => {
+    if (
+      !page.document ||
+      page.render !== "ssg" ||
+      page.rendering.html !== "static" ||
+      page.rendering.prerender !== "full" ||
+      page.ppr
+    ) {
+      return [];
+    }
+    const route = findOutputRouteForPage(output, id);
+    const path = route?.path ?? page.path;
+    if (!path?.startsWith("/")) return [];
+    return [
+      {
+        id,
+        path,
+        fileName: page.document.fileName,
+        render: page.render,
+        assets: page.assets,
+      },
+    ];
+  });
 }
 
 export function createServerManifest(
@@ -450,14 +549,15 @@ export function createDeploymentMetadata(
 ): DeploymentMetadata {
   const includeAssets = options.includeAssets ?? true;
   const publicAssetFiles = collectPublicAssetFiles(output);
+  const assets = includeAssets
+    ? clonePublicAssetRecord(output.assets, publicAssetFiles)
+    : undefined;
   return pruneUndefined({
     version: 1 as const,
     buildId: output.buildId,
     paths: output.paths,
     publicPath: output.publicPath,
-    assets: includeAssets
-      ? clonePublicAssetRecord(output.assets, publicAssetFiles)
-      : undefined,
+    assets: assets && hasAssetRecordEntries(assets) ? assets : undefined,
     documents: createDeploymentDocuments(output, includeAssets),
     routes: createDeploymentRoutes(output),
     server: pruneUndefined({
@@ -487,6 +587,7 @@ function sanitizePageOutput(
     document: cloneHtmlDocument(page.document),
     path: page.path ?? route?.path,
     routeId: page.routeId ?? route?.id,
+    render: page.render,
   }) as PublicPageOutput;
 }
 
@@ -504,18 +605,21 @@ function createDeploymentDocuments(
         id,
         fileName: app.document.fileName,
         fallback: fallbackRoute?.path,
-        assets: includeAssets ? app.assets : undefined,
+        assets: includeAssets ? optionalAssetGroup(app.assets) : undefined,
       }),
     );
   }
   for (const [id, page] of Object.entries(output.pages)) {
     if (!page.document) continue;
+    const route = findOutputRouteForPage(output, id);
+    const staticDocument = createStaticDocumentMetadata(page, route);
     documents.push(
       pruneUndefined({
         kind: "page" as const,
         id,
         fileName: page.document.fileName,
-        assets: includeAssets ? page.assets : undefined,
+        ...staticDocument,
+        assets: includeAssets ? optionalAssetGroup(page.assets) : undefined,
       }),
     );
   }
@@ -529,13 +633,6 @@ function createDeploymentRoutes(output: BuildOutput): DeploymentRouteOutput[] {
       const page = output.pages[route.pageId];
       if (!page) continue;
       if (page.document && (page.render === "csr" || page.render === "ssg")) {
-        routes.push({
-          kind: "static-page",
-          path: route.path,
-          documentId: route.pageId,
-          render: page.render,
-          methods: ["GET", "HEAD"],
-        });
         continue;
       }
       if (page.render !== "csr") {
@@ -590,6 +687,19 @@ function createDeploymentRoutes(output: BuildOutput): DeploymentRouteOutput[] {
     });
   }
   return routes;
+}
+
+function createStaticDocumentMetadata(
+  page: PageOutput,
+  route: BuildOutput["routes"][number] | undefined,
+): { path?: string; render?: Extract<PageOutput["render"], "csr" | "ssg"> } {
+  if (page.render !== "csr" && page.render !== "ssg") return {};
+  const path = route?.path ?? page.path;
+  if (!path) return {};
+  return {
+    path,
+    render: page.render,
+  };
 }
 
 function createDeploymentServerPageRendering(
@@ -669,6 +779,14 @@ function clonePublicAssetRecord(
           (group as AssetGroup).css.length > 0,
       ),
   ) as Record<string, AssetGroup>;
+}
+
+function hasAssetRecordEntries(assets: Record<string, AssetGroup>): boolean {
+  return Object.keys(assets).length > 0;
+}
+
+function optionalAssetGroup(assets: AssetGroup): AssetGroup | undefined {
+  return assets.js.length > 0 || assets.css.length > 0 ? assets : undefined;
 }
 
 function collectPublicAssetFiles(output: BuildOutput): Set<string> {
@@ -775,13 +893,14 @@ function linkServerRenderers(
       );
       return [
         renderer.name,
-        {
+        pruneUndefined({
           kind: renderer.kind,
+          phase: renderer.phase,
           owner: renderer.owner,
           assets: entry
             ? serverAssetsForEntry(entry)
             : assetsForSource(renderer.import),
-        },
+        }),
       ];
     }),
   );

--- a/packages/shared/tests/manifest.test.ts
+++ b/packages/shared/tests/manifest.test.ts
@@ -3092,7 +3092,7 @@ describe("createPublicManifest", () => {
     expect(manifest.routes.flatMap((route) => Object.keys(route))).not.toEqual(
       expect.arrayContaining(["module", "render", "hydrate", "runtime"]),
     );
-    expect(manifest.apps.admin.document).toEqual({ fileName: "admin.html" });
+    expect(manifest.app?.document).toEqual({ fileName: "admin.html" });
     expect(manifest.pages.insights.document).toEqual({
       fileName: "insights.html",
     });

--- a/packages/shared/tests/manifest.test.ts
+++ b/packages/shared/tests/manifest.test.ts
@@ -2520,7 +2520,13 @@ describe("linkBuildOutput", () => {
           prerender: true,
         },
       },
-      routes: [],
+      routes: [
+        {
+          id: "article",
+          path: "/article",
+          pageId: "article",
+        },
+      ],
       serverFunctions: [],
       serverRoutes: [],
     };
@@ -2584,6 +2590,14 @@ describe("linkBuildOutput", () => {
     });
     expect(output.pages.article.document).toEqual({
       fileName: "article.html",
+    });
+    expect(createDeploymentMetadata(output).routes).toContainEqual({
+      kind: "server-page",
+      path: "/article",
+      pageId: "article",
+      render: "ssr",
+      prerender: "full",
+      methods: ["GET", "HEAD"],
     });
   });
 
@@ -3202,7 +3216,8 @@ describe("createPublicManifest", () => {
         kind: "server-page",
         path: "/insights",
         pageId: "insights",
-        render: "rsc",
+        render: "ssr",
+        rsc: true,
         methods: ["GET", "HEAD"],
       },
       {
@@ -3216,7 +3231,8 @@ describe("createPublicManifest", () => {
         kind: "server-page",
         path: "/settlement-report",
         pageId: "settlement",
-        render: "ssg",
+        render: "ssr",
+        prerender: "full",
         methods: ["GET", "HEAD"],
       },
       {
@@ -3368,14 +3384,16 @@ describe("createServerManifest", () => {
           kind: "server-page",
           path: "/dashboard",
           pageId: "dashboard",
-          render: "rsc",
+          render: "ssr",
+          rsc: true,
           methods: ["GET", "HEAD"],
         },
         {
           kind: "server-page",
           path: "/campaign",
           pageId: "campaign",
-          render: "ppr",
+          render: "ssr",
+          prerender: "partial",
           methods: ["GET", "HEAD"],
         },
         {

--- a/packages/shared/tests/manifest.test.ts
+++ b/packages/shared/tests/manifest.test.ts
@@ -2973,16 +2973,7 @@ describe("createPublicManifest", () => {
       assets: {
         dashboard: { js: ["dashboard.js"], css: ["dashboard.css"] },
       },
-      apps: {
-        admin: {
-          assets: { js: ["admin.js"], css: [] },
-          document: { fileName: "admin.html" },
-          module: {
-            type: "entry",
-            href: "admin.js",
-          },
-        },
-      },
+      apps: {},
       pages: {
         insights: {
           assets: { js: ["evjs-rsc-client.js"], css: ["insights.css"] },
@@ -3070,11 +3061,6 @@ describe("createPublicManifest", () => {
           id: "settlement",
           path: "/settlement-report",
           pageId: "settlement",
-        },
-        {
-          id: "spa_fallback",
-          path: "*",
-          appId: "admin",
         },
       ],
       server: {
@@ -3186,13 +3172,6 @@ describe("createPublicManifest", () => {
     const deployment = createDeploymentMetadata(output);
     expect(deployment.documents).toEqual([
       {
-        kind: "app",
-        id: "admin",
-        fileName: "admin.html",
-        fallback: "*",
-        assets: { js: ["admin.js"], css: [] },
-      },
-      {
         kind: "page",
         id: "insights",
         fileName: "insights.html",
@@ -3288,6 +3267,55 @@ describe("createPublicManifest", () => {
       routing: {
         kind: "spa",
         routes: [{ id: "home", path: "/" }],
+      },
+    });
+  });
+
+  it("keeps route-owned SSG page documents in SPA manifests", () => {
+    const output: BuildOutput = {
+      ...createMinimalBuildOutput(),
+      assets: {
+        main: { js: ["main.js"], css: [] },
+      },
+      apps: {
+        default: {
+          assets: { js: ["main.js"], css: [] },
+          document: { fileName: "index.html" },
+        },
+      },
+      pages: {
+        report: {
+          assets: { js: [], css: [] },
+          document: { fileName: "report.html" },
+          render: "ssg",
+          rendering: {
+            component: "server",
+            html: "static",
+            prerender: "full",
+            streaming: false,
+            hydrate: "none",
+          },
+          path: "/report",
+          routeId: "report",
+        },
+      },
+      routes: [
+        {
+          id: "report",
+          path: "/report",
+          appId: "default",
+          pageId: "report",
+        },
+      ],
+    };
+
+    expect(createPublicManifest(output)).toMatchObject({
+      assets: {
+        main: { js: ["main.js"], css: [] },
+      },
+      routing: {
+        kind: "spa",
+        routes: [{ id: "report", path: "/report", pageId: "report" }],
       },
     });
   });

--- a/packages/shared/tests/manifest.test.ts
+++ b/packages/shared/tests/manifest.test.ts
@@ -15,7 +15,11 @@ function createMinimalBuildOutput(): BuildOutput {
   return {
     version: 1,
     buildId: "build",
-    distDir: "dist",
+    paths: {
+      rootDir: "dist",
+      publicDir: "dist/client",
+      serverDir: "dist/server",
+    },
     publicPath: "/",
     runtime: {
       server: {
@@ -118,10 +122,10 @@ describe("assertFrameworkManifestShape", () => {
 
     expect(() =>
       assertFrameworkManifestShape(
-        { ...createMinimalBuildOutput(), distDir: "" },
+        { ...createMinimalBuildOutput(), paths: null },
         "manifest",
       ),
-    ).toThrow("[evjs] manifest.distDir must be a non-empty string.");
+    ).toThrow("[evjs] manifest.paths must be an object.");
 
     expect(() =>
       assertFrameworkManifestShape(
@@ -1265,24 +1269,6 @@ describe("assertFrameworkManifestShape", () => {
       assertFrameworkManifestShape(
         {
           ...createMinimalBuildOutput(),
-          routes: [
-            {
-              id: "home",
-              path: "/home",
-              module: " ./src/pages/Home.tsx ",
-            },
-          ],
-        },
-        "manifest",
-      ),
-    ).toThrow(
-      "[evjs] manifest.routes[0].module must not contain leading or trailing whitespace.",
-    );
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
           pages: {
             home: {
               assets: { js: [], css: [] },
@@ -1381,29 +1367,6 @@ describe("assertFrameworkManifestShape", () => {
       ),
     ).toThrow(
       '[evjs] manifest.server.renderers key "dashboard.server" must contain only letters, numbers, underscores, or hyphens.',
-    );
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
-          server: {
-            assets: { js: [], css: [] },
-            renderers: {
-              dashboard: {
-                kind: "page-server",
-                module: "",
-                assets: { js: [], css: [] },
-              },
-            },
-            functions: {},
-            routes: [],
-          },
-        },
-        "manifest",
-      ),
-    ).toThrow(
-      "[evjs] manifest.server.renderers.dashboard.module must be a non-empty string.",
     );
 
     expect(() =>
@@ -1711,28 +1674,6 @@ describe("assertFrameworkManifestShape", () => {
       ),
     ).toThrow(
       '[evjs] manifest.server.functions key " getUser" must be a non-empty string without leading or trailing whitespace.',
-    );
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
-          server: {
-            assets: { js: [], css: [] },
-            functions: {
-              getUser: {
-                module: "",
-                exportName: "getUser",
-                assets: { js: [], css: [] },
-              },
-            },
-            routes: [],
-          },
-        },
-        "manifest",
-      ),
-    ).toThrow(
-      "[evjs] manifest.server.functions.getUser.module must be a non-empty string.",
     );
 
     expect(() =>
@@ -2089,7 +2030,6 @@ describe("assertFrameworkManifestShape", () => {
         {
           ...createMinimalBuildOutput(),
           rsc: {
-            endpoint: "/__evjs/rsc",
             pages: [],
           },
         },
@@ -2102,7 +2042,6 @@ describe("assertFrameworkManifestShape", () => {
         {
           ...createMinimalBuildOutput(),
           rsc: {
-            endpoint: "/__evjs/rsc",
             pages: {
               insights: [],
             },
@@ -2117,7 +2056,6 @@ describe("assertFrameworkManifestShape", () => {
         {
           ...createMinimalBuildOutput(),
           rsc: {
-            endpoint: "/__evjs/rsc",
             pages: {
               insights: {
                 renderer: "insights-rsc",
@@ -2188,7 +2126,6 @@ describe("assertFrameworkManifestShape", () => {
       },
     };
     const rsc = (page: Record<string, unknown>) => ({
-      endpoint: "/__evjs/rsc",
       pages: {
         insights: {
           renderer: "insights-rsc",
@@ -2201,183 +2138,8 @@ describe("assertFrameworkManifestShape", () => {
     expect(() =>
       assertFrameworkManifestShape(
         {
-          ...createMinimalBuildOutput(),
-          rsc: {
-            endpoint: "/__evjs/rsc",
-            clientReferences: {
-              "src/pages/Client.tsx#default": {
-                module: "src/pages/Client.tsx",
-                exportName: "default",
-              },
-            },
-            serverReferences: {
-              "fn:saveInsight": {
-                module: "src/actions.ts",
-                exportName: "saveInsight",
-              },
-            },
-            clientReferenceManifest: {},
-            serverConsumerManifest: {},
-          },
-        },
-        "manifest",
-      ),
-    ).not.toThrow();
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
-          rsc: {
-            clientReferences: {
-              "src/pages/Client.tsx#default": {
-                module: "src/pages/Client.tsx",
-                exportName: "default",
-              },
-            },
-          },
-        },
-        "manifest",
-      ),
-    ).not.toThrow();
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
-          rsc: {
-            endpoint: "/__evjs/rsc",
-            clientReferences: [],
-          },
-        },
-        "manifest",
-      ),
-    ).toThrow("[evjs] manifest.rsc.clientReferences must be an object.");
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
-          rsc: {
-            endpoint: "/__evjs/rsc",
-            clientReferences: {
-              " src/pages/Client.tsx#default": {
-                module: "src/pages/Client.tsx",
-              },
-            },
-          },
-        },
-        "manifest",
-      ),
-    ).toThrow(
-      '[evjs] manifest.rsc.clientReferences key " src/pages/Client.tsx#default" must not contain leading or trailing whitespace.',
-    );
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
-          rsc: {
-            endpoint: "/__evjs/rsc",
-            clientReferences: {
-              "src/pages/Client.tsx#default": [],
-            },
-          },
-        },
-        "manifest",
-      ),
-    ).toThrow(
-      "[evjs] manifest.rsc.clientReferences.src/pages/Client.tsx#default must be an object.",
-    );
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
-          rsc: {
-            endpoint: "/__evjs/rsc",
-            clientReferences: {
-              "src/pages/Client.tsx#default": {
-                module: " src/pages/Client.tsx ",
-              },
-            },
-          },
-        },
-        "manifest",
-      ),
-    ).toThrow(
-      "[evjs] manifest.rsc.clientReferences.src/pages/Client.tsx#default.module must not contain leading or trailing whitespace.",
-    );
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
-          rsc: {
-            endpoint: "/__evjs/rsc",
-            serverReferences: {
-              "fn:saveInsight": {
-                module: "src/actions.ts",
-                exportName: "",
-              },
-            },
-          },
-        },
-        "manifest",
-      ),
-    ).toThrow(
-      "[evjs] manifest.rsc.serverReferences.fn:saveInsight.exportName must be a non-empty string.",
-    );
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
-          rsc: {
-            endpoint: "/__evjs/rsc",
-            clientReferenceManifest: [],
-          },
-        },
-        "manifest",
-      ),
-    ).toThrow("[evjs] manifest.rsc.clientReferenceManifest must be an object.");
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...createMinimalBuildOutput(),
-          rsc: {
-            endpoint: "/__evjs/rsc",
-            serverConsumerManifest: [],
-          },
-        },
-        "manifest",
-      ),
-    ).toThrow("[evjs] manifest.rsc.serverConsumerManifest must be an object.");
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
           ...rscReferenceManifest,
           rsc: {
-            pages: {
-              insights: {
-                renderer: "insights-rsc",
-                assets: { js: [], css: [] },
-              },
-            },
-          },
-        },
-        "manifest",
-      ),
-    ).toThrow("[evjs] manifest.rsc.endpoint must be a non-empty pathname.");
-
-    expect(() =>
-      assertFrameworkManifestShape(
-        {
-          ...rscReferenceManifest,
-          rsc: {
-            endpoint: "/__evjs/rsc",
             pages: {
               missing: {
                 assets: { js: [], css: [] },
@@ -2396,7 +2158,6 @@ describe("assertFrameworkManifestShape", () => {
         {
           ...rscReferenceManifest,
           rsc: {
-            endpoint: "/__evjs/rsc",
             pages: {
               dashboard: {
                 assets: { js: [], css: [] },
@@ -2520,7 +2281,7 @@ describe("assertFrameworkManifestShape", () => {
 });
 
 describe("linkBuildOutput", () => {
-  it("links metadata-only RSC references without requiring a Flight endpoint", () => {
+  it("does not expose metadata-only RSC source references", () => {
     const graph: AppGraph = {
       version: 1,
       rootDir: "/repo",
@@ -2551,19 +2312,7 @@ describe("linkBuildOutput", () => {
 
     const output = linkBuildOutput({ graph, plan });
 
-    expect(output.rsc).toEqual({
-      endpoint: undefined,
-      pages: undefined,
-      clientReferences: {
-        "src/pages/Client.tsx#default": {
-          module: "src/pages/Client.tsx",
-          exportName: "default",
-        },
-      },
-      serverReferences: undefined,
-      clientReferenceManifest: undefined,
-      serverConsumerManifest: undefined,
-    });
+    expect(output.rsc).toBeUndefined();
     expect(() =>
       assertFrameworkManifestShape(output, "manifest"),
     ).not.toThrow();
@@ -3192,7 +2941,11 @@ describe("createPublicManifest", () => {
     const output: BuildOutput = {
       version: 1,
       buildId: "build",
-      distDir: "dist",
+      paths: {
+        rootDir: "dist",
+        publicDir: "dist/client",
+        serverDir: "dist/server",
+      },
       publicPath: "/assets/",
       runtime: {
         server: {
@@ -3208,7 +2961,6 @@ describe("createPublicManifest", () => {
         admin: {
           assets: { js: ["admin.js"], css: [] },
           document: { fileName: "admin.html" },
-          entry: "./src/main.tsx",
           module: {
             type: "entry",
             href: "admin.js",
@@ -3229,7 +2981,6 @@ describe("createPublicManifest", () => {
           },
           path: "/insights",
           routeId: "insights",
-          component: "./src/pages/Insights.tsx",
           module: {
             type: "react-component",
             href: "evjs-rsc-client.js",
@@ -3248,7 +2999,6 @@ describe("createPublicManifest", () => {
             hydrate: "none",
           },
           hydrate: "none",
-          component: "./src/pages/Campaign.tsx",
           ppr: {
             delivery: "stream",
             shell: { js: ["campaign-ppr-shell.js"], css: [] },
@@ -3256,8 +3006,6 @@ describe("createPublicManifest", () => {
               offer: {
                 id: "offer",
                 assets: { js: ["campaign-offer-ppr-region.js"], css: [] },
-                component: "./src/pages/Offer.region.tsx",
-                fallback: "./src/pages/OfferSkeleton.tsx",
                 cache: "no-store",
               },
             },
@@ -3269,7 +3017,6 @@ describe("createPublicManifest", () => {
           id: "insights",
           path: "/insights",
           pageId: "insights",
-          module: "./src/pages/Insights.tsx",
         },
       ],
       server: {
@@ -3279,14 +3026,12 @@ describe("createPublicManifest", () => {
           "insights-rsc": {
             kind: "rsc-page",
             owner: { pageId: "insights" },
-            module: "./src/pages/Insights.tsx",
             assets: { js: ["insights-rsc.js"], css: ["insights.css"] },
           },
         },
         functions: {
           "fn:refund": {
             assets: { js: ["orders.server.js"], css: [] },
-            module: "./src/api/orders.server.ts",
             exportName: "refund",
           },
         },
@@ -3299,24 +3044,11 @@ describe("createPublicManifest", () => {
         ],
       },
       rsc: {
-        endpoint: "/__evjs/rsc",
         pages: {
           insights: {
             renderer: "insights-rsc",
             assets: { js: ["insights-rsc.js"], css: ["insights.css"] },
-            component: "./src/pages/Insights.tsx",
             routeId: "insights",
-          },
-        },
-        clientReferences: {
-          "src/pages/Client.tsx#default": {
-            module: "src/pages/Client.tsx",
-            exportName: "default",
-          },
-        },
-        clientReferenceManifest: {
-          "file:///Users/example/repo/src/pages/Client.tsx": {
-            id: "client",
           },
         },
       },
@@ -3404,7 +3136,6 @@ describe("createServerManifest", () => {
         functions: {
           "fn:getUser": {
             assets: { js: ["users.server.js"], css: [] },
-            module: "./src/api/users.server.ts",
             exportName: "getUser",
           },
         },
@@ -3419,7 +3150,6 @@ describe("createServerManifest", () => {
           dashboard: {
             kind: "page-server",
             owner: { pageId: "dashboard" },
-            module: "./src/pages/dashboard.tsx",
             assets: { js: ["dashboard-server.js"], css: [] },
           },
         },

--- a/packages/shared/tests/manifest.test.ts
+++ b/packages/shared/tests/manifest.test.ts
@@ -6,6 +6,7 @@ import type {
 } from "../src/manifest/index.js";
 import {
   assertFrameworkManifestShape,
+  createDeploymentMetadata,
   createPublicManifest,
   createServerManifest,
   linkBuildOutput as linkManifestBuildOutput,
@@ -2951,6 +2952,7 @@ describe("createPublicManifest", () => {
         server: {
           basePath: "/__evjs",
           fn: "/__evjs/fn",
+          ppr: "/__evjs/ppr",
           rsc: "/__evjs/rsc",
         },
       },
@@ -2986,6 +2988,33 @@ describe("createPublicManifest", () => {
             href: "evjs-rsc-client.js",
           },
         },
+        landing: {
+          assets: { js: ["landing.js"], css: ["landing.css"] },
+          document: { fileName: "landing.html" },
+          render: "ssg",
+          rendering: {
+            component: "client",
+            html: "static",
+            prerender: "full",
+            streaming: false,
+            hydrate: "load",
+          },
+          path: "/landing",
+          routeId: "landing",
+        },
+        settlement: {
+          assets: { js: [], css: ["settlement-server.css"] },
+          render: "ssg",
+          rendering: {
+            component: "server",
+            html: "static",
+            prerender: "full",
+            streaming: false,
+            hydrate: "none",
+          },
+          path: "/settlement-report",
+          routeId: "settlement",
+        },
         campaign: {
           assets: { js: [], css: [] },
           document: { fileName: "campaign.html" },
@@ -3017,6 +3046,21 @@ describe("createPublicManifest", () => {
           id: "insights",
           path: "/insights",
           pageId: "insights",
+        },
+        {
+          id: "landing",
+          path: "/landing",
+          pageId: "landing",
+        },
+        {
+          id: "settlement",
+          path: "/settlement-report",
+          pageId: "settlement",
+        },
+        {
+          id: "spa_fallback",
+          path: "*",
+          appId: "admin",
         },
       ],
       server: {
@@ -3084,14 +3128,11 @@ describe("createPublicManifest", () => {
       js: ["evjs-rsc-client.js"],
       css: ["insights.css"],
     });
-    expect(pages.insights.module).toEqual({
-      type: "react-component",
-      href: "evjs-rsc-client.js",
-    });
+    expect("module" in pages.insights).toBe(false);
     expect("runtime" in manifest).toBe(false);
     expect("pages" in manifest).toBe(false);
     expect("routes" in manifest).toBe(false);
-    expect(manifest.app?.document).toEqual({ fileName: "admin.html" });
+    expect("app" in manifest).toBe(false);
     expect(pages.insights.document).toEqual({
       fileName: "insights.html",
     });
@@ -3099,29 +3140,91 @@ describe("createPublicManifest", () => {
     expect(pages.campaign.document).toEqual({
       fileName: "campaign.html",
     });
-    expect(pages.campaign.hydrate).toBe("none");
-    expect(pages.campaign.rendering.hydrate).toBe("none");
-    expect(pages.campaign.ppr?.delivery).toBe("stream");
-    expect(pages.campaign.ppr?.regions.offer).toEqual({
-      id: "offer",
-      assets: { js: [], css: [] },
-      cache: "no-store",
-    });
+    expect(pages.settlement.document).toBeUndefined();
+    expect("hydrate" in pages.campaign).toBe(false);
+    expect("rendering" in pages.campaign).toBe(false);
+    expect("ppr" in pages.campaign).toBe(false);
     expect("server" in manifest).toBe(false);
-    expect(
-      manifest.rsc ? "clientReferenceManifest" in manifest.rsc : false,
-    ).toBe(false);
-    expect(manifest.rsc ? "clientReferences" in manifest.rsc : false).toBe(
-      false,
-    );
-    expect(manifest.rsc?.pages?.insights).toEqual({
-      renderer: "insights-rsc",
-      assets: { js: [], css: ["insights.css"] },
-      routeId: "insights",
-    });
+    expect("rsc" in manifest).toBe(false);
     expect("distDir" in manifest).toBe(false);
     expect("paths" in manifest).toBe(false);
     expect("deployment" in manifest).toBe(false);
+
+    const deployment = createDeploymentMetadata(output);
+    expect(deployment.documents).toEqual([
+      {
+        kind: "app",
+        id: "admin",
+        fileName: "admin.html",
+        assets: { js: ["admin.js"], css: [] },
+      },
+      {
+        kind: "page",
+        id: "insights",
+        fileName: "insights.html",
+        assets: { js: ["evjs-rsc-client.js"], css: ["insights.css"] },
+      },
+      {
+        kind: "page",
+        id: "landing",
+        fileName: "landing.html",
+        assets: { js: ["landing.js"], css: ["landing.css"] },
+      },
+      {
+        kind: "page",
+        id: "campaign",
+        fileName: "campaign.html",
+        assets: { js: [], css: [] },
+      },
+    ]);
+    expect(deployment.routes).toEqual([
+      {
+        kind: "page-server",
+        path: "/insights",
+        pageId: "insights",
+        methods: ["GET", "HEAD"],
+      },
+      {
+        kind: "static-document",
+        path: "/landing",
+        documentId: "landing",
+        methods: ["GET", "HEAD"],
+      },
+      {
+        kind: "page-server",
+        path: "/settlement-report",
+        pageId: "settlement",
+        methods: ["GET", "HEAD"],
+      },
+      {
+        kind: "spa-fallback",
+        path: "*",
+        documentId: "admin",
+        methods: ["GET", "HEAD"],
+      },
+      {
+        kind: "framework-function",
+        path: "/__evjs/fn",
+        methods: ["POST"],
+      },
+      {
+        kind: "framework-ppr",
+        path: "/__evjs/ppr/*",
+        methods: ["GET", "HEAD"],
+      },
+      {
+        kind: "framework-rsc",
+        path: "/__evjs/rsc",
+        methods: ["GET", "HEAD"],
+      },
+      {
+        kind: "server-route",
+        path: "/api/health",
+        methods: ["GET"],
+      },
+    ]);
+    expect(JSON.stringify(deployment)).not.toContain("fn:refund");
+    expect(JSON.stringify(deployment)).not.toContain("insights-rsc");
   });
 });
 
@@ -3158,13 +3261,6 @@ describe("createServerManifest", () => {
     expect(createServerManifest(output)).toEqual({
       version: 1,
       entry: "server.js",
-      functions: ["fn:getUser"],
-      routes: [
-        {
-          path: "/api/users",
-          methods: ["GET", "POST"],
-        },
-      ],
     });
   });
 
@@ -3172,8 +3268,6 @@ describe("createServerManifest", () => {
     expect(createServerManifest(createMinimalBuildOutput())).toEqual({
       version: 1,
       entry: "server.js",
-      functions: [],
-      routes: [],
     });
   });
 });

--- a/packages/shared/tests/manifest.test.ts
+++ b/packages/shared/tests/manifest.test.ts
@@ -3159,17 +3159,11 @@ describe("createServerManifest", () => {
     expect(createServerManifest(output)).toEqual({
       version: 1,
       entry: "server.js",
-      assets: { js: ["server.js"], css: ["server.css"] },
-      functions: {
-        "fn:getUser": {
-          assets: { js: ["users.server.js"], css: [] },
-        },
-      },
+      functions: ["fn:getUser"],
       routes: [
         {
           path: "/api/users",
           methods: ["GET", "POST"],
-          assets: { js: ["users.routes.js"], css: [] },
         },
       ],
     });
@@ -3179,8 +3173,7 @@ describe("createServerManifest", () => {
     expect(createServerManifest(createMinimalBuildOutput())).toEqual({
       version: 1,
       entry: "server.js",
-      assets: { js: ["server.js"], css: [] },
-      functions: {},
+      functions: [],
       routes: [],
     });
   });

--- a/packages/shared/tests/manifest.test.ts
+++ b/packages/shared/tests/manifest.test.ts
@@ -2919,7 +2919,7 @@ describe("linkBuildOutput", () => {
     );
   });
 
-  it("fails when a server-present plan has no server runtime entry", () => {
+  it("ignores server build facts when no server runtime entry is planned", () => {
     const graph: AppGraph = {
       version: 1,
       rootDir: "/repo",
@@ -2941,13 +2941,17 @@ describe("linkBuildOutput", () => {
       runtime: createRuntimePlan(),
     };
 
-    expect(() =>
+    expect(
       linkBuildOutput({
         graph,
         plan,
         serverAssets: { js: ["server.js"], css: [] },
-      }),
-    ).toThrow("[evjs] Server build did not declare a server runtime entry.");
+      }).server,
+    ).toEqual({
+      assets: { js: [], css: [] },
+      functions: {},
+      routes: [],
+    });
   });
 });
 
@@ -3137,8 +3141,7 @@ describe("createPublicManifest", () => {
     expect(serialized).not.toContain(".ts");
     expect(serialized).not.toContain("file://");
     expect(serialized).not.toContain("/Users/");
-    expect(manifest.routing.kind).toBe("mpa");
-    if (manifest.routing.kind !== "mpa") {
+    if (!("routing" in manifest) || manifest.routing.kind !== "mpa") {
       throw new Error("Expected MPA public manifest.");
     }
     const pages = manifest.routing.pages;
@@ -3146,6 +3149,8 @@ describe("createPublicManifest", () => {
       js: ["evjs-rsc-client.js"],
       css: ["insights.css"],
     });
+    expect(pages.insights.render).toBe("ssr");
+    expect(pages.landing.render).toBe("ssg");
     expect("module" in pages.insights).toBe(false);
     expect("runtime" in manifest).toBe(false);
     expect("pages" in manifest).toBe(false);
@@ -3181,13 +3186,14 @@ describe("createPublicManifest", () => {
         kind: "page",
         id: "landing",
         fileName: "landing.html",
+        path: "/landing",
+        render: "ssg",
         assets: { js: ["landing.js"], css: ["landing.css"] },
       },
       {
         kind: "page",
         id: "campaign",
         fileName: "campaign.html",
-        assets: { js: [], css: [] },
       },
     ]);
     expect(deployment.routes).toEqual([
@@ -3197,13 +3203,6 @@ describe("createPublicManifest", () => {
         pageId: "insights",
         render: "ssr",
         rsc: true,
-        methods: ["GET", "HEAD"],
-      },
-      {
-        kind: "static-page",
-        path: "/landing",
-        documentId: "landing",
-        render: "ssg",
         methods: ["GET", "HEAD"],
       },
       {
@@ -3315,8 +3314,103 @@ describe("createPublicManifest", () => {
       },
       routing: {
         kind: "spa",
-        routes: [{ id: "report", path: "/report", pageId: "report" }],
+        routes: [
+          {
+            id: "report",
+            path: "/report",
+            pageId: "report",
+            render: "ssg",
+          },
+        ],
       },
+    });
+  });
+
+  it("keeps static-only SSG SPA manifests minimal", () => {
+    const output: BuildOutput = {
+      ...createMinimalBuildOutput(),
+      assets: {},
+      apps: {
+        default: {
+          assets: { js: [], css: [] },
+        },
+      },
+      pages: {
+        report: {
+          assets: { js: [], css: [] },
+          document: { fileName: "report.html" },
+          render: "ssg",
+          rendering: {
+            component: "server",
+            html: "static",
+            prerender: "full",
+            streaming: false,
+            hydrate: "none",
+          },
+          path: "/report",
+          routeId: "report",
+        },
+      },
+      routes: [
+        {
+          id: "report",
+          path: "/report",
+          appId: "default",
+          pageId: "report",
+        },
+      ],
+      server: {
+        assets: { js: [], css: [] },
+        functions: {},
+        routes: [],
+        renderers: {
+          "report-server": {
+            kind: "page-server",
+            phase: "build",
+            owner: { pageId: "report", routeId: "report" },
+            assets: { js: ["report-server.js"], css: [] },
+          },
+        },
+      },
+    };
+
+    expect(createPublicManifest(output)).toEqual({
+      version: 1,
+      buildId: "build",
+      publicPath: "/",
+      documents: [
+        {
+          id: "report",
+          path: "/report",
+          fileName: "report.html",
+          render: "ssg",
+        },
+      ],
+    });
+    expect(createDeploymentMetadata(output)).toEqual({
+      version: 1,
+      buildId: "build",
+      paths: {
+        rootDir: "dist",
+        publicDir: "dist/client",
+        serverDir: "dist/server",
+      },
+      publicPath: "/",
+      documents: [
+        {
+          kind: "page",
+          id: "report",
+          fileName: "report.html",
+          path: "/report",
+          render: "ssg",
+        },
+      ],
+      routes: [],
+      server: {},
+    });
+    expect(createServerManifest(output)).toEqual({
+      version: 1,
+      routes: [],
     });
   });
 });

--- a/packages/shared/tests/manifest.test.ts
+++ b/packages/shared/tests/manifest.test.ts
@@ -3115,6 +3115,24 @@ describe("createPublicManifest", () => {
         rscRendererReferences: "optional",
       }),
     ).not.toThrow();
+    expect(() =>
+      assertFrameworkManifestShape(
+        {
+          ...manifest,
+          assets: { insights: { js: ["evjs-rsc-client.js"], css: [] } },
+        },
+        "public manifest",
+        {
+          server: "optional",
+          serverFunctionModules: "optional",
+          pageRendererReferences: "optional",
+          pprRendererReferences: "optional",
+          rscRendererReferences: "optional",
+        },
+      ),
+    ).toThrow(
+      '[evjs] public manifest.assets must be omitted when routing.kind is "mpa".',
+    );
     expect(serialized).not.toContain(".tsx");
     expect(serialized).not.toContain(".ts");
     expect(serialized).not.toContain("file://");
@@ -3133,6 +3151,7 @@ describe("createPublicManifest", () => {
     expect("pages" in manifest).toBe(false);
     expect("routes" in manifest).toBe(false);
     expect("app" in manifest).toBe(false);
+    expect("assets" in manifest).toBe(false);
     expect(pages.insights.document).toEqual({
       fileName: "insights.html",
     });
@@ -3226,12 +3245,88 @@ describe("createPublicManifest", () => {
     expect(JSON.stringify(deployment)).not.toContain("fn:refund");
     expect(JSON.stringify(deployment)).not.toContain("insights-rsc");
   });
+
+  it("keeps top-level assets for SPA manifests", () => {
+    const output: BuildOutput = {
+      ...createMinimalBuildOutput(),
+      assets: {
+        main: { js: ["main.js"], css: ["main.css"] },
+      },
+      apps: {
+        default: {
+          assets: { js: ["main.js"], css: ["main.css"] },
+          document: { fileName: "index.html" },
+        },
+      },
+      routes: [
+        {
+          id: "home",
+          path: "/",
+          appId: "default",
+        },
+      ],
+    };
+
+    expect(createPublicManifest(output)).toMatchObject({
+      assets: {
+        main: { js: ["main.js"], css: ["main.css"] },
+      },
+      routing: {
+        kind: "spa",
+        routes: [{ id: "home", path: "/" }],
+      },
+    });
+  });
 });
 
 describe("createServerManifest", () => {
   it("projects BuildOutput into the server manifest shape", () => {
     const output: BuildOutput = {
       ...createMinimalBuildOutput(),
+      runtime: {
+        server: {
+          basePath: "/__evjs",
+          fn: "/__evjs/fn",
+          ppr: "/__evjs/ppr",
+          rsc: "/__evjs/rsc",
+        },
+      },
+      pages: {
+        dashboard: {
+          assets: { js: [], css: [] },
+          render: "ssr",
+          rendering: {
+            component: "server",
+            html: "server",
+            streaming: false,
+            hydrate: "load",
+          },
+          path: "/dashboard",
+          routeId: "dashboard",
+        },
+        campaign: {
+          assets: { js: [], css: [] },
+          render: "ssr",
+          rendering: {
+            component: "server",
+            html: "partial",
+            prerender: "partial",
+            streaming: true,
+            hydrate: "none",
+          },
+          path: "/campaign",
+          routeId: "campaign",
+          ppr: {
+            delivery: "stream",
+            shell: { js: [], css: [] },
+            regions: {},
+          },
+        },
+      },
+      routes: [
+        { id: "dashboard", path: "/dashboard", pageId: "dashboard" },
+        { id: "campaign", path: "/campaign", pageId: "campaign" },
+      ],
       server: {
         entry: "server.js",
         assets: { js: ["server.js"], css: ["server.css"] },
@@ -3256,18 +3351,67 @@ describe("createServerManifest", () => {
           },
         },
       },
+      rsc: {
+        pages: {
+          dashboard: {
+            renderer: "dashboard-rsc",
+            assets: { js: ["dashboard-rsc.js"], css: [] },
+            routeId: "dashboard",
+          },
+        },
+      },
     };
 
     expect(createServerManifest(output)).toEqual({
       version: 1,
       entry: "server.js",
+      routes: [
+        {
+          kind: "page-server",
+          path: "/dashboard",
+          pageId: "dashboard",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "page-server",
+          path: "/campaign",
+          pageId: "campaign",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "framework-function",
+          path: "/__evjs/fn",
+          methods: ["POST"],
+        },
+        {
+          kind: "framework-ppr",
+          path: "/__evjs/ppr/*",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "framework-rsc",
+          path: "/__evjs/rsc",
+          methods: ["GET", "HEAD"],
+        },
+        {
+          kind: "server-route",
+          path: "/api/users",
+          methods: ["GET", "POST"],
+        },
+      ],
     });
+    const serverManifestText = JSON.stringify(createServerManifest(output));
+    expect(serverManifestText).not.toContain("fn:getUser");
+    expect(serverManifestText).not.toContain('"assets"');
+    expect(serverManifestText).not.toContain('"renderers"');
+    expect(serverManifestText).not.toContain('"rsc"');
   });
 
   it("projects the minimal server output into the server manifest shape", () => {
     expect(createServerManifest(createMinimalBuildOutput())).toEqual({
       version: 1,
       entry: "server.js",
+      routes: [],
     });
   });
 });

--- a/packages/shared/tests/manifest.test.ts
+++ b/packages/shared/tests/manifest.test.ts
@@ -3175,6 +3175,7 @@ describe("createPublicManifest", () => {
         kind: "app",
         id: "admin",
         fileName: "admin.html",
+        fallback: "*",
         assets: { js: ["admin.js"], css: [] },
       },
       {
@@ -3198,46 +3199,43 @@ describe("createPublicManifest", () => {
     ]);
     expect(deployment.routes).toEqual([
       {
-        kind: "page-server",
+        kind: "server-page",
         path: "/insights",
         pageId: "insights",
+        render: "rsc",
         methods: ["GET", "HEAD"],
       },
       {
-        kind: "static-document",
+        kind: "static-page",
         path: "/landing",
         documentId: "landing",
+        render: "ssg",
         methods: ["GET", "HEAD"],
       },
       {
-        kind: "page-server",
+        kind: "server-page",
         path: "/settlement-report",
         pageId: "settlement",
+        render: "ssg",
         methods: ["GET", "HEAD"],
       },
       {
-        kind: "spa-fallback",
-        path: "*",
-        documentId: "admin",
-        methods: ["GET", "HEAD"],
-      },
-      {
-        kind: "framework-function",
+        kind: "server-function",
         path: "/__evjs/fn",
         methods: ["POST"],
       },
       {
-        kind: "framework-ppr",
+        kind: "ppr-endpoint",
         path: "/__evjs/ppr/*",
         methods: ["GET", "HEAD"],
       },
       {
-        kind: "framework-rsc",
+        kind: "rsc-endpoint",
         path: "/__evjs/rsc",
         methods: ["GET", "HEAD"],
       },
       {
-        kind: "server-route",
+        kind: "api-route",
         path: "/api/health",
         methods: ["GET"],
       },
@@ -3367,34 +3365,36 @@ describe("createServerManifest", () => {
       entry: "server.js",
       routes: [
         {
-          kind: "page-server",
+          kind: "server-page",
           path: "/dashboard",
           pageId: "dashboard",
+          render: "rsc",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "page-server",
+          kind: "server-page",
           path: "/campaign",
           pageId: "campaign",
+          render: "ppr",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "framework-function",
+          kind: "server-function",
           path: "/__evjs/fn",
           methods: ["POST"],
         },
         {
-          kind: "framework-ppr",
+          kind: "ppr-endpoint",
           path: "/__evjs/ppr/*",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "framework-rsc",
+          kind: "rsc-endpoint",
           path: "/__evjs/rsc",
           methods: ["GET", "HEAD"],
         },
         {
-          kind: "server-route",
+          kind: "api-route",
           path: "/api/users",
           methods: ["GET", "POST"],
         },
@@ -3404,7 +3404,7 @@ describe("createServerManifest", () => {
     expect(serverManifestText).not.toContain("fn:getUser");
     expect(serverManifestText).not.toContain('"assets"');
     expect(serverManifestText).not.toContain('"renderers"');
-    expect(serverManifestText).not.toContain('"rsc"');
+    expect(serverManifestText).not.toContain("dashboard-rsc");
   });
 
   it("projects the minimal server output into the server manifest shape", () => {

--- a/packages/shared/tests/manifest.test.ts
+++ b/packages/shared/tests/manifest.test.ts
@@ -3075,35 +3075,34 @@ describe("createPublicManifest", () => {
     expect(serialized).not.toContain(".ts");
     expect(serialized).not.toContain("file://");
     expect(serialized).not.toContain("/Users/");
-    expect(manifest.pages.insights.assets).toEqual({
+    expect(manifest.routing.kind).toBe("mpa");
+    if (manifest.routing.kind !== "mpa") {
+      throw new Error("Expected MPA public manifest.");
+    }
+    const pages = manifest.routing.pages;
+    expect(pages.insights.assets).toEqual({
       js: ["evjs-rsc-client.js"],
       css: ["insights.css"],
     });
-    expect(manifest.pages.insights.module).toEqual({
+    expect(pages.insights.module).toEqual({
       type: "react-component",
       href: "evjs-rsc-client.js",
     });
     expect("runtime" in manifest).toBe(false);
-    expect(manifest.routes).toContainEqual({
-      id: "insights",
-      path: "/insights",
-      pageId: "insights",
-    });
-    expect(manifest.routes.flatMap((route) => Object.keys(route))).not.toEqual(
-      expect.arrayContaining(["module", "render", "hydrate", "runtime"]),
-    );
+    expect("pages" in manifest).toBe(false);
+    expect("routes" in manifest).toBe(false);
     expect(manifest.app?.document).toEqual({ fileName: "admin.html" });
-    expect(manifest.pages.insights.document).toEqual({
+    expect(pages.insights.document).toEqual({
       fileName: "insights.html",
     });
-    expect(manifest.pages.campaign.assets).toEqual({ js: [], css: [] });
-    expect(manifest.pages.campaign.document).toEqual({
+    expect(pages.campaign.assets).toEqual({ js: [], css: [] });
+    expect(pages.campaign.document).toEqual({
       fileName: "campaign.html",
     });
-    expect(manifest.pages.campaign.hydrate).toBe("none");
-    expect(manifest.pages.campaign.rendering.hydrate).toBe("none");
-    expect(manifest.pages.campaign.ppr?.delivery).toBe("stream");
-    expect(manifest.pages.campaign.ppr?.regions.offer).toEqual({
+    expect(pages.campaign.hydrate).toBe("none");
+    expect(pages.campaign.rendering.hydrate).toBe("none");
+    expect(pages.campaign.ppr?.delivery).toBe("stream");
+    expect(pages.campaign.ppr?.regions.offer).toEqual({
       id: "offer",
       assets: { js: [], css: [] },
       cache: "no-store",


### PR DESCRIPTION
## Summary
- Tighten deployment-facing manifest JSON while keeping runtime-required data in explicit runtime contracts.
- Remove top-level `assets` from MPA `client/manifest.json`; MPA assets now live only on `routing.pages[pageId].assets`.
- Restore lightweight server route projection in `server/manifest.json` alongside the preserved `entry` field.
- Stop emitting default `dist/server/framework-runtime.json`; `FrameworkRuntime` is passed through build/plugin results and injected into dev or deployment bootstraps instead of being written as a JSON artifact.

## Changes
- Updated `PublicManifestOutput` to distinguish SPA and MPA shapes: SPA may expose top-level asset groups, while MPA exposes page-level assets only.
- Updated `createPublicManifest()` and manifest validation so MPA public manifests reject top-level `assets` without blocking internal `BuildOutput.assets`.
- Updated `ServerManifestOutput` and `createServerManifest()` to emit `{ version, entry?, routes }` with `page-server`, `framework-function`, `framework-ppr`, `framework-rsc`, and `server-route` rows only.
- Kept static documents and SPA fallbacks in canonical `deploymentMetadata.routes`, not in the server manifest projection.
- Removed default `framework-runtime.json` emission and kept only legacy cleanup for stale files.
- Changed dev and e2e bootstraps to inject captured `frameworkRuntime` directly instead of reading a runtime JSON sidecar.
- Aligned plugin hook types and tests with the new `clientManifest` union, `serverManifest.routes`, and runtime injection surface.
- Updated English and Chinese build/deploy/architecture docs plus CLI README for the new artifact semantics.

## Validation
- `npm run lint`
- `npm run check-types`
- `npm test`
- `npm run test:e2e -- --project=webpack-examples --reporter=line`
- `npm run test:e2e -- --project=utoopack --reporter=line`
- `git diff --check`
- Artifact scan over generated examples: no `framework-runtime.json`, no `runtime.json`; MPA manifests have no top-level `assets`; render-modes server manifest contains server route rows without assets/renderers/RSC references/function ids.

## Risk / rollout
- Breaking JSON shape change for tooling that reads MPA `client/manifest.json.assets`, assumes `server/manifest.json` is entry-only, or expects `dist/server/framework-runtime.json` to exist.
- The known online dependency on `dist/server/manifest.json.entry` is preserved.
- Deployment platforms should continue to prefer `build-output.json` / `deploymentMetadata` for full deployment planning; `server/manifest.json.routes` is only a lightweight server-side route summary.
- Runtime-heavy data stays out of manifests and output JSON files; adapters or bootstraps must receive `FrameworkRuntime` through the build/plugin result path.

## Reviewer notes
- Please focus review on the route filtering boundary between canonical `deploymentMetadata.routes` and `serverManifest.routes`.
- Also review the runtime handoff: dev/e2e/adapter paths inject `FrameworkRuntime` directly, while stale `framework-runtime.json` files are cleaned from output.
