### PR TITLE
fix(qiankun): expose Utoopack slave lifecycles globally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25775,6 +25775,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.19.15",
+        "domparser-rs": "^0.1.0",
         "typescript": "^6.0.2"
       }
     },

--- a/packages/plugin-qiankun/package.json
+++ b/packages/plugin-qiankun/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.15",
+    "domparser-rs": "^0.1.0",
     "typescript": "^6.0.2"
   },
   "keywords": [

--- a/packages/plugin-qiankun/src/index.ts
+++ b/packages/plugin-qiankun/src/index.ts
@@ -54,7 +54,7 @@ interface EntryWrapperState {
   entry: ResolvedAppEntry;
   qiankunRuntime: string;
   moduleRef?: ResolvedModuleRef;
-  libraryName?: string;
+  appName?: string;
 }
 
 interface GeneratedSourceHelpers {
@@ -66,6 +66,7 @@ const masterPluginName = "@evjs/plugin-qiankun:master";
 const slavePluginName = "@evjs/plugin-qiankun:slave";
 const qiankunRuntime = resolveQiankunRuntimeModulePath();
 const qiankunRuntimeImport = "@evjs/plugin-qiankun/runtime";
+const qiankunLifecycleProxyId = "__EVJS_QIANKUN_LIFECYCLE_PROXY__";
 
 export function evPluginQiankunMaster(
   options: QiankunMasterPluginOptions,
@@ -147,10 +148,10 @@ export function evPluginQiankunSlave(
       return {
         bundlerConfig(config, bundlerCtx) {
           assertSupportedBundler(bundlerCtx.bundlerName);
-          applySlaveLibrary(config, bundlerCtx.bundlerName, state);
+          applySlaveBundlerConfig(config, bundlerCtx.bundlerName, state);
         },
         transformHtml(doc) {
-          transformQiankunSlaveHtml(doc);
+          transformQiankunSlaveHtml(doc, state);
         },
       };
     },
@@ -267,7 +268,7 @@ async function createSlaveState(
     entry,
     qiankunRuntime,
     moduleRef: runtime,
-    libraryName: appName,
+    appName,
   };
 }
 
@@ -347,7 +348,7 @@ function createSlaveEntryWrapperSource(
     runtimeValue,
     "",
     "const qiankunSlave = createQiankunSlaveLifecycles({",
-    `  name: ${JSON.stringify(state.libraryName ?? "evjs-qiankun-slave")},`,
+    `  name: ${JSON.stringify(state.appName ?? "evjs-qiankun-slave")},`,
     `  mount: ${JSON.stringify(state.entry.mount)},`,
     "  runtime: slaveRuntime,",
     `  loadEntry: () => import(${JSON.stringify(originalEntry)}),`,
@@ -357,6 +358,11 @@ function createSlaveEntryWrapperSource(
     "export const mount = qiankunSlave.mount;",
     "export const unmount = qiankunSlave.unmount;",
     "export const update = qiankunSlave.update;",
+    "",
+    "const qiankunLifecycles = { bootstrap, mount, unmount, update };",
+    'if (typeof window !== "undefined") {',
+    `  (window as unknown as Record<string, unknown>)[${JSON.stringify(state.appName ?? "evjs-qiankun-slave")}] = qiankunLifecycles;`,
+    "}",
     "",
     "if (!qiankunSlave.isPoweredByQiankun()) {",
     "  void qiankunSlave.standalone();",
@@ -394,7 +400,7 @@ function assertSupportedBundler(bundlerName: string): void {
   );
 }
 
-function applySlaveLibrary(
+function applySlaveBundlerConfig(
   config: unknown,
   bundlerName: string,
   state: EntryWrapperState | undefined,
@@ -406,10 +412,6 @@ function applySlaveLibrary(
   }
   if (bundlerName === "webpack") {
     applyWebpackSlaveLibraryToConfig(config, state);
-    return;
-  }
-  if (bundlerName === "utoopack") {
-    applyUtoopackSlaveLibraryToConfig(config, state);
   }
 }
 
@@ -425,19 +427,11 @@ function applyWebpackSlaveLibraryToConfig(
   }
 }
 
-function applyUtoopackSlaveLibraryToConfig(
-  config: unknown,
-  state: EntryWrapperState,
-): void {
-  if (!isRecord(config)) return;
-  applyUtoopackSlaveLibrary(config, state);
-}
-
 function applyWebpackSlaveLibrary(
   config: Record<string, unknown>,
   state: EntryWrapperState,
 ): void {
-  const libraryName = state.libraryName ?? "evjs-qiankun-slave";
+  const libraryName = state.appName ?? "evjs-qiankun-slave";
   const library = { name: libraryName, type: "umd" };
   const entry = config.entry;
   if (!isRecord(entry)) {
@@ -455,20 +449,6 @@ function applyWebpackSlaveLibrary(
     }
     if (typeof value === "string") {
       entry[name] = { import: value, library };
-    }
-  }
-}
-
-function applyUtoopackSlaveLibrary(
-  config: Record<string, unknown>,
-  state: EntryWrapperState,
-): void {
-  const entries = config.entry;
-  if (!Array.isArray(entries)) return;
-
-  for (const entry of entries) {
-    if (isRecord(entry)) {
-      entry.library = { name: state.libraryName ?? "evjs-qiankun-slave" };
     }
   }
 }
@@ -518,7 +498,10 @@ async function assertFileExists(
   }
 }
 
-function transformQiankunSlaveHtml(doc: HtmlDocument): void {
+function transformQiankunSlaveHtml(
+  doc: HtmlDocument,
+  state: EntryWrapperState | undefined,
+): void {
   for (const link of doc.getElementsByTagName("link")) {
     if (link.getAttribute("rel") === "stylesheet") {
       rewriteRootRelativeAttribute(link, "href");
@@ -532,9 +515,60 @@ function transformQiankunSlaveHtml(doc: HtmlDocument): void {
     rewriteRootRelativeAttribute(script, "src");
   }
 
-  if (!scripts.some((script) => script.hasAttribute("entry"))) {
-    scripts.at(-1)?.setAttribute("entry", "");
-  }
+  const entryScript =
+    scripts.find((script) => script.hasAttribute("entry")) ?? scripts.at(-1);
+  if (!entryScript) return;
+
+  entryScript.setAttribute("entry", "");
+  if (doc.getElementById(qiankunLifecycleProxyId)) return;
+
+  const proxyScript = doc.createElement("script");
+  proxyScript.id = qiankunLifecycleProxyId;
+  proxyScript.textContent = createQiankunLifecycleProxyScript(
+    state?.appName ?? "evjs-qiankun-slave",
+  );
+  entryScript.before(proxyScript);
+}
+
+function createQiankunLifecycleProxyScript(appName: string): string {
+  return `(function() {
+  var appName = ${JSON.stringify(appName)};
+  var lifecycleNames = ["bootstrap", "mount", "unmount", "update"];
+  var global = window;
+  var existed = global[appName];
+  if (existed && typeof existed.bootstrap === "function" && typeof existed.mount === "function" && typeof existed.unmount === "function") return;
+  var resolveReady;
+  var ready = new Promise(function(resolve) { resolveReady = resolve; });
+  var proxy = {};
+  lifecycleNames.forEach(function(name) {
+    proxy[name] = function() {
+      var context = this;
+      var args = arguments;
+      return ready.then(function(lifecycles) {
+        var lifecycle = lifecycles && lifecycles[name];
+        if (typeof lifecycle !== "function") {
+          if (name === "update") return undefined;
+          throw new Error("[evjs:plugin-qiankun] lifecycle " + name + " is not available for " + appName + ".");
+        }
+        return lifecycle.apply(context, args);
+      });
+    };
+  });
+  Object.defineProperty(global, appName, {
+    configurable: true,
+    enumerable: true,
+    get: function() { return proxy; },
+    set: function(lifecycles) {
+      Object.defineProperty(global, appName, {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: lifecycles
+      });
+      resolveReady(lifecycles);
+    }
+  });
+})();`;
 }
 
 function rewriteRootRelativeAttribute(

--- a/packages/plugin-qiankun/tests/plugin.test.ts
+++ b/packages/plugin-qiankun/tests/plugin.test.ts
@@ -14,6 +14,7 @@ import type {
   GeneratedModuleRef,
   PluginContext,
 } from "@evjs/ev/plugin";
+import { DOMParser } from "domparser-rs";
 import { describe, expect, it } from "vitest";
 import { evPluginQiankunMaster, evPluginQiankunSlave } from "../src/index.js";
 
@@ -81,7 +82,7 @@ describe("@evjs/plugin-qiankun plugin", () => {
     });
   });
 
-  it("contributes a slave replacement wrapper and keeps library output in bundler config", async () => {
+  it("contributes a slave replacement wrapper without library output for utoopack", async () => {
     const cwd = await createProject({
       "package.json": JSON.stringify({ name: "console" }),
       "src/main.tsx": "console.log('entry');",
@@ -125,6 +126,9 @@ describe("@evjs/plugin-qiankun plugin", () => {
       )})`,
     );
     expect(source).not.toContain(toImportPath(cwd));
+    expect(source).toContain(
+      '(window as unknown as Record<string, unknown>)["console"] = qiankunLifecycles',
+    );
 
     const hooks = await plugin.setup?.(createPluginContext(cwd, [], {}));
     const bundlerConfig: Record<string, unknown> = {
@@ -135,12 +139,62 @@ describe("@evjs/plugin-qiankun plugin", () => {
       createBundlerContext(cwd, "utoopack"),
     );
     expect(bundlerConfig.entry).toEqual([
-      {
-        name: "main",
-        import: "./.ev/entries/main.ts",
-        library: { name: "console" },
-      },
+      { name: "main", import: "./.ev/entries/main.ts" },
     ]);
+  });
+
+  it("keeps UMD library output for webpack slave builds", async () => {
+    const cwd = await createProject({
+      "package.json": JSON.stringify({ name: "console" }),
+      "src/main.tsx": "console.log('entry');",
+    });
+    const plugin = evPluginQiankunSlave();
+    const captured = createContributionCapture(cwd, {
+      app: { entry: "./src/main.tsx" },
+    });
+    await plugin.contributions?.(captured.ctx);
+
+    const hooks = await plugin.setup?.(createPluginContext(cwd, [], {}));
+    const bundlerConfig: Record<string, unknown> = {
+      entry: { main: "./.ev/entries/main.ts" },
+    };
+    await hooks?.bundlerConfig?.(
+      bundlerConfig as never,
+      createBundlerContext(cwd, "webpack"),
+    );
+
+    expect(bundlerConfig.entry).toEqual({
+      main: {
+        import: "./.ev/entries/main.ts",
+        library: { name: "console", type: "umd" },
+      },
+    });
+  });
+
+  it("injects an utoopack lifecycle proxy before the qiankun entry script", async () => {
+    const cwd = await createProject({
+      "package.json": JSON.stringify({ name: "console" }),
+      "src/main.tsx": "console.log('entry');",
+    });
+    const plugin = evPluginQiankunSlave();
+    const captured = createContributionCapture(cwd, {
+      app: { entry: "./src/main.tsx" },
+    });
+    await plugin.contributions?.(captured.ctx);
+    const hooks = await plugin.setup?.(createPluginContext(cwd, [], {}));
+    const doc = new DOMParser().parseFromString(
+      '<!doctype html><html><head></head><body><script src="/main.js"></script></body></html>',
+      "text/html",
+    );
+
+    await hooks?.transformHtml?.(doc as never, {} as never);
+
+    const scripts = doc.querySelectorAll("script");
+    expect(scripts).toHaveLength(2);
+    expect(scripts[0]?.id).toBe("__EVJS_QIANKUN_LIFECYCLE_PROXY__");
+    expect(scripts[0]?.textContent).toContain('var appName = "console"');
+    expect(scripts[1]?.getAttribute("src")).toBe("main.js");
+    expect(scripts[1]?.hasAttribute("entry")).toBe(true);
   });
 
   it("generates an original pages app module for slave SPA file routing", async () => {


### PR DESCRIPTION
## Summary
- Stop compiling Utoopack qiankun slave entries as library bundles.
- Expose slave lifecycles through `window[appName]`, matching Umi's Utoopack integration.
- Add an inline lifecycle proxy before the HTML entry script to handle early qiankun lifecycle reads.

## Changes
- Keep UMD library configuration only for webpack slave builds.
- Publish `bootstrap`, `mount`, `unmount`, and `update` from the generated client wrapper to the application global.
- Inject an idempotent Promise-backed lifecycle proxy before the marked entry script.
- Add focused coverage for Utoopack config, webpack compatibility, and HTML script ordering.

## Validation
- `npx turbo run test check-types build --filter=@evjs/plugin-qiankun`
- `npm run lint`
- `npm run check-types`
- `npm test`
- `git diff --check`
- Built the Tern + UBOA reproduction app with server functions; verified client output, `dist/server/index.*.js`, server manifest, Tern/UBOA artifacts, and proxy-before-entry ordering.

## Risk / rollout
- Utoopack qiankun slave output changes from a library entry to a normal app entry. Lifecycles remain available through the same application global expected by qiankun.
- Webpack behavior remains UMD-based and is covered separately.
- No config migration is required.

## Reviewer notes
- Please focus on the lifecycle proxy handshake and the separation between Utoopack global exposure and webpack UMD output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Qiankun application integration by exposing lifecycle methods using the configured application name.
  - Added support for lifecycle calls made before the application is fully initialized, ensuring they are queued and processed afterward.

- **Bug Fixes**
  - Improved consistency across supported build environments.
  - Enhanced HTML transformation to preserve the application entry script while adding the required lifecycle support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->