### PR TITLE
feat(client): support runtime transport globals

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -157,10 +157,11 @@ Standalone/manual clients can import the same query hooks directly from
 ### Transport
 - `initTransport({ baseUrl, credentials, headers, functions })`: Configure the default HTTP adapter. `functions.endpoint` can override the server function path for standalone runtimes.
 - `credentials` / `headers`: Supported HTTP defaults; fetch `mode` is intentionally not configurable.
-- Hosting runtimes can set `window.__EVJS_TRANSPORT__` before server functions
-  run. The value accepts data-only `RuntimeTransportOptions` such as `baseUrl`,
-  `credentials`, `headers`, and `functions.endpoint`; application
-  `initTransport()` calls still take priority.
+- Hosting runtimes can set `window.__EVJS_TRANSPORT__` before framework server
+  requests run. The value accepts data-only `RuntimeTransportOptions`:
+  `baseUrl`, `credentials`, and `headers`. Endpoint paths continue to come from
+  framework runtime metadata; application `initTransport()` calls still take
+  priority for server functions.
 - `@evjs/client/transport`: Public subpath for low-level transport APIs such as `createServerReference`, `getFnId`, `getFnName`, and `initTransport`.
 - The default HTTP adapter expects successful server-function responses to use
   `Content-Type: application/json`. Non-JSON error responses use their trimmed

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -162,6 +162,11 @@ Standalone/manual clients can import the same query hooks directly from
   `baseUrl`, `credentials`, and `headers`. Endpoint paths continue to come from
   framework runtime metadata; application `initTransport()` calls still take
   priority for server functions.
+- Runtime transport is for framework-managed browser requests to evjs server
+  endpoints. Current consumers are server functions and RSC Flight; future
+  client helpers for server routes or PPR should use the same runtime transport.
+  It does not control runtime metadata loading, static assets, dynamic imports,
+  or application-authored `fetch()` calls.
 - `@evjs/client/transport`: Public subpath for low-level transport APIs such as `createServerReference`, `getFnId`, `getFnName`, and `initTransport`.
 - The default HTTP adapter expects successful server-function responses to use
   `Content-Type: application/json`. Non-JSON error responses use their trimmed

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -157,6 +157,10 @@ Standalone/manual clients can import the same query hooks directly from
 ### Transport
 - `initTransport({ baseUrl, credentials, headers, functions })`: Configure the default HTTP adapter. `functions.endpoint` can override the server function path for standalone runtimes.
 - `credentials` / `headers`: Supported HTTP defaults; fetch `mode` is intentionally not configurable.
+- Hosting runtimes can set `window.__EVJS_TRANSPORT__` before server functions
+  run. The value accepts data-only `RuntimeTransportOptions` such as `baseUrl`,
+  `credentials`, `headers`, and `functions.endpoint`; application
+  `initTransport()` calls still take priority.
 - `@evjs/client/transport`: Public subpath for low-level transport APIs such as `createServerReference`, `getFnId`, `getFnName`, and `initTransport`.
 - The default HTTP adapter expects successful server-function responses to use
   `Content-Type: application/json`. Non-JSON error responses use their trimmed

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -99,6 +99,7 @@ export {
 export type {
   HeaderFactory,
   RequestContext,
+  RuntimeTransportOptions,
   ServerFunction,
   TransportAdapter,
   TransportOptions,

--- a/packages/client/src/rsc/react.ts
+++ b/packages/client/src/rsc/react.ts
@@ -29,10 +29,10 @@ import {
   type ClientRuntime,
   type ClientRuntimeTransport,
   getClientRuntimeRoutes,
-  getGlobalRuntimeTransport,
+  getClientRuntimeServer,
   type HydrationMode,
-  hasClientRuntimeTransport,
   type RenderMode,
+  resolveClientRuntimeTransport,
 } from "../shared/runtime-config.js";
 import { formatErrorDetail, isRecord } from "../shared/validation.js";
 import {
@@ -313,7 +313,7 @@ export async function fetchRscFlight(
   options: RscFlightFetchOptions,
 ): Promise<Response> {
   assertRscFlightFetchOptions(options);
-  const endpoint = options.runtime.runtime.server?.rsc;
+  const endpoint = getClientRuntimeServer(options.runtime)?.rsc;
   if (!endpoint) {
     throw new Error(
       "[evjs] RSC Flight endpoint is not present in the runtime.",
@@ -325,9 +325,7 @@ export async function fetchRscFlight(
     throw new Error("[evjs] RSC Flight fetch requires a fetch implementation.");
   }
 
-  const transport = resolveRscFlightTransport(
-    options.runtime.runtime.transport,
-  );
+  const transport = resolveClientRuntimeTransport(options.runtime);
   const requestUrl = resolveRscFlightUrl(endpoint, options, transport);
   const requestInit = resolveRscFlightRequestInit(transport);
   let response: unknown;
@@ -374,15 +372,6 @@ function resolveRscFlightRequestInit(
   return init.credentials !== undefined || init.headers !== undefined
     ? init
     : undefined;
-}
-
-function resolveRscFlightTransport(
-  transport: ClientRuntimeTransport | undefined,
-): ClientRuntimeTransport | undefined {
-  if (transport !== undefined && hasClientRuntimeTransport(transport)) {
-    return transport;
-  }
-  return getGlobalRuntimeTransport();
 }
 
 function assertOptionalRscFlightString(value: unknown, path: string): void {

--- a/packages/client/src/rsc/react.ts
+++ b/packages/client/src/rsc/react.ts
@@ -27,8 +27,11 @@ import {
 import {
   assertClientRuntime,
   type ClientRuntime,
+  type ClientRuntimeTransport,
   getClientRuntimeRoutes,
+  getGlobalRuntimeTransport,
   type HydrationMode,
+  hasClientRuntimeTransport,
   type RenderMode,
 } from "../shared/runtime-config.js";
 import { formatErrorDetail, isRecord } from "../shared/validation.js";
@@ -322,10 +325,17 @@ export async function fetchRscFlight(
     throw new Error("[evjs] RSC Flight fetch requires a fetch implementation.");
   }
 
-  const requestUrl = resolveRscFlightUrl(endpoint, options);
+  const transport = resolveRscFlightTransport(
+    options.runtime.runtime.transport,
+  );
+  const requestUrl = resolveRscFlightUrl(endpoint, options, transport);
+  const requestInit = resolveRscFlightRequestInit(transport);
   let response: unknown;
   try {
-    response = await fetchImpl(requestUrl);
+    response =
+      requestInit === undefined
+        ? await fetchImpl(requestUrl)
+        : await fetchImpl(requestUrl, requestInit);
   } catch (error) {
     throw new Error(
       `[evjs] RSC Flight request failed${formatErrorDetail(error)}`,
@@ -344,6 +354,35 @@ export function assertRscFlightFetchOptions(
   assertClientRuntime(options.runtime, "fetchRscFlight() runtime");
   assertOptionalRscFlightString(options.pageId, "fetchRscFlight() pageId");
   assertOptionalRscFlightUrl(options.url, "fetchRscFlight() url");
+}
+
+function resolveRscFlightRequestInit(
+  transport: ClientRuntimeTransport | undefined,
+): RequestInit | undefined {
+  if (!transport) return undefined;
+
+  const init: RequestInit = {};
+  if (transport.credentials !== undefined) {
+    init.credentials = transport.credentials;
+  }
+
+  const headers = new Headers(transport.headers);
+  if ([...headers.keys()].length > 0) {
+    init.headers = headers;
+  }
+
+  return init.credentials !== undefined || init.headers !== undefined
+    ? init
+    : undefined;
+}
+
+function resolveRscFlightTransport(
+  transport: ClientRuntimeTransport | undefined,
+): ClientRuntimeTransport | undefined {
+  if (transport !== undefined && hasClientRuntimeTransport(transport)) {
+    return transport;
+  }
+  return getGlobalRuntimeTransport();
 }
 
 function assertOptionalRscFlightString(value: unknown, path: string): void {
@@ -425,11 +464,12 @@ export async function loadRscDebugPage(
 function resolveRscFlightUrl(
   endpoint: string,
   options: RscFlightFetchOptions,
+  transport: ClientRuntimeTransport | undefined,
 ): string {
   const explicitUrl = options.url?.toString();
   const locationHref = globalThis.location?.href;
   const currentUrl = explicitUrl ?? locationHref;
-  const transportBaseUrl = options.runtime.runtime.transport?.baseUrl;
+  const transportBaseUrl = transport?.baseUrl;
   const base = transportBaseUrl ?? locationHref ?? explicitUrl ?? endpoint;
   const url = new URL(endpoint, base);
   if (options.pageId) {

--- a/packages/client/src/server-functions/transport-runtime.ts
+++ b/packages/client/src/server-functions/transport-runtime.ts
@@ -26,8 +26,16 @@ import {
   getFetchResponseContentType,
   readFetchErrorResponseBody,
 } from "../shared/fetch-response.js";
-import type { ClientRuntime } from "../shared/runtime-config.js";
+import {
+  assertClientRuntimeTransport,
+  type ClientRuntime,
+  getGlobalRuntimeTransport,
+  hasClientRuntimeTransport,
+  type RuntimeTransportOptions,
+} from "../shared/runtime-config.js";
 import { formatErrorDetail, isRecord } from "../shared/validation.js";
+
+export type { RuntimeTransportOptions } from "../shared/runtime-config.js";
 
 /**
  * Request context passed through server calls.
@@ -62,44 +70,29 @@ export type HeaderFactory = (
 interface BaseTransportOptions {
   /** Base URL for framework server calls. Defaults to the current page origin. */
   baseUrl?: string;
-  /** Credentials policy for HTTP server function requests. */
+  /** Credentials policy for framework server requests. */
   credentials?: RequestCredentials;
-  /** Server function endpoint override. */
-  functions?: {
-    /** Path or URL for the server function endpoint. */
-    endpoint?: string;
-  };
 }
 
 interface HttpRequestDefaults {
-  /** Credentials policy for HTTP server function requests. */
+  /** Credentials policy for framework server requests. */
   credentials?: RequestCredentials;
   /** Static headers or a factory evaluated for each transport call. */
   headers?: HeadersInit | HeaderFactory;
-}
-
-export interface RuntimeTransportOptions extends BaseTransportOptions {
-  /** Static headers for HTTP server function requests. */
-  headers?: HeadersInit;
 }
 
 export interface TransportOptions extends BaseTransportOptions {
   /** Static headers or a factory evaluated for each transport call. */
   headers?: HeadersInit | HeaderFactory;
+  /** Server function endpoint override for standalone/custom runtimes. */
+  functions?: {
+    /** Path or URL for the server function endpoint. */
+    endpoint?: string;
+  };
   /** Adapter capabilities for custom runtimes or protocols. */
   adapter?: TransportAdapter;
   /** Suppress warnings when re-initializing transport. Useful for HMR. */
   silent?: boolean;
-}
-
-declare global {
-  /**
-   * Dynamic transport configuration injected by hosting runtimes before evjs
-   * server function calls start. This is data-only; custom adapters should use
-   * initTransport() from application code.
-   */
-  // eslint-disable-next-line no-var
-  var __EVJS_TRANSPORT__: RuntimeTransportOptions | undefined;
 }
 
 interface TransportRuntime {
@@ -441,7 +434,7 @@ function createTransportRuntime(options: TransportOptions): TransportRuntime {
 
 function getRuntime(): TransportRuntime {
   if (!_runtime) {
-    const transport = getGlobalTransport();
+    const transport = getGlobalRuntimeTransport();
     _runtime = createTransportRuntime(transport ?? {});
     _runtimeSource = transport ? "global" : "default";
   }
@@ -473,7 +466,8 @@ export function initTransport(options: TransportOptions = {}): void {
 export function initTransportFromRuntime(
   runtime: Pick<ClientRuntime, "runtime">,
 ): void {
-  const transport = getClientRuntimeTransport(runtime) ?? getGlobalTransport();
+  const transport =
+    getClientRuntimeTransport(runtime) ?? getGlobalRuntimeTransport();
   if (!transport || _runtimeSource === "user") return;
 
   _runtime = createTransportRuntime(transport);
@@ -742,36 +736,6 @@ function assertTransportFunctionsOptions(
   }
 }
 
-function assertRuntimeTransportOptions(
-  options: unknown,
-  source: string,
-): asserts options is RuntimeTransportOptions {
-  if (!isRecord(options)) {
-    throw new Error(`[evjs] ${source} must be an object.`);
-  }
-
-  assertBaseTransportOptions(options, source);
-
-  if (
-    options.headers !== undefined &&
-    (typeof options.headers === "function" || !isHeadersInit(options.headers))
-  ) {
-    throw new Error(`[evjs] ${source}.headers must be valid HeadersInit.`);
-  }
-
-  if (options.adapter !== undefined) {
-    throw new Error(
-      `[evjs] ${source}.adapter is not supported. Runtime transport config must be serializable.`,
-    );
-  }
-
-  if (options.silent !== undefined) {
-    throw new Error(
-      `[evjs] ${source}.silent is not supported. Runtime transport config must be serializable.`,
-    );
-  }
-}
-
 function assertBaseTransportOptions(
   options: Record<string, unknown>,
   source: string,
@@ -791,13 +755,6 @@ function assertBaseTransportOptions(
   ) {
     throw new Error(
       `[evjs] ${formatTransportOptionSource(source, "credentials")} must be "omit", "same-origin", or "include".`,
-    );
-  }
-
-  if (options.functions !== undefined) {
-    assertTransportFunctionsOptions(
-      options.functions,
-      formatTransportOptionSource(source, "functions"),
     );
   }
 }
@@ -875,27 +832,11 @@ function getClientRuntimeTransport(
 
   const transport = runtime.runtime.transport;
   if (transport === undefined) return undefined;
-  assertRuntimeTransportOptions(
+  assertClientRuntimeTransport(
     transport,
     "initTransportFromRuntime() runtime.runtime.transport",
   );
-  return hasRuntimeTransportOptions(transport) ? transport : undefined;
-}
-
-function getGlobalTransport(): RuntimeTransportOptions | undefined {
-  const transport = globalThis.__EVJS_TRANSPORT__;
-  if (transport === undefined) return undefined;
-  assertRuntimeTransportOptions(transport, "__EVJS_TRANSPORT__");
-  return hasRuntimeTransportOptions(transport) ? transport : undefined;
-}
-
-function hasRuntimeTransportOptions(options: RuntimeTransportOptions): boolean {
-  return (
-    options.baseUrl !== undefined ||
-    options.credentials !== undefined ||
-    options.headers !== undefined ||
-    options.functions !== undefined
-  );
+  return hasClientRuntimeTransport(transport) ? transport : undefined;
 }
 
 /**

--- a/packages/client/src/server-functions/transport-runtime.ts
+++ b/packages/client/src/server-functions/transport-runtime.ts
@@ -59,6 +59,18 @@ export type HeaderFactory = (
   context: RequestContext,
 ) => MaybePromise<HeadersInit | undefined>;
 
+interface BaseTransportOptions {
+  /** Base URL for framework server calls. Defaults to the current page origin. */
+  baseUrl?: string;
+  /** Credentials policy for HTTP server function requests. */
+  credentials?: RequestCredentials;
+  /** Server function endpoint override. */
+  functions?: {
+    /** Path or URL for the server function endpoint. */
+    endpoint?: string;
+  };
+}
+
 interface HttpRequestDefaults {
   /** Credentials policy for HTTP server function requests. */
   credentials?: RequestCredentials;
@@ -66,22 +78,28 @@ interface HttpRequestDefaults {
   headers?: HeadersInit | HeaderFactory;
 }
 
-export interface TransportOptions {
-  /** Base URL for framework server calls. Defaults to the current page origin. */
-  baseUrl?: string;
-  /** Credentials policy for HTTP server function requests. */
-  credentials?: RequestCredentials;
+export interface RuntimeTransportOptions extends BaseTransportOptions {
+  /** Static headers for HTTP server function requests. */
+  headers?: HeadersInit;
+}
+
+export interface TransportOptions extends BaseTransportOptions {
   /** Static headers or a factory evaluated for each transport call. */
   headers?: HeadersInit | HeaderFactory;
-  /** Server function endpoint override. */
-  functions?: {
-    /** Path or URL for the server function endpoint. */
-    endpoint?: string;
-  };
   /** Adapter capabilities for custom runtimes or protocols. */
   adapter?: TransportAdapter;
   /** Suppress warnings when re-initializing transport. Useful for HMR. */
   silent?: boolean;
+}
+
+declare global {
+  /**
+   * Dynamic transport configuration injected by hosting runtimes before evjs
+   * server function calls start. This is data-only; custom adapters should use
+   * initTransport() from application code.
+   */
+  // eslint-disable-next-line no-var
+  var __EVJS_TRANSPORT__: RuntimeTransportOptions | undefined;
 }
 
 interface TransportRuntime {
@@ -405,7 +423,8 @@ function readServerFunctionSuccessResult(payload: Record<string, unknown>) {
 }
 
 let _runtime: TransportRuntime | null = null;
-let _runtimeSource: "default" | "client-runtime" | "user" | null = null;
+let _runtimeSource: "default" | "global" | "client-runtime" | "user" | null =
+  null;
 
 function createTransportRuntime(options: TransportOptions): TransportRuntime {
   const endpoint = options.functions?.endpoint ?? getFunctionEndpoint();
@@ -422,8 +441,9 @@ function createTransportRuntime(options: TransportOptions): TransportRuntime {
 
 function getRuntime(): TransportRuntime {
   if (!_runtime) {
-    _runtime = createTransportRuntime({});
-    _runtimeSource = "default";
+    const transport = getGlobalTransport();
+    _runtime = createTransportRuntime(transport ?? {});
+    _runtimeSource = transport ? "global" : "default";
   }
   return _runtime;
 }
@@ -453,13 +473,10 @@ export function initTransport(options: TransportOptions = {}): void {
 export function initTransportFromRuntime(
   runtime: Pick<ClientRuntime, "runtime">,
 ): void {
-  const transport = getClientRuntimeTransport(runtime);
-  if (!transport?.baseUrl || _runtimeSource === "user") return;
+  const transport = getClientRuntimeTransport(runtime) ?? getGlobalTransport();
+  if (!transport || _runtimeSource === "user") return;
 
-  _runtime = createTransportRuntime({
-    baseUrl: transport.baseUrl,
-    silent: true,
-  });
+  _runtime = createTransportRuntime(transport);
   _runtimeSource = "client-runtime";
 }
 
@@ -689,20 +706,7 @@ function assertTransportOptions(
     throw new Error("[evjs] initTransport() options must be an object.");
   }
 
-  if (options.baseUrl !== undefined) {
-    assertTransportBaseUrl(options.baseUrl, "initTransport() baseUrl");
-  }
-
-  if (
-    options.credentials !== undefined &&
-    options.credentials !== "omit" &&
-    options.credentials !== "same-origin" &&
-    options.credentials !== "include"
-  ) {
-    throw new Error(
-      '[evjs] initTransport() credentials must be "omit", "same-origin", or "include".',
-    );
-  }
+  assertBaseTransportOptions(options, "initTransport()");
 
   if (options.headers !== undefined && typeof options.headers !== "function") {
     if (!isHeadersInit(options.headers)) {
@@ -727,17 +731,79 @@ function assertTransportOptions(
 
 function assertTransportFunctionsOptions(
   functions: unknown,
+  source = "initTransport() functions",
 ): asserts functions is NonNullable<TransportOptions["functions"]> {
   if (!isRecord(functions)) {
-    throw new Error("[evjs] initTransport() functions must be an object.");
+    throw new Error(`[evjs] ${source} must be an object.`);
   }
 
   if (functions.endpoint !== undefined) {
-    assertTransportEndpoint(
-      functions.endpoint,
-      "initTransport() functions.endpoint",
+    assertTransportEndpoint(functions.endpoint, `${source}.endpoint`);
+  }
+}
+
+function assertRuntimeTransportOptions(
+  options: unknown,
+  source: string,
+): asserts options is RuntimeTransportOptions {
+  if (!isRecord(options)) {
+    throw new Error(`[evjs] ${source} must be an object.`);
+  }
+
+  assertBaseTransportOptions(options, source);
+
+  if (
+    options.headers !== undefined &&
+    (typeof options.headers === "function" || !isHeadersInit(options.headers))
+  ) {
+    throw new Error(`[evjs] ${source}.headers must be valid HeadersInit.`);
+  }
+
+  if (options.adapter !== undefined) {
+    throw new Error(
+      `[evjs] ${source}.adapter is not supported. Runtime transport config must be serializable.`,
     );
   }
+
+  if (options.silent !== undefined) {
+    throw new Error(
+      `[evjs] ${source}.silent is not supported. Runtime transport config must be serializable.`,
+    );
+  }
+}
+
+function assertBaseTransportOptions(
+  options: Record<string, unknown>,
+  source: string,
+): void {
+  if (options.baseUrl !== undefined) {
+    assertTransportBaseUrl(
+      options.baseUrl,
+      formatTransportOptionSource(source, "baseUrl"),
+    );
+  }
+
+  if (
+    options.credentials !== undefined &&
+    options.credentials !== "omit" &&
+    options.credentials !== "same-origin" &&
+    options.credentials !== "include"
+  ) {
+    throw new Error(
+      `[evjs] ${formatTransportOptionSource(source, "credentials")} must be "omit", "same-origin", or "include".`,
+    );
+  }
+
+  if (options.functions !== undefined) {
+    assertTransportFunctionsOptions(
+      options.functions,
+      formatTransportOptionSource(source, "functions"),
+    );
+  }
+}
+
+function formatTransportOptionSource(source: string, key: string): string {
+  return source.endsWith(")") ? `${source} ${key}` : `${source}.${key}`;
 }
 
 function assertTransportAdapter(
@@ -795,7 +861,7 @@ function formatTransportBaseUrlError(error: UrlStringValidationError): string {
 
 function getClientRuntimeTransport(
   runtime: unknown,
-): { baseUrl?: string } | undefined {
+): RuntimeTransportOptions | undefined {
   if (!isRecord(runtime)) {
     throw new Error(
       "[evjs] initTransportFromRuntime() runtime must be a client runtime object.",
@@ -809,19 +875,27 @@ function getClientRuntimeTransport(
 
   const transport = runtime.runtime.transport;
   if (transport === undefined) return undefined;
-  if (!isRecord(transport)) {
-    throw new Error(
-      "[evjs] initTransportFromRuntime() runtime.runtime.transport must be an object.",
-    );
-  }
+  assertRuntimeTransportOptions(
+    transport,
+    "initTransportFromRuntime() runtime.runtime.transport",
+  );
+  return hasRuntimeTransportOptions(transport) ? transport : undefined;
+}
 
-  if (transport.baseUrl === undefined) return undefined;
-  return {
-    baseUrl: assertTransportBaseUrl(
-      transport.baseUrl,
-      "initTransportFromRuntime() runtime.runtime.transport.baseUrl",
-    ),
-  };
+function getGlobalTransport(): RuntimeTransportOptions | undefined {
+  const transport = globalThis.__EVJS_TRANSPORT__;
+  if (transport === undefined) return undefined;
+  assertRuntimeTransportOptions(transport, "__EVJS_TRANSPORT__");
+  return hasRuntimeTransportOptions(transport) ? transport : undefined;
+}
+
+function hasRuntimeTransportOptions(options: RuntimeTransportOptions): boolean {
+  return (
+    options.baseUrl !== undefined ||
+    options.credentials !== undefined ||
+    options.headers !== undefined ||
+    options.functions !== undefined
+  );
 }
 
 /**
@@ -863,5 +937,6 @@ function hasServerFunctionMetadata<TArgs extends unknown[], TData>(
 export function __resetForTesting(): void {
   _runtime = null;
   _runtimeSource = null;
+  delete globalThis.__EVJS_TRANSPORT__;
   fnNameRegistry.clear();
 }

--- a/packages/client/src/server-functions/transport-runtime.ts
+++ b/packages/client/src/server-functions/transport-runtime.ts
@@ -29,6 +29,7 @@ import {
 import {
   assertClientRuntimeTransport,
   type ClientRuntime,
+  getClientRuntimeTransport,
   getGlobalRuntimeTransport,
   hasClientRuntimeTransport,
   type RuntimeTransportOptions,
@@ -467,7 +468,7 @@ export function initTransportFromRuntime(
   runtime: Pick<ClientRuntime, "runtime">,
 ): void {
   const transport =
-    getClientRuntimeTransport(runtime) ?? getGlobalRuntimeTransport();
+    readClientRuntimeTransport(runtime) ?? getGlobalRuntimeTransport();
   if (!transport || _runtimeSource === "user") return;
 
   _runtime = createTransportRuntime(transport);
@@ -816,7 +817,7 @@ function formatTransportBaseUrlError(error: UrlStringValidationError): string {
   }
 }
 
-function getClientRuntimeTransport(
+function readClientRuntimeTransport(
   runtime: unknown,
 ): RuntimeTransportOptions | undefined {
   if (!isRecord(runtime)) {
@@ -830,7 +831,9 @@ function getClientRuntimeTransport(
     );
   }
 
-  const transport = runtime.runtime.transport;
+  const transport = getClientRuntimeTransport(
+    runtime as Pick<ClientRuntime, "runtime">,
+  );
   if (transport === undefined) return undefined;
   assertClientRuntimeTransport(
     transport,

--- a/packages/client/src/server-functions/transport.ts
+++ b/packages/client/src/server-functions/transport.ts
@@ -5,6 +5,7 @@
 export type {
   HeaderFactory,
   RequestContext,
+  RuntimeTransportOptions,
   ServerFunction,
   TransportAdapter,
   TransportOptions,

--- a/packages/client/src/shared/runtime-config.ts
+++ b/packages/client/src/shared/runtime-config.ts
@@ -45,9 +45,18 @@ export interface ClientRuntimeTransport {
   baseUrl?: string;
   credentials?: RequestCredentials;
   headers?: HeadersInit;
-  functions?: {
-    endpoint?: string;
-  };
+}
+
+export type RuntimeTransportOptions = ClientRuntimeTransport;
+
+declare global {
+  /**
+   * Dynamic transport configuration injected by hosting runtimes before evjs
+   * framework server requests start. Endpoint paths still come from framework
+   * runtime metadata.
+   */
+  // eslint-disable-next-line no-var
+  var __EVJS_TRANSPORT__: RuntimeTransportOptions | undefined;
 }
 
 export interface ClientRuntimeApp {
@@ -96,29 +105,10 @@ export function assertClientRuntime(
     );
   }
   if (value.runtime.transport !== undefined) {
-    assertObject(value.runtime.transport, `${source}.runtime.transport`);
-    assertRuntimeTransportBaseUrl(
-      value.runtime.transport.baseUrl,
-      `${source}.runtime.transport.baseUrl`,
+    assertClientRuntimeTransport(
+      value.runtime.transport,
+      `${source}.runtime.transport`,
     );
-    assertRuntimeTransportCredentials(
-      value.runtime.transport.credentials,
-      `${source}.runtime.transport.credentials`,
-    );
-    assertRuntimeTransportHeaders(
-      value.runtime.transport.headers,
-      `${source}.runtime.transport.headers`,
-    );
-    if (value.runtime.transport.functions !== undefined) {
-      assertObject(
-        value.runtime.transport.functions,
-        `${source}.runtime.transport.functions`,
-      );
-      assertRuntimeTransportBaseUrl(
-        value.runtime.transport.functions.endpoint,
-        `${source}.runtime.transport.functions.endpoint`,
-      );
-    }
   }
   if (value.app !== undefined) {
     assertApp(value.app, `${source}.app`);
@@ -141,6 +131,50 @@ export function getClientRuntimeRoutes(
     return createRoutesFromPages(runtime.routing.pages);
   }
   return runtime.routes ?? [];
+}
+
+export function assertClientRuntimeTransport(
+  value: unknown,
+  source: string,
+): asserts value is ClientRuntimeTransport {
+  assertObject(value, source);
+  assertRuntimeTransportBaseUrl(value.baseUrl, `${source}.baseUrl`);
+  assertRuntimeTransportCredentials(value.credentials, `${source}.credentials`);
+  assertRuntimeTransportHeaders(value.headers, `${source}.headers`);
+  if (value.functions !== undefined) {
+    throw new Error(
+      `[evjs] ${source}.functions is not supported. Runtime transport config uses framework runtime endpoints.`,
+    );
+  }
+  if (value.adapter !== undefined) {
+    throw new Error(
+      `[evjs] ${source}.adapter is not supported. Runtime transport config must be serializable.`,
+    );
+  }
+  if (value.silent !== undefined) {
+    throw new Error(
+      `[evjs] ${source}.silent is not supported. Runtime transport config must be serializable.`,
+    );
+  }
+}
+
+export function getGlobalRuntimeTransport():
+  | RuntimeTransportOptions
+  | undefined {
+  const transport = globalThis.__EVJS_TRANSPORT__;
+  if (transport === undefined) return undefined;
+  assertClientRuntimeTransport(transport, "__EVJS_TRANSPORT__");
+  return hasClientRuntimeTransport(transport) ? transport : undefined;
+}
+
+export function hasClientRuntimeTransport(
+  transport: ClientRuntimeTransport,
+): boolean {
+  return (
+    transport.baseUrl !== undefined ||
+    transport.credentials !== undefined ||
+    transport.headers !== undefined
+  );
 }
 
 function assertRuntimeRouting(

--- a/packages/client/src/shared/runtime-config.ts
+++ b/packages/client/src/shared/runtime-config.ts
@@ -133,6 +133,18 @@ export function getClientRuntimeRoutes(
   return runtime.routes ?? [];
 }
 
+export function getClientRuntimeServer(
+  runtime: Pick<ClientRuntime, "runtime">,
+): ClientRuntime["runtime"]["server"] {
+  return runtime.runtime.server;
+}
+
+export function getClientRuntimeTransport(
+  runtime: Pick<ClientRuntime, "runtime">,
+): ClientRuntimeTransport | undefined {
+  return runtime.runtime.transport;
+}
+
 export function assertClientRuntimeTransport(
   value: unknown,
   source: string,
@@ -165,6 +177,16 @@ export function getGlobalRuntimeTransport():
   if (transport === undefined) return undefined;
   assertClientRuntimeTransport(transport, "__EVJS_TRANSPORT__");
   return hasClientRuntimeTransport(transport) ? transport : undefined;
+}
+
+export function resolveClientRuntimeTransport(
+  runtime: Pick<ClientRuntime, "runtime">,
+): ClientRuntimeTransport | undefined {
+  const transport = getClientRuntimeTransport(runtime);
+  if (transport !== undefined && hasClientRuntimeTransport(transport)) {
+    return transport;
+  }
+  return getGlobalRuntimeTransport();
 }
 
 export function hasClientRuntimeTransport(

--- a/packages/client/src/shared/runtime-config.ts
+++ b/packages/client/src/shared/runtime-config.ts
@@ -179,6 +179,11 @@ export function getGlobalRuntimeTransport():
   return hasClientRuntimeTransport(transport) ? transport : undefined;
 }
 
+/**
+ * Resolve defaults for framework-managed browser requests to evjs server
+ * endpoints. Keep new server-route, PPR, or other framework client fetch
+ * consumers on this helper instead of reading runtime.transport directly.
+ */
 export function resolveClientRuntimeTransport(
   runtime: Pick<ClientRuntime, "runtime">,
 ): ClientRuntimeTransport | undefined {

--- a/packages/client/src/shared/runtime-config.ts
+++ b/packages/client/src/shared/runtime-config.ts
@@ -3,6 +3,7 @@ import {
   getPathPatternValidationError,
   getUrlStringValidationError,
   isBuildIdentifier,
+  isHeadersInit,
   normalizeRoutePathname,
   type PathPatternValidationError,
   pageRoutePathShapeFromPath,
@@ -20,9 +21,7 @@ export interface ClientRuntime {
     server?: {
       rsc?: string;
     };
-    transport?: {
-      baseUrl?: string;
-    };
+    transport?: ClientRuntimeTransport;
   };
   app?: ClientRuntimeApp;
   routing?: ClientRuntimeRouting;
@@ -40,6 +39,15 @@ export interface ClientAssetGroup {
 export interface ClientRuntimeModule {
   type: "entry" | "lifecycle" | "react-component";
   href?: string;
+}
+
+export interface ClientRuntimeTransport {
+  baseUrl?: string;
+  credentials?: RequestCredentials;
+  headers?: HeadersInit;
+  functions?: {
+    endpoint?: string;
+  };
 }
 
 export interface ClientRuntimeApp {
@@ -93,6 +101,24 @@ export function assertClientRuntime(
       value.runtime.transport.baseUrl,
       `${source}.runtime.transport.baseUrl`,
     );
+    assertRuntimeTransportCredentials(
+      value.runtime.transport.credentials,
+      `${source}.runtime.transport.credentials`,
+    );
+    assertRuntimeTransportHeaders(
+      value.runtime.transport.headers,
+      `${source}.runtime.transport.headers`,
+    );
+    if (value.runtime.transport.functions !== undefined) {
+      assertObject(
+        value.runtime.transport.functions,
+        `${source}.runtime.transport.functions`,
+      );
+      assertRuntimeTransportBaseUrl(
+        value.runtime.transport.functions.endpoint,
+        `${source}.runtime.transport.functions.endpoint`,
+      );
+    }
   }
   if (value.app !== undefined) {
     assertApp(value.app, `${source}.app`);
@@ -391,6 +417,25 @@ function assertRuntimeTransportBaseUrl(value: unknown, source: string): void {
     throw new Error(
       `[evjs] ${source} ${formatRuntimeTransportBaseUrlError(error)}`,
     );
+  }
+}
+
+function assertRuntimeTransportCredentials(
+  value: unknown,
+  source: string,
+): void {
+  if (value === undefined) return;
+  if (value !== "omit" && value !== "same-origin" && value !== "include") {
+    throw new Error(
+      `[evjs] ${source} must be "omit", "same-origin", or "include".`,
+    );
+  }
+}
+
+function assertRuntimeTransportHeaders(value: unknown, source: string): void {
+  if (value === undefined) return;
+  if (typeof value === "function" || !isHeadersInit(value)) {
+    throw new Error(`[evjs] ${source} must be valid HeadersInit.`);
   }
 }
 

--- a/packages/client/tests/public-surface-types.ts
+++ b/packages/client/tests/public-surface-types.ts
@@ -51,6 +51,7 @@ export type PublicTransportSubpathExports = [
   typeof ClientTransport.initTransport,
   ClientTransport.HeaderFactory,
   ClientTransport.RequestContext,
+  ClientTransport.RuntimeTransportOptions,
   ClientTransport.ServerFunction,
   ClientTransport.TransportAdapter,
   ClientTransport.TransportOptions,

--- a/packages/client/tests/react-runtime.test.ts
+++ b/packages/client/tests/react-runtime.test.ts
@@ -11,6 +11,7 @@ import type {
   ClientRuntime,
   ClientRuntimePage,
   ClientRuntimeRoute,
+  RuntimeTransportOptions,
 } from "../src/shared/runtime-config.js";
 
 type LegacyClientRuntime = ClientRuntime & {
@@ -639,6 +640,67 @@ describe("fetchRscFlight", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "https://runtime.example.com/__evjs/rsc?page=dashboard&url=%2Fdashboard%3Ftab%3Dstats",
     );
+  });
+
+  it("uses runtime transport request defaults for RSC Flight requests", async () => {
+    vi.stubGlobal("location", { href: "https://app.example.com/current" });
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response("flight"));
+
+    await fetchRscFlight({
+      runtime: {
+        ...createRscRuntime(),
+        runtime: {
+          ...createRscRuntime().runtime,
+          transport: {
+            baseUrl: "https://runtime.example.com/service/",
+            credentials: "include",
+            headers: {
+              "x-webgw-appid": "1800",
+              "x-webgw-version": "2.0",
+            },
+          },
+        },
+      },
+      pageId: "dashboard",
+      url: "https://app.example.com/dashboard?tab=stats",
+      fetch: fetchMock,
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1];
+    const headers = new Headers(init?.headers);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://runtime.example.com/__evjs/rsc?page=dashboard&url=%2Fdashboard%3Ftab%3Dstats",
+      expect.objectContaining({ credentials: "include" }),
+    );
+    expect(headers.get("x-webgw-appid")).toBe("1800");
+    expect(headers.get("x-webgw-version")).toBe("2.0");
+  });
+
+  it("uses global transport config for RSC Flight requests", async () => {
+    vi.stubGlobal("location", { href: "https://app.example.com/current" });
+    vi.stubGlobal("__EVJS_TRANSPORT__", {
+      baseUrl: "https://webgw.example.com/app/api/yuyan/1800/version",
+      credentials: "include",
+      headers: {
+        "x-webgw-appid": "1800",
+      },
+    } satisfies RuntimeTransportOptions);
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response("flight"));
+
+    await fetchRscFlight({
+      runtime: createRscRuntime(),
+      pageId: "dashboard",
+      url: "https://app.example.com/dashboard?tab=stats",
+      fetch: fetchMock,
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1];
+    const headers = new Headers(init?.headers);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://webgw.example.com/__evjs/rsc?page=dashboard&url=%2Fdashboard%3Ftab%3Dstats",
+      expect.objectContaining({ credentials: "include" }),
+    );
+    expect(headers.get("x-webgw-appid")).toBe("1800");
   });
 
   it("rejects malformed RSC Flight options before fetching", async () => {

--- a/packages/client/tests/transport.test.ts
+++ b/packages/client/tests/transport.test.ts
@@ -370,14 +370,7 @@ describe("initTransport + callServer", () => {
         runtime: { transport: { functions: [] } },
       } as never),
     ).toThrow(
-      "[evjs] initTransportFromRuntime() runtime.runtime.transport.functions must be an object.",
-    );
-    expect(() =>
-      initTransportFromRuntime({
-        runtime: { transport: { functions: { endpoint: "" } } },
-      } as never),
-    ).toThrow(
-      "[evjs] initTransportFromRuntime() runtime.runtime.transport.functions.endpoint must be a non-empty URL string.",
+      "[evjs] initTransportFromRuntime() runtime.runtime.transport.functions is not supported. Runtime transport config uses framework runtime endpoints.",
     );
     expect(() =>
       initTransportFromRuntime({
@@ -504,14 +497,20 @@ describe("transport types", () => {
     const options: RuntimeTransportOptions = {
       baseUrl: "https://api.example.com",
       credentials: "include",
-      functions: { endpoint: "/api/rpc" },
       headers: { Authorization: "Bearer xyz" },
     };
     expect(options).toEqual({
       baseUrl: "https://api.example.com",
       credentials: "include",
-      functions: { endpoint: "/api/rpc" },
       headers: { Authorization: "Bearer xyz" },
+    });
+
+    const invalidFunctions: RuntimeTransportOptions = {
+      // @ts-expect-error Runtime transport uses framework runtime endpoints.
+      functions: { endpoint: "/api/rpc" },
+    };
+    expect(invalidFunctions).toEqual({
+      functions: { endpoint: "/api/rpc" },
     });
 
     const invalidHeaderFactory: RuntimeTransportOptions = {
@@ -573,12 +572,12 @@ describe("default fetch adapter", () => {
     vi.stubGlobal("__EVJS_TRANSPORT__", {
       baseUrl: "https://webgw.example.com/app/api/yuyan/1800/version",
       credentials: "include",
-      functions: { endpoint: "fn" },
       headers: {
         "x-webgw-appid": "1800",
         "x-webgw-version": "2.0",
       },
     } satisfies RuntimeTransportOptions);
+    vi.stubGlobal("__EVJS_FUNCTION_ENDPOINT__", "fn");
 
     await callServer("myFn", []);
 
@@ -602,13 +601,13 @@ describe("default fetch adapter", () => {
       baseUrl: "https://global.example.com/api",
       headers: { "x-source": "global" },
     } satisfies RuntimeTransportOptions);
+    vi.stubGlobal("__EVJS_FUNCTION_ENDPOINT__", "fn");
 
     initTransportFromRuntime({
       runtime: {
         transport: {
           baseUrl: "https://runtime.example.com/api",
           credentials: "include",
-          functions: { endpoint: "fn" },
           headers: { "x-source": "runtime" },
         },
       },

--- a/packages/client/tests/transport.test.ts
+++ b/packages/client/tests/transport.test.ts
@@ -9,6 +9,7 @@ import {
   getServerFunction,
   initTransport,
   initTransportFromRuntime,
+  type RuntimeTransportOptions,
   type ServerFunction,
   type TransportAdapter,
   type TransportOptions,
@@ -350,6 +351,54 @@ describe("initTransport + callServer", () => {
     ).toThrow(
       "[evjs] initTransportFromRuntime() runtime.runtime.transport.baseUrl must be a valid URL string.",
     );
+    expect(() =>
+      initTransportFromRuntime({
+        runtime: { transport: { credentials: "credentialed" } },
+      } as never),
+    ).toThrow(
+      '[evjs] initTransportFromRuntime() runtime.runtime.transport.credentials must be "omit", "same-origin", or "include".',
+    );
+    expect(() =>
+      initTransportFromRuntime({
+        runtime: { transport: { headers: () => ({}) } },
+      } as never),
+    ).toThrow(
+      "[evjs] initTransportFromRuntime() runtime.runtime.transport.headers must be valid HeadersInit.",
+    );
+    expect(() =>
+      initTransportFromRuntime({
+        runtime: { transport: { functions: [] } },
+      } as never),
+    ).toThrow(
+      "[evjs] initTransportFromRuntime() runtime.runtime.transport.functions must be an object.",
+    );
+    expect(() =>
+      initTransportFromRuntime({
+        runtime: { transport: { functions: { endpoint: "" } } },
+      } as never),
+    ).toThrow(
+      "[evjs] initTransportFromRuntime() runtime.runtime.transport.functions.endpoint must be a non-empty URL string.",
+    );
+    expect(() =>
+      initTransportFromRuntime({
+        runtime: { transport: { adapter: { send: async () => null } } },
+      } as never),
+    ).toThrow(
+      "[evjs] initTransportFromRuntime() runtime.runtime.transport.adapter is not supported. Runtime transport config must be serializable.",
+    );
+    expect(() =>
+      initTransportFromRuntime({
+        runtime: { transport: { silent: true } },
+      } as never),
+    ).toThrow(
+      "[evjs] initTransportFromRuntime() runtime.runtime.transport.silent is not supported. Runtime transport config must be serializable.",
+    );
+    vi.stubGlobal("__EVJS_TRANSPORT__", {
+      headers: () => ({}),
+    });
+    expect(() => initTransportFromRuntime({ runtime: {} } as never)).toThrow(
+      "[evjs] __EVJS_TRANSPORT__.headers must be valid HeadersInit.",
+    );
   });
 
   it("rejects invalid server function call payloads before adapters run", async () => {
@@ -450,6 +499,37 @@ describe("transport types", () => {
       functions: { endpoint: new URL("https://api.example.com/fn") },
     });
   });
+
+  it("keeps runtime transport config serializable", () => {
+    const options: RuntimeTransportOptions = {
+      baseUrl: "https://api.example.com",
+      credentials: "include",
+      functions: { endpoint: "/api/rpc" },
+      headers: { Authorization: "Bearer xyz" },
+    };
+    expect(options).toEqual({
+      baseUrl: "https://api.example.com",
+      credentials: "include",
+      functions: { endpoint: "/api/rpc" },
+      headers: { Authorization: "Bearer xyz" },
+    });
+
+    const invalidHeaderFactory: RuntimeTransportOptions = {
+      // @ts-expect-error Runtime transport config must be serializable.
+      headers: () => ({ Authorization: "Bearer xyz" }),
+    };
+    expect(invalidHeaderFactory).toEqual({
+      headers: expect.any(Function),
+    });
+
+    const invalidAdapter: RuntimeTransportOptions = {
+      // @ts-expect-error Runtime transport config does not accept custom adapters.
+      adapter: { send: async () => "ok" },
+    };
+    expect(invalidAdapter).toEqual({
+      adapter: { send: expect.any(Function) },
+    });
+  });
 });
 
 describe("public transport subpath", () => {
@@ -485,6 +565,93 @@ describe("default fetch adapter", () => {
       new URL("http://localhost/api/rpc"),
       expect.objectContaining({ method: "POST" }),
     );
+  });
+
+  it("uses global transport config before explicit initialization", async () => {
+    const mockFetch = createSuccessfulFetchMock({ result: "ok" });
+    vi.stubGlobal("fetch", mockFetch);
+    vi.stubGlobal("__EVJS_TRANSPORT__", {
+      baseUrl: "https://webgw.example.com/app/api/yuyan/1800/version",
+      credentials: "include",
+      functions: { endpoint: "fn" },
+      headers: {
+        "x-webgw-appid": "1800",
+        "x-webgw-version": "2.0",
+      },
+    } satisfies RuntimeTransportOptions);
+
+    await callServer("myFn", []);
+
+    const init = mockFetch.mock.calls[0]?.[1];
+    const headers = new Headers(init?.headers);
+    expect(mockFetch).toHaveBeenCalledWith(
+      new URL("https://webgw.example.com/app/api/yuyan/1800/version/fn"),
+      expect.objectContaining({
+        credentials: "include",
+        method: "POST",
+      }),
+    );
+    expect(headers.get("x-webgw-appid")).toBe("1800");
+    expect(headers.get("x-webgw-version")).toBe("2.0");
+  });
+
+  it("prefers embedded runtime transport over global transport config", async () => {
+    const mockFetch = createSuccessfulFetchMock({ result: "ok" });
+    vi.stubGlobal("fetch", mockFetch);
+    vi.stubGlobal("__EVJS_TRANSPORT__", {
+      baseUrl: "https://global.example.com/api",
+      headers: { "x-source": "global" },
+    } satisfies RuntimeTransportOptions);
+
+    initTransportFromRuntime({
+      runtime: {
+        transport: {
+          baseUrl: "https://runtime.example.com/api",
+          credentials: "include",
+          functions: { endpoint: "fn" },
+          headers: { "x-source": "runtime" },
+        },
+      },
+    });
+    await callServer("myFn", []);
+
+    const headers = new Headers(mockFetch.mock.calls[0]?.[1]?.headers);
+    expect(mockFetch).toHaveBeenCalledWith(
+      new URL("https://runtime.example.com/api/fn"),
+      expect.objectContaining({ credentials: "include" }),
+    );
+    expect(headers.get("x-source")).toBe("runtime");
+  });
+
+  it("keeps explicit initTransport ahead of global transport config", async () => {
+    const mockFetch = createSuccessfulFetchMock({ result: "ok" });
+    vi.stubGlobal("fetch", mockFetch);
+    vi.stubGlobal("__EVJS_TRANSPORT__", {
+      baseUrl: "https://global.example.com/api",
+      headers: { "x-source": "global" },
+    } satisfies RuntimeTransportOptions);
+
+    initTransport({
+      baseUrl: "https://user.example.com/api",
+      functions: { endpoint: "fn" },
+      headers: { "x-source": "user" },
+    });
+    initTransportFromRuntime({
+      runtime: {
+        transport: {
+          baseUrl: "https://runtime.example.com/api",
+          headers: { "x-source": "runtime" },
+        },
+      },
+    });
+    await callServer("myFn", []);
+
+    const headers = new Headers(mockFetch.mock.calls[0]?.[1]?.headers);
+    expect(mockFetch).toHaveBeenCalledWith(
+      new URL("https://user.example.com/api/fn"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(headers.get("x-source")).toBe("user");
   });
 
   it("resolves undefined when the server function success payload omits result", async () => {

--- a/packages/ev/src/transport/index.ts
+++ b/packages/ev/src/transport/index.ts
@@ -5,6 +5,7 @@
 export type {
   HeaderFactory,
   RequestContext,
+  RuntimeTransportOptions,
   ServerFunction,
   TransportAdapter,
   TransportOptions,


### PR DESCRIPTION
## Summary
- Add a data-only runtime transport configuration path for hosting environments via `window.__EVJS_TRANSPORT__`.
- Keep server-function transport execution in the shared evjs client runtime while allowing deployment runtimes to provide computed base URL, headers, credentials, and function endpoint.

## Changes
- Added `RuntimeTransportOptions` and exported it from `@evjs/client`, `@evjs/client/transport`, and `@evjs/ev/transport`.
- Updated client transport initialization to read embedded runtime transport first, then `globalThis.__EVJS_TRANSPORT__`, while preserving explicit `initTransport()` priority.
- Extended client runtime transport validation to cover `credentials`, static `headers`, and `functions.endpoint`.
- Added tests for global runtime transport config, precedence, serialization boundaries, and public type surface.
- Documented the hosting runtime global in the client README.

## Validation
- `npm test --workspace @evjs/client -- tests/transport.test.ts`
- `npm run check-types --workspace @evjs/client`
- `npm run check-types --workspace @evjs/ev`
- `npm test --workspace @evjs/client -- tests/page-runtime.test.ts tests/shell.test.ts`
- `npm test --workspace @evjs/ev -- tests/package-surface.test.ts`
- `npm run lint`
- `npm test --workspace @evjs/client`
- `npm run check-types`

## Risk / rollout
- Low runtime risk: the new global is only consumed when no explicit user transport is installed, and runtime config remains data-only.
- Explicit `initTransport()` continues to override runtime/global config.
- Hosting integrations must inject `window.__EVJS_TRANSPORT__` before server functions execute.

## Reviewer notes
- Please review the precedence model: explicit `initTransport()` > embedded runtime transport > `window.__EVJS_TRANSPORT__` > default same-origin transport.
- Please review the serialization boundary for `RuntimeTransportOptions`; adapter and header factory remain limited to explicit `initTransport()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for host-provided runtime transport via `window.__EVJS_TRANSPORT__`, including forwarding runtime/global transport credentials and headers (notably for RSC flights).
  * Exposed `RuntimeTransportOptions` across client and EV public APIs.
* **Bug Fixes**
  * Improved transport precedence: explicit `initTransport()` overrides runtime/global transport; runtime-embedded transport overrides defaults.
  * Strengthened validation and normalization of runtime transport options, ensuring only serializable/compatible values are used.
* **Documentation**
  * Updated transport docs with the supported `__EVJS_TRANSPORT__` format and initialization priority.
* **Tests**
  * Expanded coverage for invalid inputs, serializable preservation, and URL/header/credentials precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->