### PR TITLE
docs(changelog): prepare v0.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.1] — 2026-07-29
+
 ### ⚠️ Breaking Changes
 
 - **Fixed server request-route root** — Framework request Routes are always


### PR DESCRIPTION
## Summary
- Finalize the current Unreleased notes as the v0.3.1 release entry.
- Prepare the repository commit that the v0.3.1 tag and GitHub Release will target.

## Changes
- Add the `0.3.1` heading with the 2026-07-29 release date.
- Preserve a fresh empty `Unreleased` section for subsequent work.

## Validation
- `npm run lint`
- `npm run build --workspace evjs-docs` (English and zh-Hans)
- `git diff --check`

## Risk / rollout
- Documentation-only release metadata change.
- After merge, publishing GitHub Release `v0.3.1` will trigger the existing npm release workflow, which applies package versions and concrete internal dependency versions in the release job.

## Reviewer notes
- Confirm that the v0.3.1 notes accurately describe the changes merged in PR #61.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the 0.3.1 release header and date to the changelog.
  * Improved spacing to clearly separate the release section from the unreleased changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->