### PR TITLE
feat(plugin): add onPagesResolved hook

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -129,6 +129,7 @@ flowchart TB
     BuildPlan["create BuildPlan"]
     Contributions["contributions(ctx)\nmodules + slots"]
     IR["materialize .ev"]
+    PagesResolved["onPagesResolved()\ncomplete page inventory"]
   end
 
   subgraph Build["Bundling and output"]
@@ -141,25 +142,46 @@ flowchart TB
   end
 
   Config --> Resolve --> Setup --> BuildStart --> Graph --> BuildPlan
-  BuildPlan --> Contributions --> IR --> BundlerConfig --> Bundler
+  BuildPlan --> Contributions --> IR --> PagesResolved --> BundlerConfig --> Bundler
   Bundler --> BuildOutput --> HTML --> BuildEnd --> Dispose
 
   classDef config fill:#eef6ff,stroke:#8fb5e8,color:#102a43;
   classDef plan fill:#f3f0ff,stroke:#a78bfa,color:#2e1065;
   classDef build fill:#ecfdf5,stroke:#34d399,color:#064e3b;
   class Config,Resolve,Setup config;
-  class BuildStart,Graph,BuildPlan,Contributions,IR plan;
+  class BuildStart,Graph,BuildPlan,Contributions,IR,PagesResolved plan;
   class BundlerConfig,Bundler,BuildOutput,HTML,BuildEnd,Dispose build;
 ```
 
 | Hook | Purpose |
 |------|---------|
 | `buildStart(ctx)` | Build setup before route discovery and bundling |
+| `onPagesResolved(pages)` | Read the discovered page routes after page resolution |
 | `bundlerConfig(config, ctx)` | Mutate selected bundler config |
 | `buildOutput(output, ctx)` | Add deployment/runtime metadata to the build output |
 | `transformHtml(doc, ctx)` | Mutate one HTML document at a time; receives the current manifest result fields |
 | `buildEnd({ output, isRebuild })` | Emit final artifacts after build |
 | `dispose(ctx)` | Cleanup |
+
+Use `onPagesResolved()` to read the discovered page routes after page
+resolution. Layout routes are excluded:
+
+```ts
+import type { Plugin } from "@evjs/ev/plugin";
+
+export function pageInventoryPlugin(): Plugin {
+  return {
+    name: "page-inventory",
+    setup() {
+      return {
+        onPagesResolved(pages) {
+          console.log(pages.map((page) => page.path));
+        },
+      };
+    },
+  };
+}
+```
 
 ## Generated Contributions
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugins.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugins.md
@@ -124,6 +124,7 @@ flowchart TB
     BuildPlan["create BuildPlan"]
     Contributions["contributions(ctx)\nmodules + slots"]
     IR["materialize .ev"]
+    PagesResolved["onPagesResolved()\n完整页面清单"]
   end
 
   subgraph Build["Bundling 和输出"]
@@ -136,25 +137,46 @@ flowchart TB
   end
 
   Config --> Resolve --> Setup --> BuildStart --> Graph --> BuildPlan
-  BuildPlan --> Contributions --> IR --> BundlerConfig --> Bundler
+  BuildPlan --> Contributions --> IR --> PagesResolved --> BundlerConfig --> Bundler
   Bundler --> BuildOutput --> HTML --> BuildEnd --> Dispose
 
   classDef config fill:#eef6ff,stroke:#8fb5e8,color:#102a43;
   classDef plan fill:#f3f0ff,stroke:#a78bfa,color:#2e1065;
   classDef build fill:#ecfdf5,stroke:#34d399,color:#064e3b;
   class Config,Resolve,Setup config;
-  class BuildStart,Graph,BuildPlan,Contributions,IR plan;
+  class BuildStart,Graph,BuildPlan,Contributions,IR,PagesResolved plan;
   class BundlerConfig,Bundler,BuildOutput,HTML,BuildEnd,Dispose build;
 ```
 
 | Hook | 用途 |
 |------|------|
 | `buildStart(ctx)` | 路由发现和 bundling 前的构建准备 |
+| `onPagesResolved(pages)` | 页面解析完成后读取发现到的页面 route |
 | `bundlerConfig(config, ctx)` | 修改当前 bundler 配置 |
 | `buildOutput(output, ctx)` | 向构建输出添加部署/runtime metadata |
 | `transformHtml(doc, ctx)` | 逐个 HTML 文档修改输出；接收当前 manifest result 字段 |
 | `buildEnd({ output, isRebuild })` | 构建后输出最终产物 |
 | `dispose(ctx)` | 清理资源 |
+
+使用 `onPagesResolved()` 读取页面解析完成后的页面 route 列表；layout route
+不会出现在其中：
+
+```ts
+import type { Plugin } from "@evjs/ev/plugin";
+
+export function pageInventoryPlugin(): Plugin {
+  return {
+    name: "page-inventory",
+    setup() {
+      return {
+        onPagesResolved(pages) {
+          console.log(pages.map((page) => page.path));
+        },
+      };
+    },
+  };
+}
+```
 
 ## Generated Contributions
 

--- a/packages/ev/src/_internal/build/commands.ts
+++ b/packages/ev/src/_internal/build/commands.ts
@@ -63,6 +63,7 @@ import {
   runCleanupTasks,
   runConfigHooks,
   runDisposeHooks,
+  runPagesResolvedHooks,
 } from "./plugin-lifecycle.js";
 
 const logger = getLogger(["evjs", "ev"]);
@@ -338,6 +339,9 @@ async function prepareInternalFrameworkBuild<
       plan: options.plan,
       onAnalysis: reportGraphDiagnostics,
     });
+    if (options.runLifecycleHooks ?? true) {
+      await runPagesResolvedHooks(hooks, analysis.graph);
+    }
 
     return {
       cwd,
@@ -606,6 +610,7 @@ async function runDevSession<TBundlerCfg = DefaultBundlerConfig>(
       plan: { distDir: DEV_DIST_DIR },
       onAnalysis: reportGraphDiagnostics,
     });
+    await runPagesResolvedHooks(hooks, materialized.analysis.graph);
     activeAnalysis = materialized.analysis;
     activePlan = materialized.plan;
     await assertNoActiveDevDistLock(cwd, activePlan.distDir);
@@ -884,6 +889,7 @@ async function runDevSession<TBundlerCfg = DefaultBundlerConfig>(
           plan: { distDir: DEV_DIST_DIR },
           onAnalysis: reportGraphDiagnostics,
         });
+      await runPagesResolvedHooks(hooks, nextAnalysis.graph);
       const update = diffBuildPlan(activePlan, nextPlan, reason);
       if (isEmptyPlanUpdate(update)) {
         activeConfig = nextConfig;

--- a/packages/ev/src/_internal/build/plugin-lifecycle.ts
+++ b/packages/ev/src/_internal/build/plugin-lifecycle.ts
@@ -1,4 +1,4 @@
-import type { BuildOutput } from "@evjs/shared/manifest";
+import type { AppGraph, BuildOutput } from "@evjs/shared/manifest";
 import { type Config, resolvePluginsConfig } from "../../config/index.js";
 import type {
   BuildResult,
@@ -10,6 +10,7 @@ import type {
 
 const PLUGIN_HOOK_NAMES = [
   "buildStart",
+  "onPagesResolved",
   "buildOutput",
   "bundlerConfig",
   "buildEnd",
@@ -238,6 +239,18 @@ export async function runBuildStartHooks<TBundlerCfg>(
   ctx: PluginContext<TBundlerCfg>,
 ): Promise<void> {
   for (const hook of hooks) await hook.buildStart?.(ctx);
+}
+
+export async function runPagesResolvedHooks<TBundlerCfg>(
+  hooks: PluginHooks<TBundlerCfg>[],
+  graph: AppGraph,
+): Promise<void> {
+  const pages = Object.freeze(
+    graph.routes
+      .filter((route) => route.kind !== "layout")
+      .map((route) => Object.freeze({ ...route })),
+  );
+  for (const hook of hooks) await hook.onPagesResolved?.(pages);
 }
 
 export async function runBuildOutputHooks<TBundlerCfg>(

--- a/packages/ev/src/plugin/index.ts
+++ b/packages/ev/src/plugin/index.ts
@@ -605,6 +605,11 @@ export interface EvPluginHooks<TBundlerCfg = DefaultBundlerConfig> {
   /** Called before compilation begins. */
   buildStart?: () => void | Promise<void>;
 
+  /** Called after application page routes have been resolved. */
+  onPagesResolved?: (
+    pages: readonly FrameworkRouteView[],
+  ) => void | Promise<void>;
+
   /**
    * Modify the underlying bundler configuration directly.
    *

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -401,6 +401,65 @@ describe("prepareFrameworkBuild", () => {
     expect(events).toEqual(["setup:true:true", "buildStart:true:true"]);
   });
 
+  it("exposes every resolved page to plugins after graph discovery", async () => {
+    const cwd = await createProject();
+    await fs.promises.mkdir(path.join(cwd, "src/pages"), { recursive: true });
+    await fs.promises.writeFile(
+      path.join(cwd, "src/pages/index.tsx"),
+      "export default function Home() { return null; }",
+      "utf-8",
+    );
+    await fs.promises.writeFile(
+      path.join(cwd, "src/pages/about.tsx"),
+      "export default function About() { return null; }",
+      "utf-8",
+    );
+
+    let calls = 0;
+    let pageSummary: Array<{
+      path?: string;
+      module?: string;
+    }> = [];
+    const plugin: Plugin<Record<string, never>> = {
+      name: "resolved-pages",
+      setup() {
+        return {
+          onPagesResolved(pages) {
+            calls += 1;
+            expect(Object.isFrozen(pages)).toBe(true);
+            expect(pages.every((page) => Object.isFrozen(page))).toBe(true);
+            pageSummary = pages.map((page) => ({
+              path: page.path,
+              module: page.module,
+            }));
+          },
+        };
+      },
+    };
+
+    const prepared = await prepareFrameworkBuild(
+      {
+        routing: { mode: "spa" },
+        output: { client: "dist" },
+        plugins: [plugin],
+      },
+      { cwd },
+    );
+
+    expect(calls).toBe(1);
+    expect(pageSummary).toEqual([
+      {
+        path: "/",
+        module: "./src/pages/index.tsx",
+      },
+      {
+        path: "/about",
+        module: "./src/pages/about.tsx",
+      },
+    ]);
+    await prepared.dispose();
+  });
+
   it("rolls back earlier plugin setups when a later setup fails", async () => {
     const cwd = await createProject();
     const events: string[] = [];


### PR DESCRIPTION
## Summary
- Add a minimal `onPagesResolved` plugin lifecycle hook.
- Let plugins observe discovered page routes directly instead of inferring them from `BuildPlan`.

## Changes
- Expose `onPagesResolved(pages)` with a readonly `FrameworkRouteView[]`.
- Invoke the hook after framework graph analysis during build preparation and dev page rediscovery.
- Exclude layout routes and provide an immutable page-route snapshot.
- Add lifecycle coverage and update the English and Chinese plugin documentation.

## Validation
- `npm test`
- `npm run check-types`
- `npm run lint`
- `git diff --check`

## Risk / rollout
- Low risk: this is an additive plugin API with no configuration, migration, or runtime protocol changes.
- Existing plugins are unaffected unless they opt into the new hook.

## Reviewer notes
- Please review the lifecycle timing in build and dev flows.
- Please confirm that excluding layout routes matches the intended page inventory semantics.