### PR TITLE
fix(router): preserve raw search parameter strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+### ⚠️ Breaking Changes
+
+- **Raw page search params** — evjs-managed SPA, MPA, SSR, and RSC page search params now use `Record<string, string>` without implicit number, boolean, or JSON coercion. Repeated query keys keep the last value; applications should convert values explicitly in `validateSearch`.
+
 ### ✨ Improvements
 
 - **Concurrent dev sessions** — Added per-project dev session locking and cross-process client/server port coordination so duplicate starts fail clearly while different apps select predictable available port pairs.

--- a/docs/docs/client-routes.md
+++ b/docs/docs/client-routes.md
@@ -179,7 +179,7 @@ import {
   usePageSearch,
 } from "@evjs/ev/route";
 
-export const validateSearch = (search: Record<string, unknown>) => ({
+export const validateSearch = (search: Record<string, string>) => ({
   tab: typeof search.tab === "string" ? search.tab : "overview",
 });
 
@@ -201,6 +201,11 @@ page logic, such as `loader`, `beforeLoad`, `validateSearch`,
 those exports to the evjs-managed route. In MPA mode these lifecycle hooks
 are ignored; use normal component/data logic in the page.
 
+Search params use a raw `Record<string, string>` contract in every page mode.
+Numeric, boolean-like, and JSON-shaped values remain strings; repeated query
+keys keep the last value. Convert values explicitly in `validateSearch` when a
+page needs another type, and pass strings when navigating without a validator.
+
 SPA mode also recognizes dedicated route convention modules:
 
 - `error.*` and `not-found.*` modules default-export fallback components for
@@ -211,7 +216,7 @@ SPA mode also recognizes dedicated route convention modules:
 // src/pages/search.tsx
 import { usePageSearch } from "@evjs/ev/route";
 
-export const validateSearch = (search: Record<string, unknown>) => ({
+export const validateSearch = (search: Record<string, string>) => ({
   q: typeof search.q === "string" ? search.q : "",
 });
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/client-routes.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/client-routes.md
@@ -159,6 +159,10 @@ SPA 模式下，页面模块可以导出与页面逻辑相关的页面生命周�
 和 `notFoundComponent`。evjs 会把这些导出挂到 evjs 管理的 route 上。MPA 模式不处理
 这些生命周期，页面按普通 React 组件和数据逻辑编写。
 
+所有页面模式的 search 参数都使用原始 `Record<string, string>` 契约。数字、boolean
+和 JSON 形态的值都保持字符串；重复 query key 取最后一个值。页面需要其他类型时，
+应在 `validateSearch` 中显式转换；没有 validator 时，导航也应传入字符串。
+
 SPA 模式还会识别专用 route convention 模块：
 
 - `error.*` 和 `not-found.*` 模块默认导出对应路由目录作用域及后代路由的 fallback
@@ -169,7 +173,7 @@ SPA 模式还会识别专用 route convention 模块：
 // src/pages/search.tsx
 import { usePageSearch } from "@evjs/ev/route";
 
-export const validateSearch = (search: Record<string, unknown>) => ({
+export const validateSearch = (search: Record<string, string>) => ({
   q: typeof search.q === "string" ? search.q : "",
 });
 

--- a/e2e/cases/scaffold.ts
+++ b/e2e/cases/scaffold.ts
@@ -160,6 +160,7 @@ test.describe("Scaffolding CLI E2E", () => {
       let closed = false;
       let webReady = false;
       let apiReady = false;
+      let stdout = "";
       const settle = (fn: () => void) => {
         if (!settled) {
           settled = true;
@@ -190,10 +191,11 @@ test.describe("Scaffolding CLI E2E", () => {
       devProcess.stdout?.on("data", (data) => {
         const text = data.toString();
         process.stdout.write(data);
-        if (text.includes(`http://localhost:${devPort}`)) {
+        stdout += text;
+        if (stdout.includes("App listening at:")) {
           webReady = true;
         }
-        if (text.includes("API server ready")) {
+        if (stdout.includes("API server listening at:")) {
           apiReady = true;
         }
         maybeResolveReady();

--- a/examples/basic/src/pages/search.tsx
+++ b/examples/basic/src/pages/search.tsx
@@ -11,7 +11,7 @@ const cardStyle = {
 
 const linkStyle = { color: "#2563eb", textDecoration: "none" };
 
-export function validateSearch(search: Record<string, unknown>) {
+export function validateSearch(search: Record<string, string>) {
   return {
     tab:
       search.tab === "favorites" || search.tab === "recent"

--- a/examples/complex-routing/src/pages/search.tsx
+++ b/examples/complex-routing/src/pages/search.tsx
@@ -12,9 +12,9 @@ const styles = {
   },
 };
 
-export function validateSearch(search: Record<string, unknown>) {
+export function validateSearch(search: Record<string, string>) {
   return {
-    q: (search.q as string) || "",
+    q: search.q || "",
   };
 }
 

--- a/packages/client/src/framework/page/page-context.ts
+++ b/packages/client/src/framework/page/page-context.ts
@@ -1,3 +1,4 @@
+import type { PageSearchParams } from "@evjs/shared";
 import {
   createContext,
   createElement,
@@ -45,7 +46,7 @@ export function usePageContext<const TPath extends PageRoutePath>(
 >;
 export function usePageContext<
   TParams extends Record<string, string> = Record<string, string>,
-  TSearch extends Record<string, unknown> = Record<string, unknown>,
+  TSearch extends Record<string, unknown> = PageSearchParams,
   TLoaderData = unknown,
 >(): PageProps<TParams, TSearch, TLoaderData>;
 export function usePageContext(_path?: string): PageProps {
@@ -72,7 +73,7 @@ export function usePageSearch<const TPath extends PageRoutePath>(
   path: TPath,
 ): PageRouteSearch<TPath>;
 export function usePageSearch<
-  TSearch extends Record<string, unknown> = Record<string, unknown>,
+  TSearch extends Record<string, unknown> = PageSearchParams,
 >(): TSearch;
 export function usePageSearch(_path?: string): Record<string, unknown> {
   return usePageContext().search;

--- a/packages/client/src/framework/page/route-types.ts
+++ b/packages/client/src/framework/page/route-types.ts
@@ -1,3 +1,4 @@
+import type { PageSearchParams } from "@evjs/shared";
 import type {
   createRouter,
   ResolveParams,
@@ -68,8 +69,8 @@ export type PageRouteSearch<TPath extends string> =
   }
     ? TSearch extends Record<string, unknown>
       ? TSearch
-      : Record<string, unknown>
-    : Record<string, unknown>;
+      : PageSearchParams
+    : PageSearchParams;
 
 export type PageRouteLoaderData<TPath extends string> =
   PageRouteModuleByPath<TPath> extends {

--- a/packages/client/src/framework/page/rsc-page-context.ts
+++ b/packages/client/src/framework/page/rsc-page-context.ts
@@ -1,7 +1,11 @@
 /// <reference types="node" />
 
 import { AsyncLocalStorage } from "node:async_hooks";
-import { matchPageRouteParams, parsePageSearch } from "@evjs/shared";
+import {
+  matchPageRouteParams,
+  type PageSearchParams,
+  parsePageSearch,
+} from "@evjs/shared";
 import { type ComponentType, createElement } from "react";
 import { renderToReadableStream } from "react-server-dom-webpack/server.node";
 import type { PageProps } from "./page-context.js";
@@ -94,7 +98,7 @@ export function usePageContext<const TPath extends PageRoutePath>(
 >;
 export function usePageContext<
   TParams extends Record<string, string> = Record<string, string>,
-  TSearch extends Record<string, unknown> = Record<string, unknown>,
+  TSearch extends Record<string, unknown> = PageSearchParams,
   TLoaderData = unknown,
 >(): PageProps<TParams, TSearch, TLoaderData>;
 export function usePageContext(_path?: string): PageProps {
@@ -121,7 +125,7 @@ export function usePageSearch<const TPath extends PageRoutePath>(
   path: TPath,
 ): PageRouteSearch<TPath>;
 export function usePageSearch<
-  TSearch extends Record<string, unknown> = Record<string, unknown>,
+  TSearch extends Record<string, unknown> = PageSearchParams,
 >(): TSearch;
 export function usePageSearch(_path?: string): Record<string, unknown> {
   return usePageContext().search;

--- a/packages/client/src/standalone/app.tsx
+++ b/packages/client/src/standalone/app.tsx
@@ -1,3 +1,4 @@
+import { parsePageSearch } from "@evjs/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type {
   AnyRoute,
@@ -5,10 +6,16 @@ import type {
   RouterHistory,
   TrailingSlashOption,
 } from "@tanstack/react-router";
-import { createRouter, RouterProvider } from "@tanstack/react-router";
+import {
+  createRouter,
+  RouterProvider,
+  stringifySearchWith,
+} from "@tanstack/react-router";
 import { createRoot } from "react-dom/client";
 import { formatErrorDetail } from "../shared/validation.js";
 import type { AppRouteContext } from "./context.js";
+
+const stringifyRawSearch = stringifySearchWith(String);
 
 /**
  * Router options available to standalone CSR applications.
@@ -131,6 +138,8 @@ export function createApp<
     basepath: routerOptions?.basepath ?? basepath,
     history: routerOptions?.history ?? history,
     defaultPreload: routerOptions?.defaultPreload ?? "intent",
+    parseSearch: routerOptions?.parseSearch ?? parsePageSearch,
+    stringifySearch: routerOptions?.stringifySearch ?? stringifyRawSearch,
     context: { queryClient } as AppRouteContext,
   });
 

--- a/packages/client/tests/page-route.test.ts
+++ b/packages/client/tests/page-route.test.ts
@@ -68,6 +68,50 @@ describe("createPagesApp", () => {
     expect(app.queryClient).toBeDefined();
   });
 
+  it("keeps generated SPA search params as raw strings", () => {
+    function Home() {
+      return null;
+    }
+
+    const spaceId = "2026071515292425600064506";
+    const basepath = "/ai-center/linkque";
+    const initialUrl = `${basepath}/home?spaceId=${spaceId}&enabled=true&config=%7B%22a%22%3A1%7D`;
+    const history = client.createMemoryHistory({
+      initialEntries: [initialUrl],
+    });
+    const { app } = createPagesApp({
+      routes: [{ path: "/home", module: { default: Home } }],
+    });
+    const router = app.router as {
+      latestLocation: {
+        pathname: string;
+        search: Record<string, unknown>;
+        searchStr: string;
+      };
+      options: Record<string, unknown>;
+      routeTree: unknown;
+      update(options: Record<string, unknown>): void;
+    };
+
+    router.update({
+      ...router.options,
+      routeTree: router.routeTree,
+      basepath,
+      history,
+    });
+
+    expect(router.latestLocation.search).toEqual({
+      spaceId,
+      enabled: "true",
+      config: '{"a":1}',
+    });
+    expect(router.latestLocation.searchStr).toBe(
+      `?spaceId=${spaceId}&enabled=true&config=%7B%22a%22%3A1%7D`,
+    );
+    expect(router.latestLocation.pathname).toBe("/home");
+    expect(history.location.href).toBe(initialUrl);
+  });
+
   it("matches wildcard page routes from generated public route paths", () => {
     function DocsFallback() {
       return null;

--- a/packages/client/tests/page-routing-types.ts
+++ b/packages/client/tests/page-routing-types.ts
@@ -19,7 +19,7 @@ interface EvPagePostModule {
 }
 
 interface EvPageSearchModule {
-  validateSearch(search: Record<string, unknown>): {
+  validateSearch(search: Record<string, string>): {
     q: string;
     page: number;
   };

--- a/packages/client/tests/react-runtime.test.ts
+++ b/packages/client/tests/react-runtime.test.ts
@@ -515,7 +515,7 @@ describe("createReactPageModule", () => {
     };
     const pageProps = {
       params: { postId: "42" },
-      search: { tab: "comments", tag: ["a", "b"] },
+      search: { tab: "comments", tag: "b" },
       loaderData: undefined,
     };
 

--- a/packages/ev/src/route/context.ts
+++ b/packages/ev/src/route/context.ts
@@ -4,6 +4,7 @@ import {
   usePageParams as useClientPageParams,
   usePageSearch as useClientPageSearch,
 } from "@evjs/client";
+import type { PageSearchParams } from "@evjs/shared";
 import type {
   PageRouteLoaderData,
   PageRouteParams,
@@ -13,7 +14,7 @@ import type {
 
 export interface PageProps<
   TParams extends Record<string, string> = Record<string, string>,
-  TSearch extends Record<string, unknown> = Record<string, unknown>,
+  TSearch extends Record<string, unknown> = PageSearchParams,
   TLoaderData = unknown,
 > {
   params: TParams;
@@ -30,7 +31,7 @@ export function usePageContext<const TPath extends PageRoutePath>(
 >;
 export function usePageContext<
   TParams extends Record<string, string> = Record<string, string>,
-  TSearch extends Record<string, unknown> = Record<string, unknown>,
+  TSearch extends Record<string, unknown> = PageSearchParams,
   TLoaderData = unknown,
 >(): PageProps<TParams, TSearch, TLoaderData>;
 export function usePageContext(_path?: string): PageProps {
@@ -51,7 +52,7 @@ export function usePageSearch<const TPath extends PageRoutePath>(
   path: TPath,
 ): PageRouteSearch<TPath>;
 export function usePageSearch<
-  TSearch extends Record<string, unknown> = Record<string, unknown>,
+  TSearch extends Record<string, unknown> = PageSearchParams,
 >(): TSearch;
 export function usePageSearch(_path?: string): Record<string, unknown> {
   return useClientPageSearch();

--- a/packages/ev/src/route/types.ts
+++ b/packages/ev/src/route/types.ts
@@ -1,3 +1,4 @@
+import type { PageSearchParams } from "@evjs/shared";
 import type {
   createRouter,
   ResolveParams,
@@ -60,8 +61,8 @@ export type PageRouteSearch<TPath extends string> =
   }
     ? TSearch extends Record<string, unknown>
       ? TSearch
-      : Record<string, unknown>
-    : Record<string, unknown>;
+      : PageSearchParams
+    : PageSearchParams;
 
 export type PageRouteLoaderData<TPath extends string> =
   PageRouteModuleByPath<TPath> extends {

--- a/packages/server/tests/react-renderer.test.ts
+++ b/packages/server/tests/react-renderer.test.ts
@@ -302,12 +302,8 @@ describe("createReactServerRenderAdapter", () => {
     function PostPage(props: Record<string, unknown>) {
       renderedProps = props;
       const { postId } = usePageParams<{ postId: string }>();
-      const search = usePageSearch<{ tab?: string; tag?: string[] }>();
-      return createElement(
-        "h1",
-        null,
-        `${postId}:${search.tab}:${search.tag?.join(",")}`,
-      );
+      const search = usePageSearch<{ tab?: string; tag?: string }>();
+      return createElement("h1", null, `${postId}:${search.tab}:${search.tag}`);
     }
 
     const result = await adapter(
@@ -330,7 +326,7 @@ describe("createReactServerRenderAdapter", () => {
       throw new Error("Expected HTML result.");
     }
 
-    expect(result.html).toContain("<h1>42:comments:a,b</h1>");
+    expect(result.html).toContain("<h1>42:comments:b</h1>");
     expect(renderedProps).toEqual({
       runtime: { buildId: "test" },
       route: { id: "post", path: "/posts/$postId" },

--- a/packages/shared/src/page-route-data.ts
+++ b/packages/shared/src/page-route-data.ts
@@ -1,4 +1,4 @@
-export type PageSearchParams = Record<string, string | string[]>;
+export type PageSearchParams = Record<string, string>;
 
 export type PageRouteParamNameValidationError = "empty" | "reserved";
 export type PageRouteParamSegmentValidationErrorKind =
@@ -288,14 +288,7 @@ export function parsePageSearch(search: string): PageSearchParams {
     const value = decodeQueryValue(rawValue);
     if (!key) continue;
 
-    const current = params[key];
-    if (Array.isArray(current)) {
-      current.push(value);
-    } else if (typeof current === "string") {
-      defineSearchParam(params, key, [current, value]);
-    } else {
-      defineSearchParam(params, key, value);
-    }
+    defineSearchParam(params, key, value);
   }
 
   return params;
@@ -304,7 +297,7 @@ export function parsePageSearch(search: string): PageSearchParams {
 function defineSearchParam(
   params: PageSearchParams,
   key: string,
-  value: string | string[],
+  value: string,
 ): void {
   Object.defineProperty(params, key, {
     value,

--- a/packages/shared/tests/page-route-data.test.ts
+++ b/packages/shared/tests/page-route-data.test.ts
@@ -168,10 +168,10 @@ describe("page route data helpers", () => {
     });
   });
 
-  it("parses page search params with repeated keys", () => {
+  it("parses page search params as strings and keeps the last repeated value", () => {
     expect(parsePageSearch("?q=hello+world&tag=a&tag=b&empty")).toEqual({
       q: "hello world",
-      tag: ["a", "b"],
+      tag: "b",
       empty: "",
     });
   });
@@ -182,7 +182,7 @@ describe("page route data helpers", () => {
     );
 
     expect(Object.hasOwn(params, "__proto__")).toBe(true);
-    expect(Reflect.get(params, "__proto__")).toEqual(["polluted", "safe"]);
+    expect(Reflect.get(params, "__proto__")).toBe("safe");
     expect(Reflect.get(params, "constructor")).toBe("value");
     expect(Object.getPrototypeOf(params)).toBe(Object.prototype);
   });

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -68,6 +68,9 @@ For detailed guides on specific topics, see the docs:
   and do not type props as framework route props.
 - Read route data with `usePageParams()`, `usePageSearch()`, and
   `usePageLoaderData()` from `@evjs/ev/route`.
+- Search params use `Record<string, string>` without implicit number, boolean,
+  or JSON coercion. Convert values explicitly in `validateSearch`; repeated
+  query keys keep the last value.
 - Use `Link`, `Navigate`, `useLinkProps`, and `redirect` from `@evjs/ev/navigation`
   for SPA navigation. Generated `route-types.d.ts` augments
   `@evjs/ev/route`; app code should not import TanStack Router directly.


### PR DESCRIPTION
## Summary
- Make evjs-managed page search params use a raw string contract.
- Prevent long numeric identifiers from losing precision and being rewritten when a non-root basepath is applied.

## Changes
- Configure `createApp()` with the shared raw search parser and TanStack's string serializer.
- Change `PageSearchParams` to `Record<string, string>` and make repeated keys keep the last value.
- Align SPA, MPA, SSR, and RSC types, tests, examples, English/Chinese docs, skill guidance, and changelog.

## Validation
- `npm run lint`
- `npm run check-types`
- `npm test`
- `git diff --check`

## Risk / rollout
- Breaking change: numeric, boolean-like, and JSON-shaped query values now remain strings.
- Breaking change: repeated query keys now resolve to the last value instead of `string[]`.
- Applications should convert values explicitly in `validateSearch`.
- Release core before updating the Alipay Tern integration to consume the new core contract.

## Reviewer notes
- Please focus on the `createApp()` parser/stringifier defaults and cross-runtime consistency.
- The non-root basepath regression covers the original long `spaceId` URL rewrite.