### PR TITLE
feat(routes): support SPA catch-all and cased file routes

### DIFF
--- a/docs/docs/build.md
+++ b/docs/docs/build.md
@@ -166,8 +166,9 @@ When a build fails, check the inputs users control first:
 - `ev.config.ts` exports `defineConfig(...)` and uses public config keys.
 - HTML templates contain the configured mount element, usually
   `<div id="app"></div>`.
-- `src/pages` routes follow the file conventions: `$param` dynamic segments,
-  `index.*` directory roots, and lowercase URL-safe static segments.
+- `src/pages` routes follow the file conventions: `index.*` directory roots,
+  `$param` dynamic segments, `$...splat` SPA catch-alls, and URL-safe static
+  segments.
 - Page modules default-export a React component.
 - Page rendering metadata uses literal values.
 - `"use server"` modules start with the directive and export named functions.

--- a/docs/docs/client-routes.md
+++ b/docs/docs/client-routes.md
@@ -34,8 +34,8 @@ The route convention is intentionally narrow:
 - Dynamic route segments use `$param` filenames such as `$userId.tsx` or
   `$team_id.tsx`.
 - Bracket segments such as `[id].tsx` and `[...slug].tsx` are rejected.
-- SPA catch-all segments use `$...splat.tsx` and map to `*`. Runtime params
-  expose the matched suffix as `_splat`.
+- SPA catch-all segments use `$...splat.tsx` as the final URL path segment and
+  map to `*`. Runtime params expose the matched suffix as `_splat`.
 - Optional file segments are not part of the convention, so `$slug?.tsx` and
   `$.tsx` are rejected.
 - Dynamic param names must be JavaScript identifiers after `$`.

--- a/docs/docs/client-routes.md
+++ b/docs/docs/client-routes.md
@@ -34,17 +34,20 @@ The route convention is intentionally narrow:
 - Dynamic route segments use `$param` filenames such as `$userId.tsx` or
   `$team_id.tsx`.
 - Bracket segments such as `[id].tsx` and `[...slug].tsx` are rejected.
-- Catch-all and optional file segments are not part of the convention yet, so
-  `$...slug.tsx`, `$slug?.tsx`, and `$.tsx` are rejected.
+- SPA catch-all segments use `$...splat.tsx` and map to `*`. Runtime params
+  expose the matched suffix as `_splat`.
+- Optional file segments are not part of the convention, so `$slug?.tsx` and
+  `$.tsx` are rejected.
 - Dynamic param names must be JavaScript identifiers after `$`.
 - Reserved names such as `$__proto__.tsx`, `$constructor.tsx`,
   `$prototype.tsx`, and `$_splat.tsx` are rejected. `$_splat.tsx` is reserved
   because wildcard routes expose `*` as `_splat`.
-- Static route segments must be lowercase and URL-safe: lowercase letters,
-  numbers, `.`, `_`, `-`, or `~`.
+- Static route segments must be URL-safe: letters, numbers, `.`, `_`, `-`, or
+  `~`. Lowercase names remain the recommended default for new routes, but
+  stable existing URL casing can be preserved.
 
-Use explicit `pages` config when a file needs to map to a custom or
-case-sensitive path.
+Use explicit `pages` config when a file needs to map to an optional or custom
+path shape outside these conventions.
 
 The collision checks are strict:
 

--- a/docs/docs/file-conventions.md
+++ b/docs/docs/file-conventions.md
@@ -27,25 +27,29 @@ with `routing.dir`, configure a different server file route directory with
 
 ## Segment Rules
 
-Page routes, server file routes, and API route middleware use the same
+Page routes, server file routes, and API route middleware share the same core
 path segment rules:
 
 | Pattern | Result |
 | --- | --- |
 | `index.*` | Directory root route. |
 | `$param.*` | Dynamic segment. Server file routes convert it to Hono `:param`. |
+| `$...splat.*` | SPA page-route catch-all segment. It maps to `*` and exposes `_splat` at runtime. |
 | `(group)` | Pathless route group for organization. It does not add a URL segment. |
 | `_private.*` or `_private/` | Ignored private module or directory. |
 | `.hidden.*` or `.hidden/` | Ignored hidden module or directory. |
 
-Static route segments must use lowercase URL-safe characters: lowercase
-letters, numbers, `.`, `_`, `-`, or `~`. Dynamic param names must be JavaScript
-identifiers after `$`, such as `$userId` or `$team_id`.
+Page route static segments must use URL-safe letters, numbers, `.`, `_`, `-`,
+or `~` and preserve casing for stable existing URLs. Lowercase names remain the
+recommended default for new application routes. Server file routes and API route
+middleware scopes keep lowercase URL-safe static segments. Dynamic param names
+must be JavaScript identifiers after `$`, such as `$userId` or `$team_id`.
 
 The following are rejected:
 
 - bracket routes such as `[id].tsx`;
-- catch-all routes such as `$...slug.tsx`;
+- malformed catch-all segments such as `$...123.tsx`;
+- more than one catch-all segment in one page route path;
 - optional params such as `$slug?.tsx`;
 - empty dynamic params such as `$.tsx`;
 - reserved dynamic params such as `$__proto__.tsx`, `$constructor.tsx`,
@@ -57,7 +61,9 @@ The following are rejected:
   `users/$userId.tsx`.
 
 Routes must follow the file shape. evjs does not provide alternate filename
-dialects for catch-all, optional, or bracket routes.
+dialects for optional or bracket routes. Catch-all file routes are only a SPA
+page-route convention; MPA page routes and server file routes reject catch-all
+segments.
 
 ## Ignored Support Files
 
@@ -86,6 +92,8 @@ src/pages/index.tsx              -> /
 src/pages/about.tsx              -> /about
 src/pages/users/index.tsx        -> /users
 src/pages/users/$userId.tsx      -> /users/$userId
+src/pages/docs/$...splat.tsx     -> /docs/*
+src/pages/legacyCamelCase.tsx    -> /legacyCamelCase
 src/pages/(marketing)/about.tsx  -> /about
 ```
 

--- a/docs/docs/project-structure.md
+++ b/docs/docs/project-structure.md
@@ -76,8 +76,8 @@ Quick rules:
 
 - Route files live under the configured `routing.dir` and use `.ts`, `.tsx`,
   `.js`, or `.jsx`.
-- Directory roots use `index.*`; dynamic segments use `$param`; static
-  segments stay lowercase and URL-safe.
+- Directory roots use `index.*`; dynamic segments use `$param`; SPA catch-all
+  segments use `$...splat`; static segments preserve URL-safe casing.
 - Route groups such as `(marketing)` are supported as pathless organization and
   do not add URL segments. Malformed group segments are rejected. Dynamic param
   names must be safe identifiers; reserved object-property names and `$_splat`
@@ -105,12 +105,15 @@ Migration rules stay explicit rather than adding alternate filename dialects:
 - Model SPA nested layouts with route-directory layout modules. Use ordinary
   components imported by a page when the wrapper should not participate in the
   route tree.
-- Use explicit `pages` config for catch-all, optional, case-sensitive, or other
-  custom URL shapes.
+- Use `$...splat` only for existing SPA URLs that need a catch-all route.
+  New application routes should prefer explicit static and `$param` segments
+  with simple lowercase names.
+- Use explicit `pages` config for optional or other custom URL shapes that do
+  not map to the file convention.
 
 | File or folder | Framework meaning | Use it for | Do not use it for |
 | --- | --- | --- | --- |
-| `src/pages/**/*.{tsx,jsx,ts,js}` | SPA/MPA page route discovery | Thin page components with optional literal rendering metadata | Shared helpers, tests, bracket routes, catch-all routes, or hand-written SPA router/bootstrap code |
+| `src/pages/**/*.{tsx,jsx,ts,js}` | SPA/MPA page route discovery | Thin page components with optional literal rendering metadata | Shared helpers, tests, bracket or optional routes, or hand-written SPA router/bootstrap code |
 | Same-basename `src/pages/**/*.html` beside a page route | MPA page HTML template | Page-specific document templates such as `about.html` beside `about.tsx` or `users/index.html` beside `users/index.tsx` | SPA layouts, route modules, or templates for unrelated routes |
 | Route paths, dynamic URL shapes, and generated route IDs under `src/pages` | Route collision checks before build output is generated | One page module per URL path, one parameter naming choice per dynamic URL shape, and unique generated route IDs | Parallel `users.tsx`/`users/index.tsx`, `users/$id.tsx`/`users/$userId.tsx`, or `admin/panel.tsx`/`admin_panel.tsx` routes |
 | `src/pages/(group)/**` | Pathless route group | Organizing page and layout modules without adding a URL segment | URL segments that should be visible in the browser path |
@@ -172,12 +175,15 @@ Keep the rules in four buckets:
    Rendering metadata lives beside that component. Syntax errors and missing
    default exports are reported during route discovery before the bundler runs.
 2. **Filename syntax**: `index.tsx` maps to the directory root. Dynamic segments
-   use `$param`; bracket segments such as `[id].tsx`, catch-all segments such as
-   `$...slug.tsx`, and optional segments such as `$slug?.tsx` are rejected.
+   use `$param`; SPA catch-all segments use `$...splat` and map to `*`.
+   Bracket segments such as `[id].tsx` and optional segments such as
+   `$slug?.tsx` are rejected.
 3. **URL segment safety**: dynamic names must be JavaScript identifiers after
-   `$`. Static segments must be lowercase URL-safe letters, numbers, `.`, `_`,
-   `-`, or `~`. Reserved names such as `$__proto__.tsx`, `$constructor.tsx`,
-   `$prototype.tsx`, and `$_splat.tsx` are rejected.
+   `$`. Static segments must be URL-safe letters, numbers, `.`, `_`, `-`, or
+   `~`; lowercase names remain the recommended default for new application
+   routes, but stable existing URL casing can be preserved. Reserved names such
+   as `$__proto__.tsx`, `$constructor.tsx`, `$prototype.tsx`, and `$_splat.tsx`
+   are rejected.
 4. **Organization only**: route groups such as `(marketing)` are pathless, so
    `src/pages/(marketing)/about.tsx` maps to `/about`. Malformed group segments
    such as `(marketing` are rejected.
@@ -204,9 +210,9 @@ Collision and ordering rules are also deterministic:
   `teams/$teamId/users/$teamId.tsx` is rejected.
 - Flat route files and directory index route files cannot claim the same URL
   path. Choose either `users.tsx` or `users/index.tsx` for `/users`.
-- SPA and MPA both order `/` first, parent routes before children, and static
-  siblings before dynamic siblings. For example, `users/settings.tsx` ranks
-  before `users/$id.tsx`.
+- SPA and MPA both order `/` first, parent routes before children, static
+  siblings before dynamic siblings, and catch-all siblings after dynamic
+  siblings. For example, `users/settings.tsx` ranks before `users/$id.tsx`.
 - Static siblings use locale-independent code-point ordering: `a-b.tsx`,
   `a.b.tsx`, `a0.tsx`, `a_c.tsx`, `aa.tsx`, and `a~d.tsx` keep that order on
   every machine.
@@ -217,7 +223,7 @@ Collision and ordering rules are also deterministic:
 Before build output is generated, evjs applies the same route checks to
 configured paths. It rejects duplicate paths, dynamic URL shapes, route IDs,
 empty dynamic params, reserved dynamic params, duplicate dynamic params,
-whitespace, query strings, and hashes.
+multiple wildcard segments, whitespace, query strings, and hashes.
 
 Generated route IDs come from URL paths and normalize separators and
 punctuation to underscores. That means `admin/panel.tsx` and
@@ -230,6 +236,8 @@ punctuation to underscores. That means `admin/panel.tsx` and
 | `src/pages/index.tsx` | `/` | Directory root route. |
 | `src/pages/docs/index.tsx` | `/docs` | Nested directory root route. |
 | `src/pages/users/$userId.tsx` | `/users/$userId` | Dynamic segment; the param name must be a JavaScript identifier. |
+| `src/pages/files/$...path.tsx` | `/files/*` | SPA catch-all route; runtime params expose the matched suffix as `_splat`. |
+| `src/pages/legacyCamelCase.tsx` | `/legacyCamelCase` | Case-preserving static segment for stable existing URLs. Prefer lowercase for new routes. |
 | `src/pages/users/settings.tsx` | `/users/settings` | Static sibling; it ranks before `users/$userId.tsx`. |
 | `src/pages/(marketing)/about.tsx` | `/about` | Pathless route group; `(marketing)` organizes files without adding a URL segment. |
 | `src/pages/posts/layout.tsx` | Layout route for `/posts` | SPA route layout that wraps descendants below `/posts`. |
@@ -240,7 +248,6 @@ punctuation to underscores. That means `admin/panel.tsx` and
 | `src/pages/ClientCard.client.tsx` | Ignored | Client-only modules can be colocated without becoming URL routes. |
 | `src/pages/users.server.ts` | Ignored | Server-only modules are not page routes; imported server functions are still handled by the server-function transform. |
 | `src/pages/users/[id].tsx` | Rejected | Bracket route syntax is not supported; use `$id.tsx`. |
-| `src/pages/files/$...path.tsx` | Rejected | Catch-all segments are not part of the convention. |
 | `src/pages/users/$__proto__.tsx` | Rejected | Reserved object-property names are not safe route param names. |
 | `src/pages/docs/$_splat.tsx` | Rejected | `_splat` is reserved for wildcard route params. |
 | `src/pages/layout.tsx` | Rejected | Use `src/layout/index.tsx` for the SPA root layout. Route layouts must be nested below a route segment. |
@@ -314,9 +321,9 @@ export const GET = async () => Response.json({ ok: true });
 The file path under `src/apis` is the URL path, so the example above
 maps to `/api/health`. A root route uses `src/apis/index.ts`; dynamic
 segments use `$param` filenames and map to Hono params such as `:userId`.
-Route groups are pathless, and the same segment safety rules used by page
-routes apply here: bracket, catch-all, optional, uppercase static segments,
-duplicate path, and duplicate dynamic-shape routes are rejected.
+Route groups are pathless. Server file routes reject bracket, catch-all,
+optional, uppercase static segments, duplicate path, and duplicate
+dynamic-shape routes.
 
 A file under `src/apis` becomes a server route only after it exports an
 uppercase HTTP method such as `GET` or `POST`. Files with no route exports are

--- a/docs/docs/project-structure.md
+++ b/docs/docs/project-structure.md
@@ -76,8 +76,8 @@ Quick rules:
 
 - Route files live under the configured `routing.dir` and use `.ts`, `.tsx`,
   `.js`, or `.jsx`.
-- Directory roots use `index.*`; dynamic segments use `$param`; SPA catch-all
-  segments use `$...splat`; static segments preserve URL-safe casing.
+- Directory roots use `index.*`; dynamic segments use `$param`; terminal SPA
+  catch-all segments use `$...splat`; static segments preserve URL-safe casing.
 - Route groups such as `(marketing)` are supported as pathless organization and
   do not add URL segments. Malformed group segments are rejected. Dynamic param
   names must be safe identifiers; reserved object-property names and `$_splat`
@@ -105,9 +105,9 @@ Migration rules stay explicit rather than adding alternate filename dialects:
 - Model SPA nested layouts with route-directory layout modules. Use ordinary
   components imported by a page when the wrapper should not participate in the
   route tree.
-- Use `$...splat` only for existing SPA URLs that need a catch-all route.
-  New application routes should prefer explicit static and `$param` segments
-  with simple lowercase names.
+- Use `$...splat` only as the final URL path segment for existing SPA URLs
+  that need a catch-all route. New application routes should prefer explicit
+  static and `$param` segments with simple lowercase names.
 - Use explicit `pages` config for optional or other custom URL shapes that do
   not map to the file convention.
 
@@ -175,7 +175,7 @@ Keep the rules in four buckets:
    Rendering metadata lives beside that component. Syntax errors and missing
    default exports are reported during route discovery before the bundler runs.
 2. **Filename syntax**: `index.tsx` maps to the directory root. Dynamic segments
-   use `$param`; SPA catch-all segments use `$...splat` and map to `*`.
+   use `$param`; terminal SPA catch-all segments use `$...splat` and map to `*`.
    Bracket segments such as `[id].tsx` and optional segments such as
    `$slug?.tsx` are rejected.
 3. **URL segment safety**: dynamic names must be JavaScript identifiers after
@@ -237,6 +237,7 @@ punctuation to underscores. That means `admin/panel.tsx` and
 | `src/pages/docs/index.tsx` | `/docs` | Nested directory root route. |
 | `src/pages/users/$userId.tsx` | `/users/$userId` | Dynamic segment; the param name must be a JavaScript identifier. |
 | `src/pages/files/$...path.tsx` | `/files/*` | SPA catch-all route; runtime params expose the matched suffix as `_splat`. |
+| `src/pages/files/$...path/edit.tsx` | Rejected | Catch-all segments must be the final URL path segment. |
 | `src/pages/legacyCamelCase.tsx` | `/legacyCamelCase` | Case-preserving static segment for stable existing URLs. Prefer lowercase for new routes. |
 | `src/pages/users/settings.tsx` | `/users/settings` | Static sibling; it ranks before `users/$userId.tsx`. |
 | `src/pages/(marketing)/about.tsx` | `/about` | Pathless route group; `(marketing)` organizes files without adding a URL segment. |

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
@@ -156,8 +156,8 @@ export const GET = async () => Response.json({ ok: true });
 
 - `ev.config.ts` 导出 `defineConfig(...)`，且只使用公开配置字段。
 - HTML 模板包含配置的挂载点，通常是 `<div id="app"></div>`。
-- `src/pages` 路由符合文件约定：`$param` 动态段、`index.*` 目录根路由、
-  小写 URL-safe 静态段。
+- `src/pages` 路由符合文件约定：`index.*` 目录根路由、`$param` 动态段、
+  `$...splat` SPA catch-all 和 URL-safe 静态段。
 - 页面模块默认导出 React 组件。
 - 页面渲染元信息使用字面量值。
 - `"use server"` 模块以指令开头，并导出命名函数。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/client-routes.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/client-routes.md
@@ -31,16 +31,18 @@ src/
 
 - 动态路由段使用 `$param` 文件名，例如 `$userId.tsx` 或 `$team_id.tsx`。
 - `[id].tsx` 和 `[...slug].tsx` 这类 bracket 段会被拒绝。
-- catch-all 和可选文件段暂不属于页面路由约定，因此 `$...slug.tsx`、
-  `$slug?.tsx` 和 `$.tsx` 都会被拒绝。
+- SPA catch-all 段使用 `$...splat.tsx`，并映射为 `*`。运行时 params 会把匹配到的
+  后缀暴露为 `_splat`。
+- optional 文件段不属于约定，因此 `$slug?.tsx` 和 `$.tsx` 会被拒绝。
 - 动态参数名必须是 `$` 后面的 JavaScript 标识符。
 - `$__proto__.tsx`、`$constructor.tsx`、`$prototype.tsx` 和 `$_splat.tsx`
   这类保留名称会被拒绝。`$_splat.tsx` 被保留，是因为 wildcard 路由会把 `*`
   暴露为 `_splat`。
-- 静态路由段必须小写，并且只能使用 URL-safe 字符：小写字母、数字、`.`、`_`、`-`
-  或 `~`。
+- 静态路由段必须使用 URL-safe 字符：字母、数字、`.`、`_`、`-` 或 `~`。新路由仍建议
+  使用小写命名，但既有稳定 URL 的大小写可以保留。
 
-如果文件需要映射到自定义或大小写敏感 path，请使用显式 `pages` 配置。
+如果文件需要映射到 optional 或其他约定外的自定义 path shape，请使用显式 `pages`
+配置。
 
 冲突检查也保持严格：
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/client-routes.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/client-routes.md
@@ -31,8 +31,8 @@ src/
 
 - 动态路由段使用 `$param` 文件名，例如 `$userId.tsx` 或 `$team_id.tsx`。
 - `[id].tsx` 和 `[...slug].tsx` 这类 bracket 段会被拒绝。
-- SPA catch-all 段使用 `$...splat.tsx`，并映射为 `*`。运行时 params 会把匹配到的
-  后缀暴露为 `_splat`。
+- SPA catch-all 段使用 `$...splat.tsx` 作为 URL path 的最后一段，并映射为 `*`。
+  运行时 params 会把匹配到的后缀暴露为 `_splat`。
 - optional 文件段不属于约定，因此 `$slug?.tsx` 和 `$.tsx` 会被拒绝。
 - 动态参数名必须是 `$` 后面的 JavaScript 标识符。
 - `$__proto__.tsx`、`$constructor.tsx`、`$prototype.tsx` 和 `$_splat.tsx`

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/file-conventions.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/file-conventions.md
@@ -24,24 +24,27 @@
 
 ## 路径段规则
 
-页面路由、服务端文件路由和 API route middleware 使用同一套路径段规则：
+页面路由、服务端文件路由和 API route middleware 共享一套核心路径段规则：
 
 | 模式 | 结果 |
 | --- | --- |
 | `index.*` | 目录根路由。 |
 | `$param.*` | 动态段。服务端文件路由会转换为 Hono `:param`。 |
+| `$...splat.*` | SPA 页面路由 catch-all 段。它会映射为 `*`，运行时暴露 `_splat`。 |
 | `(group)` | 用于组织目录的 pathless route group，不增加 URL segment。 |
 | `_private.*` 或 `_private/` | 忽略的私有模块或目录。 |
 | `.hidden.*` 或 `.hidden/` | 忽略的隐藏模块或目录。 |
 
-静态路由段必须使用小写 URL-safe 字符：小写字母、数字、`.`、`_`、`-`
-或 `~`。动态参数名必须是 `$` 后的 JavaScript 标识符，例如 `$userId` 或
-`$team_id`。
+页面路由的静态段必须使用 URL-safe 字母、数字、`.`、`_`、`-` 或 `~`，并为既有稳定
+URL 保留大小写。新应用路由仍建议使用小写命名。服务端文件路由和 API route
+middleware 作用域继续使用小写 URL-safe 静态段。动态参数名必须是 `$` 后的
+JavaScript 标识符，例如 `$userId` 或 `$team_id`。
 
 以下写法会被拒绝：
 
 - `[id].tsx` 这类 bracket route；
-- `$...slug.tsx` 这类 catch-all route；
+- `$...123.tsx` 这类格式错误的 catch-all 段；
+- 同一个页面路由路径中出现多个 catch-all 段；
 - `$slug?.tsx` 这类 optional param；
 - `$.tsx` 这类空动态参数；
 - `$__proto__.tsx`、`$constructor.tsx`、`$prototype.tsx` 或
@@ -50,8 +53,9 @@
 - `users.tsx` 和 `users/index.tsx` 这类重复 path；
 - `users/$id.tsx` 和 `users/$userId.tsx` 这类重复 dynamic shape。
 
-路由必须遵循文件形状。evjs 不提供 catch-all、optional 或 bracket routes
-的替代文件名方言。
+路由必须遵循文件形状。evjs 不提供 optional 或 bracket routes 的替代文件名方言。
+Catch-all 文件路由只属于 SPA 页面路由约定；MPA 页面路由和服务端文件路由都会拒绝
+catch-all 段。
 
 ## 忽略的支撑文件
 
@@ -79,6 +83,8 @@ src/pages/index.tsx              -> /
 src/pages/about.tsx              -> /about
 src/pages/users/index.tsx        -> /users
 src/pages/users/$userId.tsx      -> /users/$userId
+src/pages/docs/$...splat.tsx     -> /docs/*
+src/pages/legacyCamelCase.tsx    -> /legacyCamelCase
 src/pages/(marketing)/about.tsx  -> /about
 ```
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/project-structure.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/project-structure.md
@@ -72,8 +72,8 @@ my-evjs-app/
 
 - 路由文件放在配置的 `routing.dir` 下，并使用 `.ts`、`.tsx`、`.js` 或
   `.jsx`。
-- 目录根路由使用 `index.*`；动态段使用 `$param`；静态段保持小写且
-  URL-safe。
+- 目录根路由使用 `index.*`；动态段使用 `$param`；SPA catch-all 段使用
+  `$...splat`；静态段保留 URL-safe 的大小写。
 - 支持 `(marketing)` 这类 route group 作为 pathless 组织目录，不会增加 URL
   segment。不完整的 group segment 会被拒绝。动态参数名必须是安全标识符；
   保留对象属性名和 `$_splat` 都会被拒绝。
@@ -95,11 +95,13 @@ my-evjs-app/
   URL 中，请使用 `marketing/about.tsx` 这样的真实 URL segment。
 - SPA 嵌套布局使用路由目录内的 layout 模块建模。如果某个外框不应该参与路由树，
   则作为普通组件由需要它的页面 import。
-- catch-all、optional、大小写敏感或其他自定义 URL shape 使用显式 `pages` 配置。
+- `$...splat` 只用于需要 catch-all route 的既有 SPA URL。新应用路由仍建议使用
+  明确的静态段和 `$param` 段，并保持简单小写命名。
+- optional 或其他无法映射到文件约定的自定义 URL shape 使用显式 `pages` 配置。
 
 | 文件或目录 | 框架含义 | 用于 | 不用于 |
 | --- | --- | --- | --- |
-| `src/pages/**/*.{tsx,jsx,ts,js}` | SPA/MPA 页面路由发现 | 轻量页面组件和可选的字面量渲染元信息 | 共享 helper、测试、bracket route、catch-all route 或手写 SPA router/bootstrap 代码 |
+| `src/pages/**/*.{tsx,jsx,ts,js}` | SPA/MPA 页面路由发现 | 轻量页面组件和可选的字面量渲染元信息 | 共享 helper、测试、bracket/optional route 或手写 SPA router/bootstrap 代码 |
 | 页面路由旁同 basename 的 `src/pages/**/*.html` | MPA 页面 HTML 模板 | 页面专属 document 模板，例如 `about.tsx` 旁的 `about.html`，或 `users/index.tsx` 旁的 `users/index.html` | SPA layout、路由模块，或其他路由的模板 |
 | `src/pages` 下的 route paths、dynamic URL shapes 和生成的 route ID | 生成构建产物前的路由冲突检查 | 每个 URL path 只保留一个页面模块，每个 dynamic URL shape 只保留一种参数命名，并且生成的 route ID 必须唯一 | 并存的 `users.tsx`/`users/index.tsx`、`users/$id.tsx`/`users/$userId.tsx` 或 `admin/panel.tsx`/`admin_panel.tsx` 路由 |
 | `src/pages/(group)/**` | Pathless route group | 不增加 URL segment 的页面和 layout 组织目录 | 应出现在浏览器 URL 中的路径段 |
@@ -158,12 +160,12 @@ basename 的 colocated 模板替代全局 `index.html` 模板，例如
 1. **组件契约**：路由文件默认导出页面组件。渲染元信息放在页面组件旁边。语法错误和
    缺少默认导出的错误会在路由发现阶段、bundler 运行前报告。
 2. **文件名语法**：`index.tsx` 映射到当前目录根路径。动态段使用 `$param`。
-   `[id].tsx` 这类 bracket 段、`$...slug.tsx` 这类 catch-all 段，以及
-   `$slug?.tsx` 这类可选段都会被拒绝。
+   SPA catch-all 段使用 `$...splat`，并映射为 `*`。`[id].tsx` 这类
+   bracket 段和 `$slug?.tsx` 这类可选段会被拒绝。
 3. **URL segment 安全性**：动态参数名必须是 `$` 后面的 JavaScript 标识符。
-   静态段必须小写，并且只能使用 URL-safe 小写字母、数字、`.`、`_`、`-` 或 `~`。
-   `$__proto__.tsx`、`$constructor.tsx`、`$prototype.tsx` 和 `$_splat.tsx`
-   这类保留名称会被拒绝。
+   静态段必须使用 URL-safe 字母、数字、`.`、`_`、`-` 或 `~`；新应用路由仍建议使用
+   小写命名，但既有稳定 URL 的大小写可以保留。`$__proto__.tsx`、
+   `$constructor.tsx`、`$prototype.tsx` 和 `$_splat.tsx` 这类保留名称会被拒绝。
 4. **只做组织**：`(marketing)` 这类 route group 是 pathless 目录，因此
    `src/pages/(marketing)/about.tsx` 映射到 `/about`。`(marketing` 这类不完整
    group segment 会被拒绝。
@@ -190,16 +192,17 @@ basename 的 colocated 模板替代全局 `index.html` 模板，例如
   会被拒绝。
 - 扁平路由文件和目录 `index` 路由文件不能声明同一个 URL path。`/users` 应在
   `users.tsx` 和 `users/index.tsx` 中选择一种。
-- SPA 和 MPA 都按 `/` 最先、父路由早于子路由、同级静态路由早于动态路由排序。
-  因此 `users/settings.tsx` 会排在 `users/$id.tsx` 之前。
+- SPA 和 MPA 都按 `/` 最先、父路由早于子路由、同级静态路由早于动态路由、
+  catch-all 路由晚于动态路由排序。因此 `users/settings.tsx` 会排在
+  `users/$id.tsx` 之前。
 - 同级静态路由使用与 locale 无关的 code-point 顺序：`a-b.tsx`、`a.b.tsx`、
   `a0.tsx`、`a_c.tsx`、`aa.tsx`、`a~d.tsx` 在任何机器上都保持这个顺序。
 - 路由示例和配置应使用 `/` 分隔符。文件系统里的 `\` 分隔符会在路由解析前归一化，
   因此不同操作系统上的路径和生成 route id 保持一致。
 
 生成构建产物前，evjs 会对配置路径应用同样的路由检查。重复 path、动态 URL shape、
-route id、空动态参数、保留动态参数、重复动态参数、包含空白、query string 或 hash
-的路径都会被拒绝。
+route id、空动态参数、保留动态参数、重复动态参数、多个 wildcard 段、包含空白、
+query string 或 hash 的路径都会被拒绝。
 
 生成的 route id 来自 URL path，并把分隔符和标点归一化为下划线。因此
 `admin/panel.tsx` 和 `admin_panel.tsx` 都会生成 `admin_panel`，不能同时存在。
@@ -211,6 +214,8 @@ route id、空动态参数、保留动态参数、重复动态参数、包含空
 | `src/pages/index.tsx` | `/` | 目录根路由。 |
 | `src/pages/docs/index.tsx` | `/docs` | 嵌套目录根路由。 |
 | `src/pages/users/$userId.tsx` | `/users/$userId` | 动态段；参数名必须是 JavaScript 标识符。 |
+| `src/pages/files/$...path.tsx` | `/files/*` | SPA catch-all route；运行时 params 会把匹配到的后缀暴露为 `_splat`。 |
+| `src/pages/legacyCamelCase.tsx` | `/legacyCamelCase` | 为既有稳定 URL 保留大小写的静态段。新路由仍建议使用小写。 |
 | `src/pages/users/settings.tsx` | `/users/settings` | 静态同级路由；排序早于 `users/$userId.tsx`。 |
 | `src/pages/(marketing)/about.tsx` | `/about` | Pathless route group；`(marketing)` 只组织文件，不增加 URL segment。 |
 | `src/pages/posts/layout.tsx` | `/posts` 的 layout route | SPA route layout，会包裹 `/posts` 下的后代路由。 |
@@ -221,7 +226,6 @@ route id、空动态参数、保留动态参数、重复动态参数、包含空
 | `src/pages/ClientCard.client.tsx` | 忽略 | 客户端专用模块可以就近放置，不会成为 URL 路由。 |
 | `src/pages/users.server.ts` | 忽略 | 服务端专用模块不是页面路由；被页面导入的服务端函数仍由服务端函数转换处理。 |
 | `src/pages/users/[id].tsx` | 拒绝 | 不支持 bracket 路由语法；使用 `$id.tsx`。 |
-| `src/pages/files/$...path.tsx` | 拒绝 | catch-all 段暂不属于约定。 |
 | `src/pages/users/$__proto__.tsx` | 拒绝 | 保留对象属性名不是安全的路由参数名。 |
 | `src/pages/docs/$_splat.tsx` | 拒绝 | `_splat` 是 wildcard route params 的保留名称。 |
 | `src/pages/layout.tsx` | 拒绝 | SPA 根布局使用 `src/layout/index.tsx`。Route layout 必须嵌套在某个路由段下。 |
@@ -292,8 +296,8 @@ export const GET = async () => Response.json({ ok: true });
 `src/apis` 下的文件路径就是 URL path，因此上面的例子映射到
 `/api/health`。根路由使用 `src/apis/index.ts`；动态段使用
 `$param` 文件名，并映射为 Hono params，例如 `:userId`。
-Route group 不增加路径段，并且这里复用页面路由的 segment 安全规则：bracket、
-catch-all、optional、大写静态段、重复 path 和重复 dynamic shape 路由都会被拒绝。
+Route group 不增加路径段。服务端文件路由会拒绝 bracket、catch-all、optional、
+大写静态段、重复 path 和重复 dynamic shape 路由。
 
 `src/apis` 下的文件只有导出 `GET` 或 `POST` 这类大写 HTTP method 后才会成为
 服务端路由。没有 route exports 的文件会被忽略，因此 `schema.ts`、`db.ts` 和

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/project-structure.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/project-structure.md
@@ -72,8 +72,8 @@ my-evjs-app/
 
 - 路由文件放在配置的 `routing.dir` 下，并使用 `.ts`、`.tsx`、`.js` 或
   `.jsx`。
-- 目录根路由使用 `index.*`；动态段使用 `$param`；SPA catch-all 段使用
-  `$...splat`；静态段保留 URL-safe 的大小写。
+- 目录根路由使用 `index.*`；动态段使用 `$param`；位于 URL path 末尾的 SPA
+  catch-all 段使用 `$...splat`；静态段保留 URL-safe 的大小写。
 - 支持 `(marketing)` 这类 route group 作为 pathless 组织目录，不会增加 URL
   segment。不完整的 group segment 会被拒绝。动态参数名必须是安全标识符；
   保留对象属性名和 `$_splat` 都会被拒绝。
@@ -95,8 +95,8 @@ my-evjs-app/
   URL 中，请使用 `marketing/about.tsx` 这样的真实 URL segment。
 - SPA 嵌套布局使用路由目录内的 layout 模块建模。如果某个外框不应该参与路由树，
   则作为普通组件由需要它的页面 import。
-- `$...splat` 只用于需要 catch-all route 的既有 SPA URL。新应用路由仍建议使用
-  明确的静态段和 `$param` 段，并保持简单小写命名。
+- `$...splat` 只作为 URL path 的最后一段，用于需要 catch-all route 的既有
+  SPA URL。新应用路由仍建议使用明确的静态段和 `$param` 段，并保持简单小写命名。
 - optional 或其他无法映射到文件约定的自定义 URL shape 使用显式 `pages` 配置。
 
 | 文件或目录 | 框架含义 | 用于 | 不用于 |
@@ -160,7 +160,7 @@ basename 的 colocated 模板替代全局 `index.html` 模板，例如
 1. **组件契约**：路由文件默认导出页面组件。渲染元信息放在页面组件旁边。语法错误和
    缺少默认导出的错误会在路由发现阶段、bundler 运行前报告。
 2. **文件名语法**：`index.tsx` 映射到当前目录根路径。动态段使用 `$param`。
-   SPA catch-all 段使用 `$...splat`，并映射为 `*`。`[id].tsx` 这类
+   位于 URL path 末尾的 SPA catch-all 段使用 `$...splat`，并映射为 `*`。`[id].tsx` 这类
    bracket 段和 `$slug?.tsx` 这类可选段会被拒绝。
 3. **URL segment 安全性**：动态参数名必须是 `$` 后面的 JavaScript 标识符。
    静态段必须使用 URL-safe 字母、数字、`.`、`_`、`-` 或 `~`；新应用路由仍建议使用
@@ -215,6 +215,7 @@ query string 或 hash 的路径都会被拒绝。
 | `src/pages/docs/index.tsx` | `/docs` | 嵌套目录根路由。 |
 | `src/pages/users/$userId.tsx` | `/users/$userId` | 动态段；参数名必须是 JavaScript 标识符。 |
 | `src/pages/files/$...path.tsx` | `/files/*` | SPA catch-all route；运行时 params 会把匹配到的后缀暴露为 `_splat`。 |
+| `src/pages/files/$...path/edit.tsx` | 拒绝 | Catch-all 段必须是 URL path 的最后一段。 |
 | `src/pages/legacyCamelCase.tsx` | `/legacyCamelCase` | 为既有稳定 URL 保留大小写的静态段。新路由仍建议使用小写。 |
 | `src/pages/users/settings.tsx` | `/users/settings` | 静态同级路由；排序早于 `users/$userId.tsx`。 |
 | `src/pages/(marketing)/about.tsx` | `/about` | Pathless route group；`(marketing)` 只组织文件，不增加 URL segment。 |

--- a/packages/client/src/framework/page/route-types.ts
+++ b/packages/client/src/framework/page/route-types.ts
@@ -52,7 +52,13 @@ type PageRouteModuleByPath<TPath extends string> =
     ? TModule
     : unknown;
 
-export type PageRouteParams<TPath extends string> = ResolveParams<TPath>;
+export type PageRouteParams<TPath extends string> = ResolveParams<TPath> &
+  PageRouteSplatParams<TPath>;
+
+type PageRouteSplatParams<TPath extends string> =
+  TPath extends `${string}*${string}`
+    ? { _splat: string }
+    : Record<never, never>;
 
 export type PageRouteSearch<TPath extends string> =
   PageRouteModuleByPath<TPath> extends {
@@ -103,7 +109,7 @@ type EvPageRoute<TId extends string, TFullPath extends string, TModule> = Route<
   TId,
   TId,
   EvModuleSearchValidator<TModule>,
-  ResolveParams<TFullPath>,
+  PageRouteParams<TFullPath>,
   EvEmpty,
   EvEmpty,
   EvEmpty,

--- a/packages/client/tests/page-routing-types.ts
+++ b/packages/client/tests/page-routing-types.ts
@@ -27,6 +27,7 @@ interface EvPageSearchModule {
 
 interface EvPageRoutes {
   index: { id: "index"; path: "/"; module: EvPageIndexModule };
+  docs_splat: { id: "docs_splat"; path: "/docs/*"; module: Empty };
   posts_postId: {
     id: "posts_postId";
     path: "/posts/$postId";
@@ -41,6 +42,7 @@ declare module "@evjs/client" {
 
 export function PageRouteLinkTypeTests() {
   useLinkProps({ to: "/" });
+  useLinkProps({ to: "/docs/*", params: { _splat: "guides/install" } });
   useLinkProps({ to: "/posts/$postId", params: { postId: "p1" } });
   useLinkProps({ to: "/search", search: { q: "router", page: 1 } });
   Link({ to: "/posts/$postId", params: { postId: "p1" }, children: "Post" });
@@ -49,6 +51,8 @@ export function PageRouteLinkTypeTests() {
 
   const postParams = usePageParams("/posts/$postId");
   postParams.postId.toUpperCase();
+  const docsParams = usePageParams("/docs/*");
+  docsParams._splat.toUpperCase();
 
   const search = usePageSearch("/search");
   search.page.toFixed();
@@ -66,17 +70,20 @@ export function PageRouteLinkTypeTests() {
   // @ts-expect-error page data hooks use the generated route path list.
   usePageParams("/missing");
 
-  // @ts-expect-error route params follow dynamic segment names.
-  postParams.id;
-
   // @ts-expect-error search objects follow validateSearch output.
   search.page.toUpperCase();
 
   // @ts-expect-error dynamic page routes require their params.
   useLinkProps({ to: "/posts/$postId" });
 
+  // @ts-expect-error wildcard page routes require the _splat param.
+  useLinkProps({ to: "/docs/*" });
+
   // @ts-expect-error dynamic params must match the page route segment name.
   useLinkProps({ to: "/posts/$postId", params: { id: "p1" } });
+
+  // @ts-expect-error wildcard page routes expose the _splat param.
+  useLinkProps({ to: "/docs/*", params: { path: "guides/install" } });
 
   // @ts-expect-error search objects follow validateSearch output.
   useLinkProps({ to: "/search", search: { q: "router", page: "one" } });

--- a/packages/ev/src/_internal/build/page-route-conventions.ts
+++ b/packages/ev/src/_internal/build/page-route-conventions.ts
@@ -24,12 +24,14 @@ export const PAGE_ROUTE_CONVENTION_RULES = [
   {
     id: "dynamic-segment",
     category: "route",
-    summary: "$param filenames for dynamic segments and $...splat catch-alls",
+    summary:
+      "$param filenames for dynamic segments and terminal $...splat catch-alls",
     valid: ["users/$userId.tsx", "files/$...splat.tsx"],
     invalid: [
       "users/[userId].tsx",
       "users/$123.tsx",
       "files/$...123.tsx",
+      "files/$...path/edit.tsx",
       "users/$__proto__.tsx",
       "docs/$_splat.tsx",
     ],
@@ -226,6 +228,7 @@ export interface InvalidPageRouteSegment {
     | "duplicate-catch-all"
     | "duplicate-dynamic"
     | "dynamic"
+    | "non-terminal-catch-all"
     | "reserved-catch-all"
     | "reserved-dynamic"
     | "static";
@@ -379,8 +382,15 @@ export function findInvalidRouteSegment(
     options.allowCasePreservingStatic === false
       ? LOWERCASE_STATIC_ROUTE_SEGMENT_PATTERN
       : CASE_PRESERVING_STATIC_ROUTE_SEGMENT_PATTERN;
+  let lastRouteSegmentIndex = -1;
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    if (!isPageRouteGroupSegment(segments[index])) {
+      lastRouteSegmentIndex = index;
+      break;
+    }
+  }
   let hasCatchAll = false;
-  for (const segment of segments) {
+  for (const [index, segment] of segments.entries()) {
     if (isPageRouteGroupSegment(segment)) continue;
 
     if (isCatchAllPageRouteSegment(segment)) {
@@ -393,6 +403,9 @@ export function findInvalidRouteSegment(
       const name = getCatchAllRouteParamName(segment);
       if (getPageRouteParamNameValidationError(name) === "reserved") {
         return { kind: "reserved-catch-all", segment };
+      }
+      if (index !== lastRouteSegmentIndex) {
+        return { kind: "non-terminal-catch-all", segment };
       }
       if (hasCatchAll) return { kind: "duplicate-catch-all", segment };
       hasCatchAll = true;
@@ -500,6 +513,9 @@ function formatInvalidRouteSegmentViolation(
   }
   if (invalid.kind === "duplicate-catch-all") {
     return `Catch-all page route segment "${invalid.segment}" repeats a wildcard route segment. Use at most one catch-all segment within one route path.`;
+  }
+  if (invalid.kind === "non-terminal-catch-all") {
+    return `Catch-all page route segment "${invalid.segment}" must be the final URL path segment. Move it to the end of the route path, or split the route into explicit files.`;
   }
   if (invalid.kind === "dynamic") {
     return `Dynamic page route segment "${invalid.segment}" must use a JavaScript identifier after "$", such as "$userId".`;

--- a/packages/ev/src/_internal/build/page-route-conventions.ts
+++ b/packages/ev/src/_internal/build/page-route-conventions.ts
@@ -24,12 +24,12 @@ export const PAGE_ROUTE_CONVENTION_RULES = [
   {
     id: "dynamic-segment",
     category: "route",
-    summary: "$param filenames for dynamic segments",
-    valid: ["users/$userId.tsx"],
+    summary: "$param filenames for dynamic segments and $...splat catch-alls",
+    valid: ["users/$userId.tsx", "files/$...splat.tsx"],
     invalid: [
       "users/[userId].tsx",
       "users/$123.tsx",
-      "files/$...path.tsx",
+      "files/$...123.tsx",
       "users/$__proto__.tsx",
       "docs/$_splat.tsx",
     ],
@@ -65,9 +65,9 @@ export const PAGE_ROUTE_CONVENTION_RULES = [
   {
     id: "static-segment",
     category: "route",
-    summary: "lowercase URL-safe static segments",
-    valid: ["about.tsx", "docs/api-v1.tsx"],
-    invalid: ["About.tsx", "contact us.tsx"],
+    summary: "case-preserving URL-safe static segments",
+    valid: ["about.tsx", "legacyCamelCase.tsx", "docs/API.tsx"],
+    invalid: ["contact us.tsx"],
   },
   {
     id: "private-module",
@@ -178,8 +178,11 @@ export const PAGE_ROUTE_UNSUPPORTED_ROOT_LAYOUT_FILES = [
 const PAGE_ROUTE_SOURCE_EXTENSION_SET = new Set<string>(
   PAGE_ROUTE_SOURCE_EXTENSIONS,
 );
-const STATIC_ROUTE_SEGMENT_PATTERN = /^[a-z0-9][a-z0-9._~-]*$/;
+const CASE_PRESERVING_STATIC_ROUTE_SEGMENT_PATTERN =
+  /^[A-Za-z0-9][A-Za-z0-9._~-]*$/;
+const LOWERCASE_STATIC_ROUTE_SEGMENT_PATTERN = /^[a-z0-9][a-z0-9._~-]*$/;
 const DYNAMIC_ROUTE_PARAM_PATTERN = /^\$[A-Za-z_][A-Za-z0-9_]*$/;
+const CATCH_ALL_ROUTE_PARAM_PATTERN = /^\$\.\.\.[A-Za-z_][A-Za-z0-9_]*$/;
 
 export interface PageRouteFileConvention {
   segments: string[];
@@ -218,8 +221,20 @@ export interface PageRouteConventionRule {
 }
 
 export interface InvalidPageRouteSegment {
-  kind: "duplicate-dynamic" | "dynamic" | "reserved-dynamic" | "static";
+  kind:
+    | "catch-all"
+    | "duplicate-catch-all"
+    | "duplicate-dynamic"
+    | "dynamic"
+    | "reserved-catch-all"
+    | "reserved-dynamic"
+    | "static";
   segment: string;
+}
+
+export interface PageRouteSegmentConventionOptions {
+  allowCasePreservingStatic?: boolean;
+  allowCatchAll?: boolean;
 }
 
 export type PageRouteSegmentConventionViolation =
@@ -343,20 +358,46 @@ export function findBracketRouteSegment(
 
 export function findUnsupportedDynamicRouteSegment(
   segments: string[],
+  options: PageRouteSegmentConventionOptions = {},
 ): string | undefined {
+  const allowCatchAll = options.allowCatchAll !== false;
   return segments.find(
     (segment) =>
       segment.startsWith("$") &&
-      (segment === "$" || segment.startsWith("$...") || segment.endsWith("?")),
+      (segment === "$" ||
+        (!allowCatchAll && isCatchAllPageRouteSegment(segment)) ||
+        segment.endsWith("?")),
   );
 }
 
 export function findInvalidRouteSegment(
   segments: string[],
+  options: PageRouteSegmentConventionOptions = {},
 ): InvalidPageRouteSegment | undefined {
   const dynamicNames = new Set<string>();
+  const staticSegmentPattern =
+    options.allowCasePreservingStatic === false
+      ? LOWERCASE_STATIC_ROUTE_SEGMENT_PATTERN
+      : CASE_PRESERVING_STATIC_ROUTE_SEGMENT_PATTERN;
+  let hasCatchAll = false;
   for (const segment of segments) {
     if (isPageRouteGroupSegment(segment)) continue;
+
+    if (isCatchAllPageRouteSegment(segment)) {
+      if (options.allowCatchAll === false) {
+        return { kind: "catch-all", segment };
+      }
+      if (!CATCH_ALL_ROUTE_PARAM_PATTERN.test(segment)) {
+        return { kind: "catch-all", segment };
+      }
+      const name = getCatchAllRouteParamName(segment);
+      if (getPageRouteParamNameValidationError(name) === "reserved") {
+        return { kind: "reserved-catch-all", segment };
+      }
+      if (hasCatchAll) return { kind: "duplicate-catch-all", segment };
+      hasCatchAll = true;
+      continue;
+    }
 
     if (segment.startsWith("$")) {
       if (!DYNAMIC_ROUTE_PARAM_PATTERN.test(segment)) {
@@ -371,7 +412,7 @@ export function findInvalidRouteSegment(
       continue;
     }
 
-    if (!STATIC_ROUTE_SEGMENT_PATTERN.test(segment)) {
+    if (!staticSegmentPattern.test(segment)) {
       return { kind: "static", segment };
     }
   }
@@ -381,6 +422,7 @@ export function findInvalidRouteSegment(
 
 export function findPageRouteSegmentConventionViolation(
   segments: string[],
+  options: PageRouteSegmentConventionOptions = {},
 ): PageRouteSegmentConventionViolation | undefined {
   const routeGroupSegment = findRouteGroupSegment(segments);
   if (routeGroupSegment) {
@@ -390,8 +432,10 @@ export function findPageRouteSegmentConventionViolation(
   const bracketSegment = findBracketRouteSegment(segments);
   if (bracketSegment) return { kind: "bracket", segment: bracketSegment };
 
-  const unsupportedDynamicSegment =
-    findUnsupportedDynamicRouteSegment(segments);
+  const unsupportedDynamicSegment = findUnsupportedDynamicRouteSegment(
+    segments,
+    options,
+  );
   if (unsupportedDynamicSegment) {
     return {
       kind: "unsupported-dynamic",
@@ -399,7 +443,7 @@ export function findPageRouteSegmentConventionViolation(
     };
   }
 
-  return findInvalidRouteSegment(segments);
+  return findInvalidRouteSegment(segments, options);
 }
 
 export function formatPageRouteSegmentConventionViolation(
@@ -448,6 +492,15 @@ function formatUnsupportedDynamicRouteSegmentViolation(
 function formatInvalidRouteSegmentViolation(
   invalid: InvalidPageRouteSegment,
 ): string {
+  if (invalid.kind === "catch-all") {
+    return `Catch-all page route segment "${invalid.segment}" must use a JavaScript identifier after "$...", such as "$...splat".`;
+  }
+  if (invalid.kind === "reserved-catch-all") {
+    return `Catch-all page route segment "${invalid.segment}" uses a reserved param name. Use a safe application-specific name such as "$...splat"; runtime wildcard params are exposed as "_splat".`;
+  }
+  if (invalid.kind === "duplicate-catch-all") {
+    return `Catch-all page route segment "${invalid.segment}" repeats a wildcard route segment. Use at most one catch-all segment within one route path.`;
+  }
   if (invalid.kind === "dynamic") {
     return `Dynamic page route segment "${invalid.segment}" must use a JavaScript identifier after "$", such as "$userId".`;
   }
@@ -458,13 +511,21 @@ function formatInvalidRouteSegmentViolation(
     return `Dynamic page route segment "${invalid.segment}" repeats a param name. Use unique dynamic param filenames within one route path.`;
   }
 
-  return `Static page route segment "${invalid.segment}" must use lowercase URL-safe characters: lowercase letters, numbers, ".", "_", "-", or "~". Rename the file to a lowercase URL-safe segment, or use explicit pages config for custom paths.`;
+  return `Static page route segment "${invalid.segment}" must use URL-safe characters: letters, numbers, ".", "_", "-", or "~". Rename the file to a URL-safe segment, or use explicit pages config for custom paths.`;
 }
 
 export function routePathFromSegments(segments: string[]): string {
-  const pathSegments = segments.filter(
-    (segment) => !isPageRouteGroupSegment(segment),
-  );
+  const pathSegments = segments
+    .filter((segment) => !isPageRouteGroupSegment(segment))
+    .map(routePathSegmentFromConventionSegment);
+  if (pathSegments.length === 0) return "/";
+  return `/${pathSegments.join("/")}`;
+}
+
+export function routeIdPathFromSegments(segments: string[]): string {
+  const pathSegments = segments
+    .filter((segment) => !isPageRouteGroupSegment(segment))
+    .map(routeIdSegmentFromConventionSegment);
   if (pathSegments.length === 0) return "/";
   return `/${pathSegments.join("/")}`;
 }
@@ -479,4 +540,22 @@ export function routePathShapeFromPath(routePath: string): PageRouteShape {
     key: shape,
     label: shape,
   };
+}
+
+export function isCatchAllPageRouteSegment(segment: string): boolean {
+  return segment.startsWith("$...");
+}
+
+function routePathSegmentFromConventionSegment(segment: string): string {
+  return isCatchAllPageRouteSegment(segment) ? "*" : segment;
+}
+
+function routeIdSegmentFromConventionSegment(segment: string): string {
+  return isCatchAllPageRouteSegment(segment)
+    ? `$${getCatchAllRouteParamName(segment)}`
+    : segment;
+}
+
+function getCatchAllRouteParamName(segment: string): string {
+  return segment.slice("$...".length);
 }

--- a/packages/ev/src/_internal/build/page-routes.ts
+++ b/packages/ev/src/_internal/build/page-routes.ts
@@ -12,6 +12,7 @@ import {
   PAGE_ROUTE_SOURCE_EXTENSION_LABEL,
   PAGE_ROUTE_UNSUPPORTED_ROOT_LAYOUT_FILES,
   parsePageRouteFile,
+  routeIdPathFromSegments,
   routePathFromSegments,
   routeShapeFromSegments,
 } from "./page-route-conventions.js";
@@ -83,6 +84,7 @@ export async function discoverPageRoutes(
   let hasRouteCandidate = false;
   const spaConventions =
     options.mode !== "mpa" && options.spaConventions !== false;
+  const allowCatchAll = options.mode !== "mpa";
 
   for (const file of files) {
     const sourceRel = toProjectPath(cwd, file);
@@ -93,6 +95,7 @@ export async function discoverPageRoutes(
     if (conventionFile) {
       const segmentViolation = findPageRouteSegmentConventionViolation(
         conventionFile.segments,
+        { allowCatchAll },
       );
       if (segmentViolation) {
         diagnostics.push({
@@ -145,6 +148,7 @@ export async function discoverPageRoutes(
 
       const segmentViolation = findPageRouteSegmentConventionViolation(
         layoutFile.segments,
+        { allowCatchAll },
       );
       if (segmentViolation) {
         diagnostics.push({
@@ -197,6 +201,7 @@ export async function discoverPageRoutes(
 
     const segmentViolation = findPageRouteSegmentConventionViolation(
       routeFile.segments,
+      { allowCatchAll },
     );
     if (segmentViolation) {
       diagnostics.push({
@@ -242,7 +247,9 @@ export async function discoverPageRoutes(
     }
     routeByShape.set(routeShape.key, { file: sourceRel, path: routePath });
 
-    const routeId = deriveRouteIdFromPath(routePath);
+    const routeId = deriveRouteIdFromPath(
+      routeIdPathFromSegments(routeFile.segments),
+    );
     const previousIdOwner = routeById.get(routeId);
     if (previousIdOwner) {
       diagnostics.push({

--- a/packages/ev/src/_internal/build/server-conventions.ts
+++ b/packages/ev/src/_internal/build/server-conventions.ts
@@ -177,6 +177,7 @@ async function discoverRouteMiddlewares(
 
     const segmentViolation = findPageRouteSegmentConventionViolation(
       convention.scopeSegments,
+      { allowCasePreservingStatic: false, allowCatchAll: false },
     );
     if (segmentViolation) {
       diagnostics.push({

--- a/packages/ev/src/_internal/build/server-routes.ts
+++ b/packages/ev/src/_internal/build/server-routes.ts
@@ -178,7 +178,10 @@ async function analyzeServerRouteFile(
     return { diagnostics };
   }
 
-  const segmentViolation = findPageRouteSegmentConventionViolation(segments);
+  const segmentViolation = findPageRouteSegmentConventionViolation(segments, {
+    allowCasePreservingStatic: false,
+    allowCatchAll: false,
+  });
   if (segmentViolation) {
     diagnostics.push({
       level: "error",

--- a/packages/ev/tests/build-tools-page-route-types.test.ts
+++ b/packages/ev/tests/build-tools-page-route-types.test.ts
@@ -202,6 +202,33 @@ describe("generatePageRouteTypes", () => {
     );
   });
 
+  it("generates route declarations for case-preserving and catch-all paths", () => {
+    const source = generatePageRouteTypes({
+      routes: [
+        {
+          id: "docs_splat",
+          path: "/docs/*",
+          module: "./src/pages/docs/$...splat.tsx",
+        },
+        {
+          id: "legacyCamelCase",
+          path: "/legacyCamelCase",
+          module: "./src/pages/legacyCamelCase.tsx",
+        },
+      ],
+    });
+
+    expect(source).toContain(
+      'import type * as EvPage_docs_splat from "./src/pages/docs/$...splat";',
+    );
+    expect(source).toContain(
+      'EvRoute_docs_splat: { id: "docs_splat"; path: "/docs/*"; module: typeof EvPage_docs_splat };',
+    );
+    expect(source).toContain(
+      'EvRoute_legacyCamelCase: { id: "legacyCamelCase"; path: "/legacyCamelCase"; module: typeof EvPage_legacyCamelCase };',
+    );
+  });
+
   it("escapes route ids that are not valid TypeScript identifiers", () => {
     const source = generatePageRouteTypes({
       routes: [

--- a/packages/ev/tests/build-tools-page-routes.test.ts
+++ b/packages/ev/tests/build-tools-page-routes.test.ts
@@ -17,6 +17,7 @@ import {
   PAGE_ROUTE_CONVENTION_SUMMARY,
   PAGE_ROUTE_SOURCE_EXTENSIONS,
   parsePageRouteFile,
+  routeIdPathFromSegments,
   routePathFromSegments,
   routePathShapeFromPath,
   routeShapeFromSegments,
@@ -94,10 +95,13 @@ describe("discoverPageRoutes", () => {
         expect.objectContaining({
           id: "dynamic-segment",
           category: "route",
-          valid: expect.arrayContaining(["users/$userId.tsx"]),
+          valid: expect.arrayContaining([
+            "users/$userId.tsx",
+            "files/$...splat.tsx",
+          ]),
           invalid: expect.arrayContaining([
             "users/[userId].tsx",
-            "files/$...path.tsx",
+            "files/$...123.tsx",
             "users/$__proto__.tsx",
             "docs/$_splat.tsx",
           ]),
@@ -206,7 +210,7 @@ describe("discoverPageRoutes", () => {
       ]),
     );
     expect(PAGE_ROUTE_CONVENTION_SUMMARY).toBe(
-      "Page route files use index files for directory roots, $param filenames for dynamic segments, one page file per URL path, one dynamic param name per URL shape, unique generated route ids, route groups for pathless organization, and lowercase URL-safe static segments; ignored colocated modules include _-prefixed private modules, dot-prefixed hidden modules, declaration files, test/spec modules, Storybook modules, client-only *.client.* modules, and server-only *.server.* modules; SPA root layout auto-discovery uses one layout/index.tsx module beside the route directory; nested SPA route layouts use layout source modules below a route; SPA error boundaries use error source modules scoped by directory; SPA not-found boundaries use not-found source modules scoped by directory; MPA page routes can use colocated HTML templates with the same basename",
+      "Page route files use index files for directory roots, $param filenames for dynamic segments and $...splat catch-alls, one page file per URL path, one dynamic param name per URL shape, unique generated route ids, route groups for pathless organization, and case-preserving URL-safe static segments; ignored colocated modules include _-prefixed private modules, dot-prefixed hidden modules, declaration files, test/spec modules, Storybook modules, client-only *.client.* modules, and server-only *.server.* modules; SPA root layout auto-discovery uses one layout/index.tsx module beside the route directory; nested SPA route layouts use layout source modules below a route; SPA error boundaries use error source modules scoped by directory; SPA not-found boundaries use not-found source modules scoped by directory; MPA page routes can use colocated HTML templates with the same basename",
     );
     expect(isPageRouteSourceModuleFile("index.tsx")).toBe(true);
     expect(isPageRouteSourceModuleFile("index.d.ts")).toBe(false);
@@ -223,6 +227,10 @@ describe("discoverPageRoutes", () => {
     expect(parsePageRouteFile("users/$userId.tsx")?.segments).toEqual([
       "users",
       "$userId",
+    ]);
+    expect(parsePageRouteFile("docs/$...splat.tsx")?.segments).toEqual([
+      "docs",
+      "$...splat",
     ]);
     expect(normalizePageRouteConventionPath("users\\$userId.tsx")).toBe(
       "users/$userId.tsx",
@@ -258,19 +266,22 @@ describe("discoverPageRoutes", () => {
 
     expect(routePathFromSegments([])).toBe("/");
     expect(routePathFromSegments(["users", "$userId"])).toBe("/users/$userId");
+    expect(routePathFromSegments(["docs", "$...splat"])).toBe("/docs/*");
     expect(routePathFromSegments(["(marketing)", "about"])).toBe("/about");
+    expect(routeIdPathFromSegments(["docs", "$...splat"])).toBe("/docs/$splat");
     expect(routeShapeFromSegments(["users", "$userId"])).toEqual({
       key: "/users/:param",
       label: "/users/:param",
+    });
+    expect(routeShapeFromSegments(["docs", "$...splat"])).toEqual({
+      key: "/docs/*",
+      label: "/docs/*",
     });
     expect(routePathShapeFromPath("/users/:userId")).toEqual({
       key: "/users/:param",
       label: "/users/:param",
     });
-    expect(findInvalidRouteSegment(["Users"])).toEqual({
-      kind: "static",
-      segment: "Users",
-    });
+    expect(findInvalidRouteSegment(["Users"])).toBeUndefined();
     expect(
       findPageRouteSegmentConventionViolation(["(marketing)", "about"]),
     ).toBeUndefined();
@@ -306,10 +317,7 @@ describe("discoverPageRoutes", () => {
     );
     expect(
       findPageRouteSegmentConventionViolation(["files", "$...path"]),
-    ).toEqual({
-      kind: "unsupported-dynamic",
-      segment: "$...path",
-    });
+    ).toBeUndefined();
     expect(
       formatPageRouteSegmentConventionViolation({
         kind: "unsupported-dynamic",
@@ -318,17 +326,64 @@ describe("discoverPageRoutes", () => {
     ).toBe(
       'Catch-all page route segments are not supported. Use explicit pages config for wildcard or custom URL shapes instead of "$...path".',
     );
-    expect(findPageRouteSegmentConventionViolation(["Users"])).toEqual({
+    expect(
+      findPageRouteSegmentConventionViolation(["files", "$...123"]),
+    ).toEqual({
+      kind: "catch-all",
+      segment: "$...123",
+    });
+    expect(
+      formatPageRouteSegmentConventionViolation({
+        kind: "catch-all",
+        segment: "$...123",
+      }),
+    ).toBe(
+      'Catch-all page route segment "$...123" must use a JavaScript identifier after "$...", such as "$...splat".',
+    );
+    expect(
+      findPageRouteSegmentConventionViolation(["files", "$..._splat"]),
+    ).toEqual({
+      kind: "reserved-catch-all",
+      segment: "$..._splat",
+    });
+    expect(
+      formatPageRouteSegmentConventionViolation({
+        kind: "reserved-catch-all",
+        segment: "$..._splat",
+      }),
+    ).toBe(
+      'Catch-all page route segment "$..._splat" uses a reserved param name. Use a safe application-specific name such as "$...splat"; runtime wildcard params are exposed as "_splat".',
+    );
+    expect(
+      findPageRouteSegmentConventionViolation([
+        "files",
+        "$...path",
+        "edit",
+        "$...rest",
+      ]),
+    ).toEqual({
+      kind: "duplicate-catch-all",
+      segment: "$...rest",
+    });
+    expect(
+      formatPageRouteSegmentConventionViolation({
+        kind: "duplicate-catch-all",
+        segment: "$...rest",
+      }),
+    ).toBe(
+      'Catch-all page route segment "$...rest" repeats a wildcard route segment. Use at most one catch-all segment within one route path.',
+    );
+    expect(findPageRouteSegmentConventionViolation(["contact us"])).toEqual({
       kind: "static",
-      segment: "Users",
+      segment: "contact us",
     });
     expect(
       formatPageRouteSegmentConventionViolation({
         kind: "static",
-        segment: "Users",
+        segment: "contact us",
       }),
     ).toBe(
-      'Static page route segment "Users" must use lowercase URL-safe characters: lowercase letters, numbers, ".", "_", "-", or "~". Rename the file to a lowercase URL-safe segment, or use explicit pages config for custom paths.',
+      'Static page route segment "contact us" must use URL-safe characters: letters, numbers, ".", "_", "-", or "~". Rename the file to a URL-safe segment, or use explicit pages config for custom paths.',
     );
     expect(findInvalidRouteSegment(["$__proto__"])).toEqual({
       kind: "reserved-dynamic",
@@ -397,6 +452,58 @@ describe("discoverPageRoutes", () => {
     expect(discovery.diagnostics).toEqual([]);
   });
 
+  it("discovers case-preserving and catch-all SPA page routes", async () => {
+    const cwd = await createFixture({
+      "src/layout/index.tsx": "export default function Root() { return null; }",
+      "src/pages/index.tsx": "export default function Home() { return null; }",
+      "src/pages/legacyCamelCase.tsx":
+        "export default function Legacy() { return null; }",
+      "src/pages/docs/layout.tsx":
+        "export default function DocsLayout() { return null; }",
+      "src/pages/docs/$...splat.tsx":
+        "export default function DocsCatchAll() { return null; }",
+      "src/pages/teams/$teamId/reports/$...path.tsx":
+        "export default function TeamReportsCatchAll() { return null; }",
+    });
+
+    const discovery = await discoverPageRoutes(cwd, {
+      dir: "./src/pages",
+      mode: "spa",
+    });
+
+    expect(discovery.rootModule).toBe("./src/layout/index.tsx");
+    expect(discovery.routes).toEqual([
+      {
+        id: "index",
+        path: "/",
+        module: "./src/pages/index.tsx",
+      },
+      {
+        id: "docs_layout",
+        path: "/docs",
+        module: "./src/pages/docs/layout.tsx",
+        kind: "layout",
+      },
+      {
+        id: "docs_splat",
+        path: "/docs/*",
+        module: "./src/pages/docs/$...splat.tsx",
+        parentId: "docs_layout",
+      },
+      {
+        id: "legacyCamelCase",
+        path: "/legacyCamelCase",
+        module: "./src/pages/legacyCamelCase.tsx",
+      },
+      {
+        id: "teams_teamId_reports_path",
+        path: "/teams/$teamId/reports/*",
+        module: "./src/pages/teams/$teamId/reports/$...path.tsx",
+      },
+    ]);
+    expect(discovery.diagnostics).toEqual([]);
+  });
+
   it("discovers colocated MPA HTML templates with the same basename", async () => {
     const cwd = await createFixture({
       "src/pages/index.tsx": "export default function Home() { return null; }",
@@ -441,6 +548,35 @@ describe("discoverPageRoutes", () => {
       },
     ]);
     expect(discovery.diagnostics).toEqual([]);
+  });
+
+  it("rejects catch-all page route segments in MPA mode", async () => {
+    const cwd = await createFixture({
+      "src/pages/index.tsx": "export default function Home() { return null; }",
+      "src/pages/docs/$...splat.tsx":
+        "export default function DocsCatchAll() { return null; }",
+    });
+
+    const discovery = await discoverPageRoutes(cwd, {
+      dir: "./src/pages",
+      mode: "mpa",
+    });
+
+    expect(discovery.routes).toEqual([
+      {
+        id: "index",
+        path: "/",
+        module: "./src/pages/index.tsx",
+      },
+    ]);
+    expect(discovery.diagnostics).toEqual([
+      {
+        level: "error",
+        file: "src/pages/docs/$...splat.tsx",
+        message:
+          'Catch-all page route segments are not supported. Use explicit pages config for wildcard or custom URL shapes instead of "$...splat".',
+      },
+    ]);
   });
 
   it("does not treat routing.html as an MPA file-route convention", async () => {
@@ -1115,8 +1251,12 @@ describe("discoverPageRoutes", () => {
       "src/pages/index.tsx": "export default function Home() { return null; }",
       "src/pages/files/$.tsx":
         "export default function EmptyDynamic() { return null; }",
-      "src/pages/files/$...path.tsx":
-        "export default function CatchAll() { return null; }",
+      "src/pages/files/$...123.tsx":
+        "export default function InvalidCatchAll() { return null; }",
+      "src/pages/files/$..._splat.tsx":
+        "export default function ReservedCatchAll() { return null; }",
+      "src/pages/files/$...path/archive/$...rest.tsx":
+        "export default function DuplicateCatchAll() { return null; }",
       "src/pages/users/$id?.tsx":
         "export default function OptionalUser() { return null; }",
     });
@@ -1133,9 +1273,21 @@ describe("discoverPageRoutes", () => {
     expect(discovery.diagnostics).toEqual([
       {
         level: "error",
-        file: "src/pages/files/$...path.tsx",
+        file: "src/pages/files/$...123.tsx",
         message:
-          'Catch-all page route segments are not supported. Use explicit pages config for wildcard or custom URL shapes instead of "$...path".',
+          'Catch-all page route segment "$...123" must use a JavaScript identifier after "$...", such as "$...splat".',
+      },
+      {
+        level: "error",
+        file: "src/pages/files/$..._splat.tsx",
+        message:
+          'Catch-all page route segment "$..._splat" uses a reserved param name. Use a safe application-specific name such as "$...splat"; runtime wildcard params are exposed as "_splat".',
+      },
+      {
+        level: "error",
+        file: "src/pages/files/$...path/archive/$...rest.tsx",
+        message:
+          'Catch-all page route segment "$...rest" repeats a wildcard route segment. Use at most one catch-all segment within one route path.',
       },
       {
         level: "error",
@@ -1152,12 +1304,14 @@ describe("discoverPageRoutes", () => {
     ]);
   });
 
-  it("rejects uppercase static route segments", async () => {
+  it("preserves uppercase static route segments", async () => {
     const cwd = await createFixture({
       "src/pages/index.tsx": "export default function Home() { return null; }",
       "src/pages/About.tsx": "export default function About() { return null; }",
       "src/pages/docs/API.tsx":
         "export default function ApiDocs() { return null; }",
+      "src/pages/legacyCamelCase.tsx":
+        "export default function Legacy() { return null; }",
       "src/pages/users/$userId.tsx":
         "export default function User() { return null; }",
     });
@@ -1171,25 +1325,27 @@ describe("discoverPageRoutes", () => {
         module: "./src/pages/index.tsx",
       },
       {
+        id: "About",
+        path: "/About",
+        module: "./src/pages/About.tsx",
+      },
+      {
+        id: "docs_API",
+        path: "/docs/API",
+        module: "./src/pages/docs/API.tsx",
+      },
+      {
+        id: "legacyCamelCase",
+        path: "/legacyCamelCase",
+        module: "./src/pages/legacyCamelCase.tsx",
+      },
+      {
         id: "users_userId",
         path: "/users/$userId",
         module: "./src/pages/users/$userId.tsx",
       },
     ]);
-    expect(discovery.diagnostics).toEqual([
-      {
-        level: "error",
-        file: "src/pages/About.tsx",
-        message:
-          'Static page route segment "About" must use lowercase URL-safe characters: lowercase letters, numbers, ".", "_", "-", or "~". Rename the file to a lowercase URL-safe segment, or use explicit pages config for custom paths.',
-      },
-      {
-        level: "error",
-        file: "src/pages/docs/API.tsx",
-        message:
-          'Static page route segment "API" must use lowercase URL-safe characters: lowercase letters, numbers, ".", "_", "-", or "~". Rename the file to a lowercase URL-safe segment, or use explicit pages config for custom paths.',
-      },
-    ]);
+    expect(discovery.diagnostics).toEqual([]);
   });
 
   it("rejects unsafe route segments and invalid dynamic parameter names", async () => {
@@ -1227,7 +1383,7 @@ describe("discoverPageRoutes", () => {
         level: "error",
         file: "src/pages/contact us.tsx",
         message:
-          'Static page route segment "contact us" must use lowercase URL-safe characters: lowercase letters, numbers, ".", "_", "-", or "~". Rename the file to a lowercase URL-safe segment, or use explicit pages config for custom paths.',
+          'Static page route segment "contact us" must use URL-safe characters: letters, numbers, ".", "_", "-", or "~". Rename the file to a URL-safe segment, or use explicit pages config for custom paths.',
       },
       {
         level: "error",
@@ -1251,7 +1407,7 @@ describe("discoverPageRoutes", () => {
         level: "error",
         file: "src/pages/settings?.tsx",
         message:
-          'Static page route segment "settings?" must use lowercase URL-safe characters: lowercase letters, numbers, ".", "_", "-", or "~". Rename the file to a lowercase URL-safe segment, or use explicit pages config for custom paths.',
+          'Static page route segment "settings?" must use URL-safe characters: letters, numbers, ".", "_", "-", or "~". Rename the file to a URL-safe segment, or use explicit pages config for custom paths.',
       },
       {
         level: "error",

--- a/packages/ev/tests/build-tools-page-routes.test.ts
+++ b/packages/ev/tests/build-tools-page-routes.test.ts
@@ -102,6 +102,7 @@ describe("discoverPageRoutes", () => {
           invalid: expect.arrayContaining([
             "users/[userId].tsx",
             "files/$...123.tsx",
+            "files/$...path/edit.tsx",
             "users/$__proto__.tsx",
             "docs/$_splat.tsx",
           ]),
@@ -210,7 +211,7 @@ describe("discoverPageRoutes", () => {
       ]),
     );
     expect(PAGE_ROUTE_CONVENTION_SUMMARY).toBe(
-      "Page route files use index files for directory roots, $param filenames for dynamic segments and $...splat catch-alls, one page file per URL path, one dynamic param name per URL shape, unique generated route ids, route groups for pathless organization, and case-preserving URL-safe static segments; ignored colocated modules include _-prefixed private modules, dot-prefixed hidden modules, declaration files, test/spec modules, Storybook modules, client-only *.client.* modules, and server-only *.server.* modules; SPA root layout auto-discovery uses one layout/index.tsx module beside the route directory; nested SPA route layouts use layout source modules below a route; SPA error boundaries use error source modules scoped by directory; SPA not-found boundaries use not-found source modules scoped by directory; MPA page routes can use colocated HTML templates with the same basename",
+      "Page route files use index files for directory roots, $param filenames for dynamic segments and terminal $...splat catch-alls, one page file per URL path, one dynamic param name per URL shape, unique generated route ids, route groups for pathless organization, and case-preserving URL-safe static segments; ignored colocated modules include _-prefixed private modules, dot-prefixed hidden modules, declaration files, test/spec modules, Storybook modules, client-only *.client.* modules, and server-only *.server.* modules; SPA root layout auto-discovery uses one layout/index.tsx module beside the route directory; nested SPA route layouts use layout source modules below a route; SPA error boundaries use error source modules scoped by directory; SPA not-found boundaries use not-found source modules scoped by directory; MPA page routes can use colocated HTML templates with the same basename",
     );
     expect(isPageRouteSourceModuleFile("index.tsx")).toBe(true);
     expect(isPageRouteSourceModuleFile("index.d.ts")).toBe(false);
@@ -355,16 +356,30 @@ describe("discoverPageRoutes", () => {
       'Catch-all page route segment "$..._splat" uses a reserved param name. Use a safe application-specific name such as "$...splat"; runtime wildcard params are exposed as "_splat".',
     );
     expect(
+      findPageRouteSegmentConventionViolation(["files", "$...path", "edit"]),
+    ).toEqual({
+      kind: "non-terminal-catch-all",
+      segment: "$...path",
+    });
+    expect(
       findPageRouteSegmentConventionViolation([
         "files",
         "$...path",
         "edit",
-        "$...rest",
+        "$...path",
       ]),
     ).toEqual({
-      kind: "duplicate-catch-all",
-      segment: "$...rest",
+      kind: "non-terminal-catch-all",
+      segment: "$...path",
     });
+    expect(
+      formatPageRouteSegmentConventionViolation({
+        kind: "non-terminal-catch-all",
+        segment: "$...path",
+      }),
+    ).toBe(
+      'Catch-all page route segment "$...path" must be the final URL path segment. Move it to the end of the route path, or split the route into explicit files.',
+    );
     expect(
       formatPageRouteSegmentConventionViolation({
         kind: "duplicate-catch-all",
@@ -664,6 +679,7 @@ describe("discoverPageRoutes", () => {
       expect(doc).toContain("src/pages/users/$userId.tsx");
       expect(doc).toContain("src/pages/users/[id].tsx");
       expect(doc).toContain("src/pages/files/$...path.tsx");
+      expect(doc).toContain("src/pages/files/$...path/edit.tsx");
       expect(doc).toContain("src/pages/users/$__proto__.tsx");
       expect(doc).toContain("src/pages/users.tsx");
       expect(doc).toContain("src/pages/users/index.tsx");
@@ -1255,8 +1271,8 @@ describe("discoverPageRoutes", () => {
         "export default function InvalidCatchAll() { return null; }",
       "src/pages/files/$..._splat.tsx":
         "export default function ReservedCatchAll() { return null; }",
-      "src/pages/files/$...path/archive/$...rest.tsx":
-        "export default function DuplicateCatchAll() { return null; }",
+      "src/pages/files/$...path/archive.tsx":
+        "export default function NonTerminalCatchAll() { return null; }",
       "src/pages/users/$id?.tsx":
         "export default function OptionalUser() { return null; }",
     });
@@ -1285,9 +1301,9 @@ describe("discoverPageRoutes", () => {
       },
       {
         level: "error",
-        file: "src/pages/files/$...path/archive/$...rest.tsx",
+        file: "src/pages/files/$...path/archive.tsx",
         message:
-          'Catch-all page route segment "$...rest" repeats a wildcard route segment. Use at most one catch-all segment within one route path.',
+          'Catch-all page route segment "$...path" must be the final URL path segment. Move it to the end of the route path, or split the route into explicit files.',
       },
       {
         level: "error",

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -605,12 +605,32 @@ describe("build", () => {
       "export default function Home() { return null; }",
       "utf-8",
     );
+    await fs.promises.mkdir(path.join(cwd, "src/pages/docs"), {
+      recursive: true,
+    });
+    await fs.promises.writeFile(
+      path.join(cwd, "src/pages/docs/$...splat.tsx"),
+      "export default function DocsCatchAll() { return null; }",
+      "utf-8",
+    );
+    await fs.promises.writeFile(
+      path.join(cwd, "src/pages/legacyCamelCase.tsx"),
+      "export default function Legacy() { return null; }",
+      "utf-8",
+    );
     const events: string[] = [];
     const bundler = createMockBundler(events, {
       onBuildPlan(plan) {
         const entry = plan.entries[0];
         events.push(`entry:${entry?.import}`);
         events.push(`metadata:${entry?.metadata?.type}`);
+        events.push(
+          `routes:${
+            entry?.metadata?.type === "pages-app"
+              ? entry.metadata.routes.map((route) => route.path).join(",")
+              : ""
+          }`,
+        );
       },
     });
 
@@ -627,13 +647,16 @@ describe("build", () => {
     expect(events).toEqual([
       "entry:evjs:pages-app",
       "metadata:pages-app",
+      "routes:/,/docs/*,/legacyCamelCase",
       "bundler.build",
       "bundler.entries:main",
     ]);
     expect(fs.existsSync(path.join(cwd, ".evjs"))).toBe(false);
     await expect(
       fs.promises.readFile(path.join(cwd, "src/route-types.d.ts"), "utf-8"),
-    ).resolves.toContain('import type * as EvPage_index from "./pages/index";');
+    ).resolves.toContain(
+      'import type * as EvPage_docs_splat from "./pages/docs/$...splat";',
+    );
   });
 
   it("does not rewrite unchanged generated SPA route types", async () => {
@@ -2179,7 +2202,7 @@ describe("build", () => {
     );
     expect((error as Error).message).toContain("src/pages/contact us.tsx");
     expect((error as Error).message).toContain(
-      'Static page route segment "contact us" must use lowercase URL-safe characters: lowercase letters, numbers, ".", "_", "-", or "~". Rename the file to a lowercase URL-safe segment, or use explicit pages config for custom paths.',
+      'Static page route segment "contact us" must use URL-safe characters: letters, numbers, ".", "_", "-", or "~". Rename the file to a URL-safe segment, or use explicit pages config for custom paths.',
     );
     expect((error as Error).message).toContain("src/pages/users/$123.tsx");
     expect((error as Error).message).toContain(

--- a/packages/shared/tests/manifest.test.ts
+++ b/packages/shared/tests/manifest.test.ts
@@ -3272,6 +3272,32 @@ describe("createPublicManifest", () => {
     });
   });
 
+  it("keeps wildcard SPA routes in public manifests", () => {
+    const output: BuildOutput = {
+      ...createMinimalBuildOutput(),
+      apps: {
+        default: {
+          assets: { js: ["main.js"], css: [] },
+          document: { fileName: "index.html" },
+        },
+      },
+      routes: [
+        {
+          id: "docs_splat",
+          path: "/docs/*",
+          appId: "default",
+        },
+      ],
+    };
+
+    expect(createPublicManifest(output)).toMatchObject({
+      routing: {
+        kind: "spa",
+        routes: [{ id: "docs_splat", path: "/docs/*" }],
+      },
+    });
+  });
+
   it("keeps route-owned SSG page documents in SPA manifests", () => {
     const output: BuildOutput = {
       ...createMinimalBuildOutput(),


### PR DESCRIPTION
## Summary
- Add SPA file-route support for case-preserving static segments and terminal `$...splat` catch-all routes.
- Keep MPA and server file-route conventions strict where wildcard and uppercase static segments are still unsupported.
- Closes #39.

## Changes
- Relax page static segment validation to preserve URL-safe casing.
- Map terminal SPA `$...name` file segments to `*` route paths while deriving stable route IDs from the catch-all name.
- Reject non-terminal `$...` file segments so catch-all syntax cannot silently behave as a one-segment wildcard.
- Expose wildcard page route params as `_splat` in generated route helper types.
- Add focused discovery, route type, command/build-plan, public manifest, and client type tests.
- Update English and Chinese docs for page route conventions, client routing, build checks, and project structure.

## Validation
- `npm --workspace @evjs/ev test -- tests/build-tools-page-routes.test.ts`
- `npm --workspace @evjs/shared test -- tests/manifest.test.ts`
- `npm --workspace @evjs/ev test -- tests/build-tools-page-route-types.test.ts`
- `npm --workspace @evjs/ev test -- tests/commands.test.ts`
- `npm --workspace @evjs/ev test -- tests/build-tools-server-routes.test.ts`
- `npx tsc -p tsconfig.test.json --noEmit`
- `npm run check-types`
- `npm run lint`
- `npm test`
- `git diff --check`

## Risk / rollout
- Low runtime risk: shared route matching already supported terminal wildcard paths and `_splat`; this change wires file-convention discovery and route typing into that existing runtime behavior.
- MPA and server route behavior remains guarded by explicit strict validation options.
- Non-terminal `$...` page file segments are rejected because they do not have catch-all runtime semantics.

## Reviewer notes
- Please review the convention parser changes in `packages/ev/src/_internal/build/page-route-conventions.ts` and the SPA discovery path in `packages/ev/src/_internal/build/page-routes.ts`.
- The type helper change in `packages/client/src/framework/page/route-types.ts` ensures wildcard routes expose `_splat` consistently with runtime params.
- The public manifest assertion in `packages/shared/tests/manifest.test.ts` covers wildcard SPA routes in browser-facing manifest output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SPA catch-all route support using `$...splat`, mapping to `*` with matched suffix available via `_splat`, and updated route typing/linking for wildcard params.
  * Static URL segments can now preserve URL-safe casing (where applicable), improving compatibility with existing URLs.
* **Bug Fixes**
  * Improved route validation and diagnostics for catch-all placement/duplicates and invalid wildcard patterns; MPA and server routes continue to reject catch-alls.
* **Documentation**
  * Refined build/checks and routing/file-convention docs (including localized content) with updated examples and clearer casing/catch-all rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->