### PR TITLE
docs(changelog): prepare v0.2.15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ---
 
+## [0.2.15] — 2026-07-21
+
+### ✨ Improvements
+
+- **Plugin CLI flags** — Exposed extra `ev dev`, `ev build`, and `ev prepare` command-line flags through plugin contexts, with support for boolean, string, dashed, and repeated flag values.
+
+---
+
 ## [0.2.14] — 2026-07-20
 
 ### 🐛 Bug Fixes


### PR DESCRIPTION
## Summary
- add the v0.2.15 changelog entry for plugin CLI flag support
- prepare the latest main commit for release

## Validation
- npm run lint
- npm run check-types
- git diff --check

## Risk / rollout
- Low risk: documentation-only release metadata change.

## Reviewer notes
- Verify the v0.2.15 summary matches the CLI flag behavior introduced in #46.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Plugin contexts now expose command-line flags for `ev dev`, `ev build`, and `ev prepare`.
  - Supports boolean, string, dashed, and repeated flag values.

- **Documentation**
  - Added release notes for version 0.2.15, including details about the newly available CLI flag support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->