### PR TITLE
fix(bundler-utoopack): require utoopack runtime

### DIFF
--- a/packages/bundler-utoopack/src/adapter/index.ts
+++ b/packages/bundler-utoopack/src/adapter/index.ts
@@ -8,6 +8,7 @@
  */
 
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import type {
   BundlerAdapter,
@@ -24,6 +25,8 @@ import { UtoopackManifestGenerator } from "../manifest-generator.js";
 import { getOutputPaths } from "./output-paths.js";
 
 const logger = getLogger(["evjs", "bundler-utoopack"]);
+const require = createRequire(import.meta.url);
+type UtoopackRuntime = Pick<typeof import("@utoo/pack"), "build" | "serve">;
 
 async function cleanServerOutput(
   cwd: string,
@@ -58,6 +61,11 @@ async function generateDevArtifacts(
   return true;
 }
 
+function requireUtoopack(): UtoopackRuntime {
+  // @utoo/pack's import condition targets ESM .js files; Node 18 parses them as CJS.
+  return require("@utoo/pack") as UtoopackRuntime;
+}
+
 export const utoopackAdapter: BundlerAdapter<ConfigComplete> = {
   name: "utoopack",
   async build(
@@ -71,7 +79,7 @@ export const utoopackAdapter: BundlerAdapter<ConfigComplete> = {
 
     await cleanServerOutput(cwd, config.output, plan.distDir);
 
-    const { build } = await import("@utoo/pack");
+    const { build } = requireUtoopack();
     await build({ config: utoopackConfig });
 
     logger.info`Collecting utoopack build facts...`;
@@ -91,7 +99,7 @@ export const utoopackAdapter: BundlerAdapter<ConfigComplete> = {
 
     logger.info`Starting development server with utoopack...`;
 
-    const { serve } = await import("@utoo/pack");
+    const { serve } = requireUtoopack();
     await serve({ config: utoopackConfig });
 
     await generateDevArtifacts(config, cwd, plan, callbacks.onBuildFacts, {

--- a/packages/bundler-utoopack/tests/adapter.test.ts
+++ b/packages/bundler-utoopack/tests/adapter.test.ts
@@ -27,44 +27,62 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createClientRuntime } from "../../ev/src/_internal/build/framework-runtime.js";
 import { utoopackAdapter } from "../src/adapter/index.js";
 
-vi.mock("@utoo/pack", () => ({
-  serve: vi.fn(async ({ config }) => {
-    const fs = await import("node:fs");
-    const path = await import("node:path");
-    const clientOutDir = config.output.path;
+const utoopackMock = vi.hoisted(() => ({
+  requireUtoopack: vi.fn(() => ({
+    serve: vi.fn(async ({ config }) => {
+      const fs = await import("node:fs");
+      const path = await import("node:path");
+      const clientOutDir = config.output.path;
 
-    await fs.promises.mkdir(clientOutDir, { recursive: true });
-    await fs.promises.writeFile(path.join(clientOutDir, "main.js"), "");
-    await fs.promises.writeFile(path.join(clientOutDir, "main.css"), "");
-    await fs.promises.writeFile(
-      path.join(clientOutDir, "stats.json"),
-      JSON.stringify({
-        entrypoints: {
-          main: {
-            assets: [{ name: "main.js" }, { name: "main.css" }],
-          },
-        },
-      }),
-    );
-
-    if (config.server) {
-      const serverOutDir = config.server.output.path;
-      await fs.promises.mkdir(serverOutDir, { recursive: true });
-      await fs.promises.writeFile(path.join(serverOutDir, "index.js"), "");
+      await fs.promises.mkdir(clientOutDir, { recursive: true });
+      await fs.promises.writeFile(path.join(clientOutDir, "main.js"), "");
+      await fs.promises.writeFile(path.join(clientOutDir, "main.css"), "");
       await fs.promises.writeFile(
-        path.join(serverOutDir, "stats.json"),
+        path.join(clientOutDir, "stats.json"),
         JSON.stringify({
           entrypoints: {
             main: {
-              assets: [{ name: "index.js" }],
+              assets: [{ name: "main.js" }, { name: "main.css" }],
             },
           },
         }),
       );
-    }
-  }),
-  build: vi.fn(),
+
+      if (config.server) {
+        const serverOutDir = config.server.output.path;
+        await fs.promises.mkdir(serverOutDir, { recursive: true });
+        await fs.promises.writeFile(path.join(serverOutDir, "index.js"), "");
+        await fs.promises.writeFile(
+          path.join(serverOutDir, "stats.json"),
+          JSON.stringify({
+            entrypoints: {
+              main: {
+                assets: [{ name: "index.js" }],
+              },
+            },
+          }),
+        );
+      }
+    }),
+    build: vi.fn(),
+  })),
 }));
+
+vi.mock("node:module", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:module")>();
+  return {
+    ...actual,
+    createRequire(filename: string | URL) {
+      const actualRequire = actual.createRequire(filename);
+      return ((specifier: string) =>
+        specifier === "@utoo/pack"
+          ? utoopackMock.requireUtoopack()
+          : actualRequire(specifier)) as ReturnType<
+        typeof actual.createRequire
+      >;
+    },
+  };
+});
 
 const CLIENT_RUNTIME_SCRIPT_ID = "__EVJS_CLIENT_RUNTIME__";
 const tempDirs: string[] = [];


### PR DESCRIPTION
## Summary
- Route runtime access to @utoo/pack through a single CJS require path inside the utoopack adapter.
- Avoid Node 18 parsing @utoo/pack's ESM .js import target as CommonJS.

## Changes
- Updated the utoopack adapter build/dev paths to use an inline requireUtoopack() helper.
- Removed direct runtime dynamic import of @utoo/pack from the adapter.
- Updated adapter tests to mock createRequire() for @utoo/pack while preserving normal require behavior for other modules.

## Validation
- npm run lint
- npm run check-types
- npm test
- git diff --check
- Node 18 direct check against built adapter index.js

## Risk / rollout
- Low risk: scoped to the utoopack adapter runtime load path and preserves the same build/serve API calls.
- No migrations, config changes, feature flags, or public API changes.

## Reviewer notes
- Main review area is the inline requireUtoopack() helper and the adapter test mock for createRequire().
- Remaining @utoo/pack import() references are type-only and do not emit runtime imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when running the bundler adapter by using a more reliable module loading approach.
  * Development and production builds now resolve the bundler runtime more consistently, helping avoid loading issues in supported environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->