### PR TITLE
fix(rendering): enforce CSR hydration boundaries

### DIFF
--- a/docs/docs/build.md
+++ b/docs/docs/build.md
@@ -196,6 +196,14 @@ digits, `.`, `_`, `~`, or `-`. Empty and standalone `.` or `..` segments,
 RSC and partial prerendering cannot be combined on one Page. These settings
 normalize to Core Page rendering fields without changing Page identity.
 
+Omitting `render` always normalizes the Page to `"csr"`. CSR mounts a new
+client tree and therefore must omit `hydrate`; only explicitly selected SSR or
+SSG Pages can configure `hydrate: "load" | "none"`. Ordinary SSR defaults to
+load hydration, SSG defaults to no hydration, and RSC/PPR remain unhydrated at
+the Page level. Generated runtime metadata still uses an effective `"load"`
+client activation for CSR bootstrap, but that internal value is not a Page
+authoring option.
+
 The server-function and active RSC endpoints are exact paths. An active PPR
 endpoint owns its rooted subtree. Build planning requires those active
 endpoints to be disjoint and rejects any Page, redirect, or server request

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -230,7 +230,9 @@ export default definePageConfig({
 The module is evaluated synchronously while evjs constructs the build graph.
 It must default-export a plain object containing static JSON data. Supported
 core fields are `title`, `meta`, `render`, `hydrate`, `prerender`, and `rsc`.
-`hydrate` accepts only `"none"` or `"load"`.
+Omitting `render` always selects CSR, and CSR must omit `hydrate`. Explicit SSR
+and SSG Pages may use `hydrate: "none" | "load"`; ordinary SSR defaults to
+`"load"`, SSG defaults to `"none"`, and RSC/PPR remain unhydrated at Page level.
 `meta` is a string record for `<meta name="key" content="value">`; it does not
 accept `property`, `charset`, links, scripts, functions, or a generic head
 tree. Plugin-owned values must use registered namespaced keys under

--- a/docs/docs/file-conventions.md
+++ b/docs/docs/file-conventions.md
@@ -116,7 +116,9 @@ export default definePageConfig({
 The module is evaluated synchronously at build time. It default-exports a plain
 object containing static JSON data. Core owns `title`, named `meta`, `render`,
 `hydrate`, `prerender`, and `rsc`; plugins register and own namespaced values
-under `extensions`. `meta` maps string keys and values only to
+under `extensions`. Omitted `render` always means CSR, which must omit
+`hydrate`; explicit SSR/SSG Pages may select `"load"` or `"none"`. `meta` maps
+string keys and values only to
 `<meta name="key" content="value">`. It does not provide `property`, `charset`,
 links, scripts, dynamic metadata, or a general head DSL. Core title/meta are
 materialized for the Page; plugin extension values require explicit plugin

--- a/docs/docs/project-structure.md
+++ b/docs/docs/project-structure.md
@@ -297,7 +297,9 @@ export default definePageConfig({
 ```
 
 Core fields include the static Page `title`, named `meta`, `render`, `hydrate`,
-`prerender`, and `rsc`. Each `meta` entry becomes
+`prerender`, and `rsc`. Omitted `render` always normalizes to CSR, which must
+omit `hydrate`; explicit SSR/SSG Pages may select `"load"` or `"none"`. Each
+`meta` entry becomes
 `<meta name="key" content="value">`; it does not represent `property`,
 `charset`, `link`, `script`, dynamic metadata, or an arbitrary head DSL.
 Plugin-owned Page values live below top-level `extensions`; Route-owned values

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
@@ -180,6 +180,13 @@ URL-safe segment 组成，每个 segment 只能包含字母、数字、`.`、`_`
 非 ASCII 字符都会被拒绝。同一 Page 不能组合 RSC 与 partial prerendering。这些
 setting normalize 到 Core Page rendering field，且不改变 Page identity。
 
+省略 `render` 时，Page 始终归一化为 `"csr"`。CSR 会在浏览器中 mount 一棵新的
+client tree，因此必须省略 `hydrate`；只有显式选择 SSR 或 SSG 的 Page 才能配置
+`hydrate: "load" | "none"`。普通 SSR 默认执行 load hydration，SSG 默认不执行
+hydration，RSC/PPR 则保持 Page 级不 hydration。生成的 runtime metadata 仍会
+用有效值 `"load"` 表示 CSR bootstrap 的 client activation，但该内部值不是
+Page authoring option。
+
 Server-function 与启用后的 RSC endpoint 是精确路径；启用后的 PPR endpoint 持有
 以自身为根的子树。BuildPlan 要求这些 active endpoint 互不相交，并拒绝任何可能
 匹配 reserved runtime path 的 Page、redirect 或 server request Route pattern。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/config.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/config.md
@@ -217,7 +217,10 @@ export default definePageConfig({
 
 evjs 构建 graph 时同步求值该 module。它必须 default-export plain object，且只
 包含 static JSON data。支持的 core 字段是 `title`、`meta`、`render`、
-`hydrate`、`prerender` 与 `rsc`。`hydrate` 只接受 `"none"` 或 `"load"`。
+`hydrate`、`prerender` 与 `rsc`。省略 `render` 时始终选择 CSR，且 CSR 必须
+省略 `hydrate`。显式 SSR 与 SSG Page 可以使用 `hydrate: "none" | "load"`；
+普通 SSR 默认值是 `"load"`，SSG 默认值是 `"none"`，RSC/PPR 保持 Page 级
+不 hydration。
 `meta` 是生成
 `<meta name="key" content="value">` 的字符串 record；它不接受 `property`、
 `charset`、link、script、函数或通用 head tree。插件持有的值必须放在

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/file-conventions.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/file-conventions.md
@@ -109,7 +109,9 @@ export default definePageConfig({
 
 该 module 在构建期同步求值，default-export 只包含 static JSON data 的 plain
 object。Core 持有 `title`、named `meta`、`render`、`hydrate`、`prerender`
-与 `rsc`；插件注册并持有 `extensions` 下的 namespaced value。`meta` 只把
+与 `rsc`；插件注册并持有 `extensions` 下的 namespaced value。省略 `render`
+始终表示 CSR，且必须省略 `hydrate`；显式 SSR/SSG Page 可以选择 `"load"` 或
+`"none"`。`meta` 只把
 字符串 key/value 映射为 `<meta name="key" content="value">`，不提供
 `property`、`charset`、link、script、动态元信息或通用 head DSL。Core
 title/meta 会为 Page 物化；插件 extension value 在 runtime 使用前仍需插件显式

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/project-structure.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/project-structure.md
@@ -276,7 +276,9 @@ export default definePageConfig({
 ```
 
 Core 字段包括静态 Page `title`、named `meta`、`render`、`hydrate`、
-`prerender` 与 `rsc`。每个 `meta` 项都会生成
+`prerender` 与 `rsc`。省略 `render` 时始终归一化为 CSR，且必须省略
+`hydrate`；显式 SSR/SSG Page 可以选择 `"load"` 或 `"none"`。每个 `meta`
+项都会生成
 `<meta name="key" content="value">`；它不表示 `property`、`charset`、
 `link`、`script`、动态元信息或任意 head DSL。Plugin 持有的 Page value 放在
 顶层 `extensions`，Route-owned value 放在 `route.extensions`；两者都使用已注册

--- a/packages/bundler-utoopack/tests/create-config.test.ts
+++ b/packages/bundler-utoopack/tests/create-config.test.ts
@@ -1353,7 +1353,6 @@ function createGraph(
             provider: "@evjs/provider/page-anchor",
           },
           render: page.render ?? "csr",
-          hydrate: "load" as const,
           extensions: {},
           provenance,
         },

--- a/packages/bundler-webpack/tests/create-config.test.ts
+++ b/packages/bundler-webpack/tests/create-config.test.ts
@@ -925,8 +925,15 @@ function createGraph(
             provider: "@evjs/provider/page-anchor",
           },
           render: page.render ?? "csr",
-          hydrate: page.rsc ? ("none" as const) : ("load" as const),
-          ...(page.rsc ? { componentModel: "rsc" as const } : {}),
+          ...(page.rsc
+            ? {
+                componentModel: "rsc" as const,
+                hydrate: "none" as const,
+              }
+            : {}),
+          ...(!page.rsc && page.render !== undefined && page.render !== "csr"
+            ? { hydrate: "load" as const }
+            : {}),
           extensions: {},
           provenance,
         },

--- a/packages/ev/src/_internal/build/graph/config-route.ts
+++ b/packages/ev/src/_internal/build/graph/config-route.ts
@@ -28,6 +28,7 @@ import type {
   ResolvedConfigRoute,
   ResolvedConfigRouteApplication,
 } from "../../../config/index.js";
+import { DEFAULT_PAGE_RENDER_MODE } from "../page-rendering-contract.js";
 import {
   PAGE_CONFIG_FILES,
   PAGE_CONFIG_LABEL,
@@ -495,7 +496,7 @@ async function defineConfigRoutePage(
       scope,
       provider: CONFIG_ROUTE_PROVIDER_ID,
     },
-    render: "csr",
+    render: DEFAULT_PAGE_RENDER_MODE,
     extensions: {},
     provenance: {
       producer: CONFIG_ROUTE_PRODUCER,

--- a/packages/ev/src/_internal/build/graph/core.ts
+++ b/packages/ev/src/_internal/build/graph/core.ts
@@ -20,6 +20,7 @@ import {
 } from "@evjs/shared/manifest";
 import type { ResolvedPageFileConfig } from "../page-config-module.js";
 import { createStaticPageDocumentOutput } from "../page-document-output.js";
+import { resolvePageRenderMode } from "../page-rendering-contract.js";
 import { CANONICAL_PAGE_ROUTE_ROOT } from "../page-route-conventions.js";
 import type { GraphConfig } from "./index.js";
 
@@ -192,7 +193,7 @@ export function createPageAnchorGraph(
         scope: route.scope,
         provider: PAGE_ANCHOR_PROVIDER_ID,
       },
-      render: resolvedPageConfig?.render ?? "csr",
+      render: resolvePageRenderMode(resolvedPageConfig?.render),
       ...(resolvedPageConfig?.componentModel
         ? { componentModel: resolvedPageConfig.componentModel }
         : {}),

--- a/packages/ev/src/_internal/build/page-config-module.ts
+++ b/packages/ev/src/_internal/build/page-config-module.ts
@@ -163,16 +163,12 @@ async function resolvePageConfigModule(
   );
   const document = resolvePageDocument(value.document, page);
   const routeExtensions = resolvePageRouteExtensions(value.route, page);
-  validatePageRenderingContract(
-    `Page "${page.pageId}" config "${source}"`,
-    {
-      ...(render ? { render } : {}),
-      ...(componentModel ? { componentModel } : {}),
-      ...(hydrate ? { hydrate } : {}),
-      ...(prerender ? { prerender } : {}),
-    },
-    { requireExplicitRenderForFullPrerender: true },
-  );
+  validatePageRenderingContract(`Page "${page.pageId}" config "${source}"`, {
+    ...(render ? { render } : {}),
+    ...(componentModel ? { componentModel } : {}),
+    ...(hydrate ? { hydrate } : {}),
+    ...(prerender ? { prerender } : {}),
+  });
 
   return {
     config: {

--- a/packages/ev/src/_internal/build/page-rendering-contract.ts
+++ b/packages/ev/src/_internal/build/page-rendering-contract.ts
@@ -15,19 +15,23 @@ export interface PageRenderingContract {
 }
 
 export interface PageBuildContract extends PageRenderingContract {
+  render: RenderMode;
   component?: string;
 }
 
-export interface ValidatePageRenderingContractOptions {
-  requireExplicitRenderForFullPrerender?: boolean;
+export const DEFAULT_PAGE_RENDER_MODE = "csr" satisfies RenderMode;
+
+export function resolvePageRenderMode(
+  render: RenderMode | undefined,
+): RenderMode {
+  return render ?? DEFAULT_PAGE_RENDER_MODE;
 }
 
 export function validatePageRenderingContract(
   label: string,
   page: PageRenderingContract,
-  options: ValidatePageRenderingContractOptions = {},
 ): void {
-  const violation = getPageRenderingContractViolation(label, page, options);
+  const violation = getPageRenderingContractViolation(label, page);
   if (violation) throw new Error(`[evjs] ${violation}`);
 }
 
@@ -42,16 +46,13 @@ export function validatePageBuildContract(
 export function getPageRenderingContractViolation(
   label: string,
   page: PageRenderingContract,
-  options: ValidatePageRenderingContractOptions = {},
 ): string | undefined {
+  const render = resolvePageRenderMode(page.render);
   const rsc = isRscPage(page);
   const partial = isPartialPrerenderPage(page);
   const fullPrerender = isFullPrerenderPage(page);
-  const missingFullPrerenderRender =
-    options.requireExplicitRenderForFullPrerender === true &&
-    page.render === undefined;
 
-  if (fullPrerender && (page.render === "csr" || missingFullPrerenderRender)) {
+  if (fullPrerender && render === "csr") {
     return `${label} uses full prerendering and must declare render: "ssg" or "ssr".`;
   }
   if (rsc && page.render !== "ssr") {
@@ -69,6 +70,9 @@ export function getPageRenderingContractViolation(
   if (rsc && partial) {
     return `${label} combines RSC and partial prerendering, which is not supported yet. Choose either rsc: true or prerender: { partial: true }, or split them into separate page routes.`;
   }
+  if (render === "csr" && page.hydrate !== undefined) {
+    return `${label} resolves to render: "csr" and must omit hydrate. Hydration is only configurable for render: "ssr" or "ssg".`;
+  }
   return undefined;
 }
 
@@ -76,6 +80,9 @@ export function getPageBuildContractViolation(
   label: string,
   page: PageBuildContract,
 ): string | undefined {
+  if (page.render === undefined) {
+    return `${label} is missing its resolved render mode. Core Pages must resolve render before build planning.`;
+  }
   const rsc = isRscPage(page);
   const partial = isPartialPrerenderPage(page);
 

--- a/packages/ev/src/config/index.ts
+++ b/packages/ev/src/config/index.ts
@@ -338,20 +338,9 @@ export interface PageRoutingConfig {
 
 export type PageRoutingMode = "spa" | "mpa";
 
-/**
- * Canonical configuration colocated with a `page.*` Page anchor.
- *
- * The module is evaluated by evjs at build time. Its resolved value must be
- * static JSON data; plugins decide whether an extension is consumed while
- * building or explicitly projected into generated runtime code.
- */
-export interface PageFileConfig<
+interface PageFileConfigBase<
   TExtensions extends ConfigExtensionValues = ConfigExtensionValues,
 > extends PageMetadata {
-  /** Framework document render mode. Defaults to "csr". */
-  readonly render?: RenderMode;
-  /** Framework hydration mode. Defaults to "load" except SSG defaults to "none". */
-  readonly hydrate?: HydrationMode;
   /** Prerender behavior for SSR/SSG Pages. */
   readonly prerender?: PrerenderConfig;
   /** Enable React Server Components. Requires `render: "ssr"`. */
@@ -371,6 +360,33 @@ export interface PageFileConfig<
    */
   readonly route?: PageFileRouteConfig;
 }
+
+type PageFileRenderingConfig =
+  | {
+      /** Defaults to CSR when omitted. */
+      readonly render?: RenderMode;
+      /** Hydration must be omitted unless SSR/SSG is selected explicitly. */
+      readonly hydrate?: never;
+    }
+  | {
+      /** Hydration requires explicitly selected server or build-time HTML. */
+      readonly render: Exclude<RenderMode, "csr">;
+      /** Whether the browser hydrates the generated HTML. */
+      readonly hydrate: HydrationMode;
+    };
+
+/**
+ * Canonical configuration colocated with a `page.*` Page anchor.
+ *
+ * The module is evaluated by evjs at build time. Its resolved value must be
+ * static JSON data; plugins decide whether an extension is consumed while
+ * building or explicitly projected into generated runtime code. Omitting
+ * `render` always selects CSR. Hydration applies only to SSR/SSG Pages because
+ * CSR mounts a new client tree instead of adopting existing HTML.
+ */
+export type PageFileConfig<
+  TExtensions extends ConfigExtensionValues = ConfigExtensionValues,
+> = PageFileConfigBase<TExtensions> & PageFileRenderingConfig;
 
 export interface PageFileDocumentConfig {
   /**

--- a/packages/ev/tests/build-tools-graph-plan.test.ts
+++ b/packages/ev/tests/build-tools-graph-plan.test.ts
@@ -457,6 +457,12 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
     expect(spa.diagnostics).toEqual([]);
     expect(mpa.diagnostics).toEqual([]);
     expect(mpa.graph.pages).toEqual(spa.graph.pages);
+    expect(spa.graph.pages).toMatchObject({
+      index: { render: "csr" },
+      about: { render: "csr" },
+    });
+    expect(spa.graph.pages.index).not.toHaveProperty("hydrate");
+    expect(spa.graph.pages.about).not.toHaveProperty("hydrate");
     expect(clientRouteProjection(mpa.graph)).toEqual(
       clientRouteProjection(spa.graph),
     );
@@ -503,17 +509,29 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
             entry.metadata?.type === "react-component-page"
               ? entry.metadata.layers
               : undefined,
+          render:
+            entry.metadata?.type === "react-component-page"
+              ? entry.metadata.render
+              : undefined,
+          hydrate:
+            entry.metadata?.type === "react-component-page"
+              ? entry.metadata.hydrate
+              : undefined,
         })),
     ).toEqual([
       {
         name: createPageClientBuildEntryName("index"),
         owner: { appId: "default", pageId: "index" },
         layers: [{ kind: "layout", module: "./src/pages/layout.tsx" }],
+        render: "csr",
+        hydrate: "load",
       },
       {
         name: createPageClientBuildEntryName("about"),
         owner: { appId: "default", pageId: "about" },
         layers: [{ kind: "layout", module: "./src/pages/layout.tsx" }],
+        render: "csr",
+        hydrate: "load",
       },
     ]);
     expect(mpaPlan.html).toEqual([
@@ -1389,6 +1407,41 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
 
     await expect(createCoreGraph(config, cwd)).rejects.toThrow(
       'Page "report" config "./src/pages/report/page.config.ts" combines RSC and partial prerendering',
+    );
+  });
+
+  it.each([
+    "load",
+    "none",
+  ] as const)("rejects manually injected CSR hydrate %s before build planning", async (hydrate) => {
+    const cwd = await createFixture({
+      "src/pages/page.tsx": "export default function Home() { return null; }",
+      "index.html": '<main id="app"></main>',
+    });
+    const config = await createCanonicalConfig(cwd, "spa");
+    const analysis = await createCoreGraph(config, cwd);
+    const page = analysis.graph.pages.index;
+    if (!page) throw new Error("Expected the root Page.");
+    page.hydrate = hydrate;
+
+    expect(() => createBuildPlan(config, analysis.graph)).toThrow(
+      'Page "index" resolves to render: "csr" and must omit hydrate. Hydration is only configurable for render: "ssr" or "ssg".',
+    );
+  });
+
+  it("rejects a Core Page without a resolved render mode", async () => {
+    const cwd = await createFixture({
+      "src/pages/page.tsx": "export default function Home() { return null; }",
+      "index.html": '<main id="app"></main>',
+    });
+    const config = await createCanonicalConfig(cwd, "spa");
+    const analysis = await createCoreGraph(config, cwd);
+    const page = analysis.graph.pages.index;
+    if (!page) throw new Error("Expected the root Page.");
+    Object.defineProperty(page, "render", { value: undefined });
+
+    expect(() => createBuildPlan(config, analysis.graph)).toThrow(
+      'Page "index" is missing its resolved render mode. Core Pages must resolve render before build planning.',
     );
   });
 

--- a/packages/ev/tests/config-route.test.ts
+++ b/packages/ev/tests/config-route.test.ts
@@ -44,12 +44,14 @@ describe("explicit SPA route graph", () => {
 
     expect(graph.pages.index).toMatchObject({
       id: "index",
+      render: "csr",
       source: {
         module: "./src/pages/page.tsx",
         scope: { kind: "directory", root: "./src/pages" },
       },
       metadata: { title: "Home" },
     });
+    expect(graph.pages.index).not.toHaveProperty("hydrate");
     expect(graph.routes).toContainEqual(
       expect.objectContaining({
         target: { kind: "page", pageId: "index" },
@@ -82,6 +84,8 @@ describe("explicit SPA route graph", () => {
       scope: { kind: "directory", root: "./app/pages/dashboard" },
       provider: CONFIG_ROUTE_PROVIDER_ID,
     });
+    expect(graph.pages.dashboard?.render).toBe("csr");
+    expect(graph.pages.dashboard).not.toHaveProperty("hydrate");
   });
 
   it("rejects a component symlink that escapes application.pageRoot", async () => {

--- a/packages/ev/tests/config.test.ts
+++ b/packages/ev/tests/config.test.ts
@@ -4,6 +4,7 @@ import {
   createNoPageRoutesFoundMessage,
   withPageRoutingDefaults,
 } from "../src/_internal/build/convention-config.js";
+import type { PageFileConfig } from "../src/config/index.js";
 import {
   CONFIG_DEFAULTS,
   defineConfig,
@@ -71,6 +72,20 @@ describe("config authoring", () => {
       // @ts-expect-error arbitrary head DSLs are not Page config.
       head: [["meta", { name: "description", content: "Home" }]],
     });
+    // @ts-expect-error omitted render resolves to CSR, which cannot hydrate.
+    const invalidDefaultCsrHydration = definePageConfig({ hydrate: "load" });
+    const invalidCsrHydration = definePageConfig({
+      render: "csr",
+      // @ts-expect-error explicit CSR mounts instead of hydrating.
+      hydrate: "none",
+    });
+    // @ts-expect-error PageFileConfig also rejects bypassing definePageConfig.
+    const invalidDefaultCsrConfig: PageFileConfig = { hydrate: "none" };
+    const invalidCsrConfig: PageFileConfig = {
+      render: "csr",
+      // @ts-expect-error explicit CSR cannot declare any hydration mode.
+      hydrate: "load",
+    };
 
     expect(unsupportedApp).toHaveProperty("app");
     expect(unsupportedPages).toHaveProperty("pages");
@@ -78,6 +93,10 @@ describe("config authoring", () => {
     expect(missingApplicationRoutes).toHaveProperty("application");
     expect(emptyApplicationRoutes).toHaveProperty("application");
     expect(invalidPageConfig).toHaveProperty("head");
+    expect(invalidDefaultCsrHydration).toHaveProperty("hydrate");
+    expect(invalidCsrHydration).toHaveProperty("hydrate");
+    expect(invalidDefaultCsrConfig).toHaveProperty("hydrate");
+    expect(invalidCsrConfig).toHaveProperty("hydrate");
   });
 });
 

--- a/packages/ev/tests/page-config-module.test.ts
+++ b/packages/ev/tests/page-config-module.test.ts
@@ -526,6 +526,40 @@ describe("page.config modules", () => {
 
   it.each([
     {
+      rendering: "default CSR with load hydration",
+      source: 'export default { hydrate: "load" };',
+    },
+    {
+      rendering: "default CSR with disabled hydration",
+      source: 'export default { hydrate: "none" };',
+    },
+    {
+      rendering: "explicit CSR with load hydration",
+      source: 'export default { render: "csr", hydrate: "load" };',
+    },
+    {
+      rendering: "explicit CSR with disabled hydration",
+      source: 'export default { render: "csr", hydrate: "none" };',
+    },
+  ])("rejects $rendering", async ({ source }) => {
+    const cwd = await createFixture({
+      "src/pages/home/page.tsx":
+        "export default function Home() { return null; }",
+      "src/pages/home/page.config.ts": source,
+    });
+
+    await expect(
+      resolvePageConfigModules(
+        cwd,
+        createPageMetadata("home", "./src/pages/home/page.config.ts"),
+      ),
+    ).rejects.toThrow(
+      'Page "home" config "./src/pages/home/page.config.ts" resolves to render: "csr" and must omit hydrate. Hydration is only configurable for render: "ssr" or "ssg".',
+    );
+  });
+
+  it.each([
+    {
       feature: "RSC",
       source: 'export default { render: "ssr", hydrate: "load", rsc: true };',
       message:

--- a/packages/shared/src/manifest/core-graph.ts
+++ b/packages/shared/src/manifest/core-graph.ts
@@ -75,6 +75,7 @@ export interface CorePageNode {
   source: CorePageSource;
   render: RenderMode;
   componentModel?: ComponentModel;
+  /** Author-selected hydration policy. CSR Pages must omit this field. */
   hydrate?: HydrationMode;
   prerender?: PrerenderConfig;
   ppr?: PprConfig;
@@ -448,6 +449,11 @@ function assertPageNode(value: unknown, id: string, source: string): void {
     page.hydrate !== "load"
   ) {
     throw new Error(`[evjs] ${source}.hydrate must be "none" or "load".`);
+  }
+  if (page.render === "csr" && page.hydrate !== undefined) {
+    throw new Error(
+      `[evjs] ${source}.hydrate must be omitted when render is "csr".`,
+    );
   }
   const prerender = getOwn(page, "prerender");
   if (prerender !== undefined) {

--- a/packages/shared/src/manifest/index.ts
+++ b/packages/shared/src/manifest/index.ts
@@ -212,6 +212,10 @@ export interface ReactComponentPageEntryMetadata {
   /** Outer-to-inner Page composition for an independent MPA Page. */
   layers?: ReactPageLayer[];
   mount: string;
+  /**
+   * Effective browser activation policy. `"load"` mounts a CSR Page, but
+   * hydrates a Page whose initial HTML came from SSR or SSG.
+   */
   hydrate: HydrationMode;
   render: RenderMode;
   route?: {
@@ -502,6 +506,7 @@ export interface PageOutput {
   path?: string;
   routeId?: string;
   componentModel?: ComponentModel;
+  /** Effective browser activation; CSR `"load"` means mount, not hydration. */
   hydrate?: HydrationMode;
   mount?: string;
   prerender?: PrerenderConfig;
@@ -533,7 +538,10 @@ export interface PageRenderingOutput {
   prerender?: "full" | "partial";
   /** Whether the page can stream server-rendered content after shell start. */
   streaming: boolean;
-  /** Browser hydration behavior for client-capable parts of the page. */
+  /**
+   * Effective browser activation policy. CSR `"load"` means mount; with
+   * server- or build-rendered HTML it means hydrate.
+   */
   hydrate: HydrationMode;
 }
 

--- a/packages/shared/tests/core-graph.test.ts
+++ b/packages/shared/tests/core-graph.test.ts
@@ -104,6 +104,18 @@ describe("assertCoreGraph", () => {
     );
   });
 
+  it.each([
+    "load",
+    "none",
+  ])("rejects CSR with Page hydration mode %s", (hydrate) => {
+    const graph = createValidGraph();
+    Reflect.set(getPage(graph), "hydrate", hydrate);
+
+    expect(() => assertCoreGraph(graph, "coreGraph")).toThrow(
+      '[evjs] coreGraph.pages.orders.hydrate must be omitted when render is "csr".',
+    );
+  });
+
   it("validates Server Function nodes and rejects duplicate ids", () => {
     const graph = createValidGraph();
     graph.serverFunctions = [


### PR DESCRIPTION
## Summary
- Guarantee that omitted Page render modes normalize to CSR across canonical and explicit route inputs.
- Remove hydration from the CSR authoring contract while preserving SSR/SSG hydration controls.
- Clarify that derived CSR `"load"` metadata means client mount/activation, not hydration.

## Changes
- Add a shared CSR default and use it when normalizing canonical and configured Pages.
- Reject `hydrate` on default or explicit CSR Pages in TypeScript authoring, Page config loading, CoreGraph validation, and build planning.
- Keep SSR/SSG `"load" | "none"` behavior and generated CSR client activation metadata unchanged.
- Update synthetic bundler graph fixtures to follow the normalized CoreGraph contract.
- Document the contract in the English and Chinese build, config, file-convention, and project-structure guides.

## Validation
- `npm run check-types`
- `npm run lint`
- `npm test`
- `git diff --check`

## Risk / rollout
- This intentionally rejects existing Page configs that combine omitted/`"csr"` render with any `hydrate` value; remove `hydrate` from those CSR configs.
- No manifest schema or runtime bootstrap change is included. CSR still derives effective `"load"` client activation and mounts a new tree.

## Reviewer notes
- Please focus on the `PageFileConfig` type union and the matching runtime guards in Page config, CoreGraph, and BuildPlan validation.
- Renaming the generated manifest field from `hydrate` to a broader activation term is intentionally outside this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that pages default to CSR when `render` is omitted.
  * Documented that CSR pages must omit hydration settings.
  * Explained hydration options and defaults for SSR and SSG pages.
  * Updated English and Simplified Chinese documentation.

* **Bug Fixes**
  * Added validation to reject hydration settings on CSR pages.
  * Improved consistency of page rendering defaults and configuration validation.

* **Type Improvements**
  * Configuration types now enforce valid render and hydration combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->