### PR TITLE
refactor(plugin): strengthen composition and activation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,14 @@ server routes, examples, or scaffolds change.
    object according to the plugin's declared defaults and `withPageOptIn()`
    activation mode. Route and Document contributions derive from the normalized
    Page graph instead of exposing separate plugin configuration surfaces.
+   `definePluginPreset()` is the only nested composition boundary; raw nested
+   arrays and async entries are invalid. `.when(condition, reason?)` keeps
+   contracts and generated Page keys installed while disabling execution,
+   whereas falsy array entries omit the plugin and its Page keys. Ordering uses
+   stable authored order plus required/present-optional dependency edges; do
+   not reintroduce a global `enforce` tier. Public context config projects
+   plugin/bundler metadata only. `prepare` and `inspect` analyze deterministic
+   IR without activating `setup()` or `dispose()`.
 9. Treat `.ev`, `src/route-types.d.ts`, `src/plugin-types.d.ts`, `dist`,
    `.turbo`, and `node_modules` as generated output. Scaffolds and templates
    must not copy generated route or plugin types. Keep declarations under

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -180,7 +180,7 @@ route, server-topology, resolution, and bundler-config changes report that
 ## Programmatic Preparation
 
 `prepareFrameworkBuild()` is the supported pre-bundler API for tooling. It
-loads and resolves config, runs plugin preflight hooks, analyzes the graph,
-reports diagnostics, and returns resolved config, file dependencies, plugin
-watch files, and `dispose()`. It does not run a bundler or emit deployment
-artifacts.
+loads and resolves config, runs `configure` and deterministic plugin IR
+emission, analyzes the graph, reports diagnostics, and returns resolved config,
+file dependencies, plugin watch files, and a no-op `dispose()`. It does not
+activate plugin `setup`, run a bundler, or emit deployment artifacts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
   snapshot and installs prepend, match, redirect, and micro-app route
   components before the first render. Resolver routes no longer require fixed
   containers, `activeRule`, or physical Pages at the mounted master paths.
+- **Plugin ordering follows dependencies, not global tiers** — The public
+  `enforce` field is removed. Plugins keep their authored array order unless
+  `dependencies` or a present `optionalDependencies` edge requires a stable
+  topological reorder. Framework-private phases are no longer projected as one
+  ordering tier onto every plugin lifecycle method.
 
 ### ✨ Improvements
 
@@ -53,6 +58,19 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
   an omitted Page, a normal installation uses declared Page defaults when
   available, while `withPageOptIn()` always requires `true` or an options
   object.
+- **Type-stable conditional execution** — Defined plugin instances expose
+  `.when(condition, reason?)`. A false condition keeps the plugin contract and
+  generated Page key installed while skipping configuration, setup, and IR
+  emission, so editor types no longer vary with an environment condition.
+  Falsy `plugins` entries remain the explicit way to omit a plugin completely.
+- **Typed plugin presets** — `definePluginPreset()` lets plugin packages expose
+  parameterized, tuple-preserving plugin groups. evjs expands only branded
+  presets, keeps each contained plugin's identity and dependency semantics, and
+  rejects ambiguous raw nested arrays.
+- **Non-activating analysis and narrower contexts** — `prepare` and `inspect`
+  can analyze deterministic IR without running plugin `setup()`. Lifecycle
+  contexts now project plugin and bundler metadata instead of exposing callable
+  plugin hooks or adapter build/dev methods.
 - **Composable plugin defaults** — Application and Page contracts remain
   independent, while authored fields deep-merge over defaults within each
   contract before validation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,22 +129,23 @@ Release automation replaces them with the release version before publishing.
 
 ## Build Pipeline
 
-`ev prepare`, `ev build`, and `ev dev` share the same semantic preparation:
+`ev prepare`, `ev build`, and `ev dev` share the same deterministic analysis:
 
 ```txt
 load config
 run configure methods and resolve Application plugin settings
-run setup hooks
 create CoreGraph while resolving Page plugin settings
 derive BuildPlan
 collect generated contributions
 materialize .ev
 ```
 
-`ev build` then asks the selected bundler for build facts, runs `beforeBuild`,
-links `BuildOutput`, runs output and HTML hooks, writes deployment metadata and
-Documents, and runs `afterBuild`. `ev prepare` and `ev inspect` do not receive
-bundler facts and therefore call neither build-cycle hook.
+`ev build` and `ev dev` additionally activate plugin `setup` hooks before graph
+analysis. `ev build` then asks the selected bundler for build facts, runs
+`beforeBuild`, links `BuildOutput`, runs output and HTML hooks, writes
+deployment metadata and Documents, and runs `afterBuild`. `ev prepare` and
+`ev inspect` do not activate `setup`, allocate plugin resources, or run
+build-cycle hooks.
 
 `ev dev` keeps normal source edits on the bundler watch/HMR path. Framework
 input changes recreate and diff the graph/plan, then call the adapter's

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -176,9 +176,13 @@ sync. A plugin with Application or Page options declares one short `key`.
 CoreGraph uses that same key for its Application and Page setting entries.
 Conditional entries may use `false`, `null`, or `undefined`; inactive entries
 are omitted at runtime. Because they are not guaranteed to install, entries
-with a possible falsy branch do not expose keys to Page config. When the Page
-contract has defaults, use `plugin.withPageOptIn(config)` to keep the plugin
-and its Application options active while every Page opts in explicitly.
+with a possible falsy branch do not expose keys to Page config. Use
+`plugin(config).when(condition, reason?)` instead when the contract and
+generated Page key must remain installed while execution is disabled. Reusable
+typed groups use `definePluginPreset(factory)`; raw nested plugin arrays are
+invalid. When the Page contract has defaults, use
+`plugin.withPageOptIn(config)` to keep the plugin and its Application options
+active while every Page opts in explicitly.
 
 Application configuration may contain typed executable options or explicit
 module references when the plugin contract allows them. Do not put secrets in
@@ -243,6 +247,9 @@ config does not widen the Page registry to `any`; use `ev.config.ts` when Page
 plugin completion is required. Framework commands create the bridge before
 Page graph analysis, and it stays under `src` because ordinary application
 tsconfigs include `src` while excluding generated `.ev` IR.
+Statically known `definePluginPreset()` tuples and `.when()` instances keep
+their keys; conditional falsy entries, conditional preset branches, and
+widened arrays do not claim keys they cannot guarantee.
 
 Application and Page configuration are independent plugin contracts. evjs
 does not merge the object passed to the Application factory into a Page value.

--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -54,9 +54,10 @@ export default defineConfig({
 ```
 
 The `plugins` array preserves installation order among otherwise equivalent
-plugins; declared dependencies and `enforce` tiers may reorder hooks. Factory
-arguments hold Application configuration; there is no parallel top-level
-configuration bag.
+plugins; required dependencies and present optional dependencies may perform a
+stable topological reorder. There is no global pre/post tier spanning unrelated
+plugin stages. Factory arguments hold Application configuration; there is no
+parallel top-level configuration bag.
 
 ## Declare Application and Page Contracts
 
@@ -187,7 +188,9 @@ the plugin declares Application or Page options. The same key identifies both
 contracts and their CoreGraph settings. A hooks-only plugin may omit it. Plugin
 keys and names must each be unique in one Application.
 
-`dependencies`, `optionalDependencies`, and `enforce` control hook ordering.
+`dependencies` names plugins that must be installed and active first.
+`optionalDependencies` adds the same ordering edge only when the named plugin
+is present and active. Otherwise evjs preserves the authored array order.
 Unknown descriptor fields and misspelled hooks are rejected.
 
 Plugin configuration exists only at Application and Page scope. Derive Route or
@@ -238,12 +241,13 @@ export default defineConfig({
 Do not use `configureBundler()` for framework protocol paths. Server functions,
 PPR, and RSC endpoints are derived from `server.basePath`.
 
-After `configure()` finishes, every later `ctx.config` is typed as a deeply
-read-only view of the resolved framework config. evjs also supplies a detached,
-frozen snapshot at runtime so JavaScript plugins cannot mutate the active
-framework config through that view. `configureBundler()` may mutate only its
-explicit bundler-config argument. Plugin authors should keep framework
-configuration changes in this one validated phase.
+After `configure()` finishes, every later `ctx.config` is a detached, frozen
+metadata view of the resolved framework config. Installed plugins expose only
+their identity, key, and activation state; the selected bundler exposes only
+its name and capabilities. Callable plugin hooks and adapter build/dev methods
+are not projected through another plugin's context. `configureBundler()` may
+mutate only its explicit bundler-config argument. Plugin authors should keep
+framework configuration changes in this one validated phase.
 
 ## Initialize Shared State in `setup()`
 
@@ -287,18 +291,24 @@ hook-specific contracts.
 
 ## Installation and Execution Modes
 
-The factory controls Page omission without changing plugin execution or typed
-Application options:
+The normal and `withPageOptIn()` factory forms control Page omission without
+changing typed Application options. `.when()` separately controls whether the
+installed plugin executes:
 
 - `plugin(options)` installs and executes the plugin; Pages with defaults are
   enabled when their key is omitted;
 - for a Page contract with defaults, `plugin.withPageOptIn(options)` installs and
   executes the same plugin with the same Application options, but every Page
   must opt in with `true` or an object;
+- `plugin(options).when(condition, reason?)` keeps the contracts and generated
+  Page types installed, but a false condition disables owner settings and skips
+  `configure()`, `setup()`, and IR emission;
 - a `false`, `null`, or `undefined` entry in `config.plugins` omits the whole
   plugin and executes no plugin hook.
 
 Required Application options stay required in either available factory form.
+Reusable typed groups should be created with `definePluginPreset(factory)`;
+bare nested arrays and asynchronous preset results are rejected.
 
 ## Choose the Right Extension Point
 

--- a/docs/docs/plugin-hooks.md
+++ b/docs/docs/plugin-hooks.md
@@ -82,8 +82,9 @@ linked and stabilized. A failed output cycle does not call `afterBuild()`.
 Because that output is already published, an `afterBuild()` failure in dev is
 reported as a warning while the published snapshot stays active and server
 activation continues; the same failure still fails a production build.
-`ev prepare` and `ev inspect` do not produce bundler facts, so neither command
-calls `beforeBuild()` or `afterBuild()`.
+`ev prepare` and `ev inspect` are non-activating analysis commands: they run
+`configure()` and deterministic IR emission, but do not run `setup()`,
+`beforeBuild()`, `afterBuild()`, or `dispose()`.
 
 The `setup()` and IR-emission contexts expose `addWatchFile()` for analysis
 dependencies. Build-cycle, output, HTML, and disposal contexts do not. Changing
@@ -103,11 +104,11 @@ cannot prove it produced fresh facts for them.
 
 ## Disposal
 
-`dispose()` tears down resources allocated by `setup()`. It runs when a
-prepared plugin snapshot is no longer active: after a one-shot command such as
-`build` or `prepare`, when a dev session stops, or after a successful config
-reload replaces the previous snapshot. It does not run after every dev
-rebuild.
+`dispose()` tears down resources allocated by `setup()`. It runs when an
+activated plugin snapshot is no longer active: after a one-shot `build`, when a
+dev session stops, or after a successful config reload replaces the previous
+snapshot. It does not run after every dev rebuild. Non-activating `prepare` and
+`inspect` commands have no setup resources to dispose.
 
 Use it for resources whose lifetime extends beyond one hook call, such as file
 watchers, timers, worker processes, sockets, or temporary service handles.

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -27,6 +27,30 @@ The `plugins` array is the ordered installation boundary. Configuration stays
 in each factory call, so there is no separate extension bag or repeated package
 key.
 
+Plugin packages can expose a typed group without asking applications to manage
+its internal members:
+
+```ts
+import { definePluginPreset } from "@evjs/ev/plugin";
+
+export const observability = definePluginPreset(
+  (options: ObservabilityOptions) => [
+    analytics(options.analytics),
+    monitoring(options.monitoring),
+  ],
+);
+```
+
+The application still installs one explicit entry:
+
+```ts
+plugins: [observability({ analytics: {}, monitoring: {} })]
+```
+
+Only `definePluginPreset()` results are expanded. Raw nested arrays and
+asynchronous preset results are rejected, so runtime installation and generated
+Page types are derived from the same deterministic tuple.
+
 ## Configure a Page
 
 Put Page behavior next to the Page and use the plugin's short key:
@@ -86,6 +110,7 @@ Application options. They differ only in what an omitted key on a Page means:
 |---|---|
 | `analytics(config)` | Install and execute the plugin. An omitted Page uses Page defaults when they exist; otherwise that Page is off. |
 | `analytics.withPageOptIn(config)` | For a Page contract with defaults, install and execute the plugin but require every Page to opt in explicitly. |
+| `analytics(config).when(condition, reason?)` | Keep the plugin and its Page types installed, but skip all executable plugin stages when the condition is false. |
 | `false`, `null`, or `undefined` in `plugins` | Omit the whole plugin conditionally; no plugin hook executes. |
 | `analytics` omitted on a Page after `analytics(config)` | Enable with Page defaults when the Page contract has defaults; otherwise disable that Page. |
 | `analytics` omitted on a Page after `analytics.withPageOptIn(config)` | Disable that Page, even when Page defaults exist. |
@@ -129,7 +154,24 @@ contract defaults, install the plugin normally, and set `analytics: false` on
 exceptions. A Page contract without defaults always treats omission as off and
 requires an object to enable the Page.
 
-For a build-only condition, use a falsy array entry:
+When Page config must remain typed across environments, keep the plugin
+installed and conditionally execute it:
+
+```ts
+plugins: [
+  analytics(options).when(
+    process.env.ANALYTICS === "1",
+    "ANALYTICS is not enabled",
+  ),
+]
+```
+
+A false condition disables its Application and Page settings and skips
+`configure()`, `setup()`, and IR emission. `ev inspect` reports the plugin as
+inactive with the supplied reason, while `src/plugin-types.d.ts` still includes
+its Page key.
+
+Use a falsy entry only when the plugin should be omitted completely:
 
 ```ts
 plugins: [process.env.ANALYTICS === "1" && analytics(options)]
@@ -137,16 +179,15 @@ plugins: [process.env.ANALYTICS === "1" && analytics(options)]
 
 A plugin with a possible falsy branch is not statically guaranteed to be
 installed, so its key is intentionally unavailable to Page config. Use this
-form for whole-plugin conditions that have no Page settings. When Pages
-configure the plugin, install it deterministically and use `analytics: false`
-or `withPageOptIn()` for Page-specific activation.
+form for whole-plugin conditions that have no Page settings.
 
 Plugin keys are derived only from the definite entries of the tuple inferred by
 `defineConfig()`. A widened plugin array, a conditional choice between arrays,
 or a conditional choice between whole config objects cannot prove that an
 entry exists and therefore exposes no key to Page config. Keep
 Page-configurable plugins directly in the
-`defineConfig({ plugins: [...] })` tuple.
+`defineConfig({ plugins: [...] })` tuple or in a statically known
+`definePluginPreset()` result.
 
 ## Type Safety and Validation
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/config.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/config.md
@@ -164,8 +164,11 @@ export default defineConfig({
 options，就要提供一个短 `key`；CoreGraph 中的 Application 与 Page setting entry
 都使用这个 key。条件项可以使用 `false`、`null` 或 `undefined`；运行时会忽略这些
 非活跃项。可能进入 falsy 分支的条目不保证安装，因此不会向 Page config 暴露 key。
-Page 合同有 defaults，且插件与 Application options 需要保持启用、但每个 Page
-必须显式 opt in 时，使用 `plugin.withPageOptIn(config)`。
+合同与生成的 Page key 需要保持安装、但本次不执行插件时，改用
+`plugin(config).when(condition, reason?)`。可复用的类型安全组合使用
+`definePluginPreset(factory)`；裸嵌套插件数组无效。Page 合同有 defaults，且插件与
+Application options 需要保持启用、但每个 Page 必须显式 opt in 时，使用
+`plugin.withPageOptIn(config)`。
 
 插件合同允许时，Application 配置可以包含类型安全的可执行选项或显式模块引用。
 不要把 secret 放进插件会投影到 generated file 或浏览器 runtime 的值中。
@@ -227,6 +230,8 @@ evjs 构建 graph 时同步求值该 module。它必须 default-export plain obj
 插件补全时请使用 `ev.config.ts`。Framework 命令会在 Page graph analysis 前生成该
 桥接；它保留在 `src` 下，因为普通应用 tsconfig 会包含 `src`，同时排除生成的 `.ev`
 IR。
+静态确定的 `definePluginPreset()` tuple 与 `.when()` instance 会保留 key；条件 falsy
+条目、条件 preset 分支与 widened array 不会声明无法保证存在的 key。
 
 Application 与 Page 配置是两个独立的插件合同。evjs 不会把 Application 工厂的
 对象合并到 Page value。在任一合同内部，authoring 字段会先深度合并到该合同的

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugin-authoring.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugin-authoring.md
@@ -48,9 +48,9 @@ export default defineConfig({
 });
 ```
 
-对于其他条件相同的插件，`plugins` 数组保留安装顺序；声明的 dependencies 与
-`enforce` 层级可以重排 hooks。工厂参数承载 Application 配置，不再维护并行的顶层
-配置 bag。
+对于其他条件相同的插件，`plugins` 数组保留安装顺序；required dependency 与当前存在的
+optional dependency 会进行稳定拓扑排序。框架不再把一个全局 pre/post 层级投影到彼此
+无关的插件阶段。工厂参数承载 Application 配置，不再维护并行的顶层配置 bag。
 
 ## 声明 Application 与 Page 合同
 
@@ -164,8 +164,9 @@ symbol、bigint、非有限数值、class instance、稀疏数组与循环引用
 标识两份合同及其 CoreGraph setting；纯 hooks 插件可以省略。一个 Application 中的
 plugin name 与 plugin key 都必须分别唯一。
 
-`dependencies`、`optionalDependencies` 与 `enforce` 控制 hook 顺序。未知 descriptor
-字段与拼错的 hook 会被拒绝。
+`dependencies` 指定必须先安装且保持 active 的插件。`optionalDependencies` 只在目标
+插件存在且 active 时增加同样的顺序边；其他情况保留 authored array 顺序。未知
+descriptor 字段与拼错的 hook 会被拒绝。
 
 插件配置只存在于 Application 与 Page scope。在 graph analysis 阶段根据已启用 Page
 派生 Route/Document 效果，再通过 [generated contributions](./generated-contributions)
@@ -212,10 +213,11 @@ export default defineConfig({
 不要用 `configureBundler()` 修改框架协议路径。Server function、PPR 和 RSC endpoint
 都从 `server.basePath` 派生。
 
-`configure()` 完成后，后续阶段的 `ctx.config` 在类型上都是 resolved framework config 的
-深度只读视图；运行时也会收到隔离且冻结的快照，因此 JavaScript 插件无法通过该视图修改
-当前生效的 framework 配置。`configureBundler()` 只能修改其显式传入的 bundler config
-参数。插件作者应把 framework 配置变更都放在这个经过校验的阶段。
+`configure()` 完成后，后续阶段的 `ctx.config` 是 resolved framework config 的隔离、
+冻结 metadata 视图。已安装插件只暴露 identity、key 与 activation state；选中的 bundler
+只暴露 name 与 capabilities。其他插件的 callable hooks 和 adapter build/dev 方法不会
+通过 context 泄露。`configureBundler()` 只能修改其显式传入的 bundler config 参数。
+插件作者应把 framework 配置变更都放在这个经过校验的阶段。
 
 ## 在 `setup()` 中初始化共享状态
 
@@ -254,15 +256,20 @@ settle 前完成注册。
 
 ## 安装与执行模式
 
-工厂只控制 Page 省略语义，不改变插件执行和类型安全的 Application options：
+普通工厂与 `withPageOptIn()` 控制 Page 省略语义，不改变类型安全的 Application
+options；`.when()` 单独控制已安装插件本次是否执行：
 
 - `plugin(options)` 安装并执行插件；Page 有 defaults 时，省略 key 会启用该 Page；
 - Page 合同有 defaults 时，`plugin.withPageOptIn(options)` 使用相同 Application options
   安装并执行同一个插件，但每个 Page 都必须通过 `true` 或 object 显式启用；
+- `plugin(options).when(condition, reason?)` 保持合同与生成的 Page 类型已安装；条件为
+  false 时关闭 owner settings，并跳过 `configure()`、`setup()` 与 IR emission；
 - `config.plugins` 中的 `false`、`null` 或 `undefined` 会省略整个插件，不执行任何插件
   hook。
 
 无论使用哪种可用工厂写法，必填 Application 参数都保持必填。
+可复用的类型安全组合应使用 `definePluginPreset(factory)`；裸嵌套数组和异步 preset
+结果会被拒绝。
 
 ## 选择合适的扩展点
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugin-hooks.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugin-hooks.md
@@ -78,8 +78,9 @@ hook 内可见，不会改变后续 hook 或 deployment adapter 收到的输入�
 framework output 完成 link 并稳定后调用；output 周期失败时不调用 `afterBuild()`。
 由于此时 output 已发布，dev 中的 `afterBuild()` 失败只会报告 warning，已发布快照仍
 保持 active，server activation 也会继续；同样的失败在 production build 中仍会使构建失败。
-`ev prepare` 与 `ev inspect` 不会产生 bundler facts，因此都不会调用 `beforeBuild()`
-或 `afterBuild()`。
+`ev prepare` 与 `ev inspect` 是非激活的 analysis 命令：它们会运行 `configure()` 与
+确定性的 IR emission，但不会运行 `setup()`、`beforeBuild()`、`afterBuild()` 或
+`dispose()`。
 
 `setup()` 与 IR emission context 提供 `addWatchFile()` 来注册 analysis 依赖；
 build-cycle、output、HTML 与 dispose context 不提供它。文件变化时，框架复用已提交的
@@ -95,9 +96,10 @@ adapter 无法安全地原地替换配置，更新会 fail-closed 并明确提�
 
 ## 资源释放
 
-`dispose()` 用于释放 `setup()` 创建的资源。Prepared plugin snapshot 不再活跃时会调用
-它：一次性 `build` 或 `prepare` 命令结束后、dev session 停止时，或成功的 config
-reload 用新快照替换旧快照后。它不会在每次 dev rebuild 后执行。
+`dispose()` 用于释放 `setup()` 创建的资源。Activated plugin snapshot 不再活跃时会调用
+它：一次性 `build` 结束后、dev session 停止时，或成功的 config reload 用新快照替换旧
+快照后。它不会在每次 dev rebuild 后执行。非激活的 `prepare` 与 `inspect` 没有 setup
+资源需要释放。
 
 适合在这里关闭跨多个 hook 调用存活的 file watcher、timer、worker process、socket
 或临时 service handle；普通内存值无需清理。对于在 `setup()` 中取得的资源，应立即

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugins.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugins.md
@@ -24,6 +24,28 @@ export default defineConfig({
 `plugins` 数组是有序安装边界。配置直接放在各工厂调用中，因此不需要另一份 extension
 bag，也不需要重复 package key。
 
+插件包可以对外提供类型安全的插件组合，而不要求应用管理其内部成员：
+
+```ts
+import { definePluginPreset } from "@evjs/ev/plugin";
+
+export const observability = definePluginPreset(
+  (options: ObservabilityOptions) => [
+    analytics(options.analytics),
+    monitoring(options.monitoring),
+  ],
+);
+```
+
+应用仍然只安装一个显式条目：
+
+```ts
+plugins: [observability({ analytics: {}, monitoring: {} })]
+```
+
+evjs 只展开 `definePluginPreset()` 的结果。裸嵌套数组和异步 preset 结果会被拒绝，
+确保 runtime 安装结果与生成的 Page 类型来自同一个确定 tuple。
+
 ## 配置 Page
 
 把页面行为放在 Page 旁边，并使用插件的短 key：
@@ -75,6 +97,7 @@ Application 配置与 Page 配置是两份独立的类型合同：
 |---|---|
 | `analytics(config)` | 安装并执行插件。Page 有 defaults 时，省略 key 会使用 defaults；否则该 Page 关闭。 |
 | `analytics.withPageOptIn(config)` | Page 合同有 defaults 时，使用同一份 Application options 安装并执行插件，但要求每个 Page 显式启用。 |
+| `analytics(config).when(condition, reason?)` | 保持插件和 Page 类型已安装；条件为 false 时跳过所有可执行插件阶段。 |
 | `plugins` 中的 `false`、`null` 或 `undefined` | 条件式省略整个插件；不执行任何插件 hook。 |
 | `analytics(config)` 后 Page 省略 key | Page 合同有 defaults 时用 defaults 启用；否则关闭该 Page。 |
 | `analytics.withPageOptIn(config)` 后 Page 省略 key | 即使 Page 有 defaults，也关闭该 Page。 |
@@ -116,20 +139,35 @@ export default definePageConfig({
 例外 Page 中设置 `analytics: false`。没有 defaults 的 Page 合同始终把省略视为关闭，
 并要求通过 object 启用 Page。
 
-对于构建期条件，直接使用 falsy 数组项：
+Page config 需要在不同环境中保持类型稳定时，保留安装并按条件执行插件：
+
+```ts
+plugins: [
+  analytics(options).when(
+    process.env.ANALYTICS === "1",
+    "ANALYTICS is not enabled",
+  ),
+]
+```
+
+条件为 false 时，Application 与 Page setting 都会关闭，并跳过 `configure()`、
+`setup()` 与 IR emission。`ev inspect` 会展示 inactive 状态和原因，而
+`src/plugin-types.d.ts` 仍包含对应 Page key。
+
+只有需要彻底省略插件时才使用 falsy 条目：
 
 ```ts
 plugins: [process.env.ANALYTICS === "1" && analytics(options)]
 ```
 
 可能进入 falsy 分支的插件并不保证安装，因此不会向 Page config 暴露 key。这种写法
-适用于没有 Page setting 的整插件条件。Page 需要配置插件时，应确定性安装插件，再用
-`analytics: false` 或 `withPageOptIn()` 控制 Page 级启用。
+适用于没有 Page setting 的整插件条件。
 
 Plugin key 只从 `defineConfig()` 推导出的 tuple 中确定存在的条目生成。宽化后的 plugin
 array、在多个 array 之间做条件选择，或在多个完整 config object 之间做条件选择，都
 无法证明某个条目一定存在，因此不会向 Page config 暴露 key。需要 Page 配置的插件应
-直接保留在 `defineConfig({ plugins: [...] })` tuple 中。
+直接保留在 `defineConfig({ plugins: [...] })` tuple 或静态确定的
+`definePluginPreset()` 结果中。
 
 ## 类型安全与校验
 

--- a/examples/plugin-authoring/README.md
+++ b/examples/plugin-authoring/README.md
@@ -4,8 +4,10 @@ Demonstrates the typed evjs plugin factory together with ordinary build-time
 lifecycle hooks.
 
 - **`definePlugin()`** — declare a stable `name`, plus one short `key` whenever Application or Page options exist, and return an installable factory
+- **`definePluginPreset()`** — expose a parameterized, tuple-preserving group of plugins as one application entry
 - **`pluginOptions()`** — declare independent, type-safe Application and Page option contracts
-- **`plugins: [metadataPlugin(config)]`** — install and configure the Application in one expression
+- **`.when(condition, reason)`** — retain the plugin contract and Page key while conditionally skipping execution
+- **`plugins: [examplePlugins(config)]`** — install and configure the typed preset in one expression
 - **`page.config.ts#plugins.metadata`** — configure a Page with the short plugin key and no plugin import
 - **`src/plugin-types.d.ts`** — generated under the tsconfig-included `src` directory as a stable bridge to the static `ev.config.ts` type for Page editor types
 - **`setup`** — read the resolved Application setting before graph analysis

--- a/examples/plugin-authoring/ev.config.ts
+++ b/examples/plugin-authoring/ev.config.ts
@@ -1,6 +1,10 @@
 import { merge, utoopack } from "@evjs/bundler-utoopack";
 import { defineConfig } from "@evjs/ev";
-import { definePlugin, pluginOptions } from "@evjs/ev/plugin";
+import {
+  definePlugin,
+  definePluginPreset,
+  pluginOptions,
+} from "@evjs/ev/plugin";
 
 type ApplicationMetadata = {
   channel: string;
@@ -84,6 +88,14 @@ const txtPlugin = definePlugin({
   },
 });
 
+const examplePlugins = definePluginPreset((metadata: ApplicationMetadata) => [
+  metadataPlugin(metadata).when(
+    process.env.EXAMPLE_METADATA !== "off",
+    "EXAMPLE_METADATA is set to off",
+  ),
+  txtPlugin(),
+]);
+
 /**
  * Example: evjs plugin system.
  *
@@ -96,5 +108,5 @@ const txtPlugin = definePlugin({
  */
 export default defineConfig({
   routing: { mode: "spa" },
-  plugins: [metadataPlugin({ channel: "web" }), txtPlugin()],
+  plugins: [examplePlugins({ channel: "web" })],
 });

--- a/packages/bundler-utoopack/tests/create-config.test.ts
+++ b/packages/bundler-utoopack/tests/create-config.test.ts
@@ -5,7 +5,6 @@ import {
   createBuildPlan,
   materializeFrameworkIR,
 } from "@evjs/ev/_internal/build";
-import type { Plugin } from "@evjs/ev/plugin";
 import type {
   BuildPlan,
   CoreGraph,
@@ -148,8 +147,11 @@ describe("createUtoopackConfig", () => {
   });
 
   it("resolves generated alias contributions directly to generated files", async () => {
-    const plugin: Plugin<ConfigComplete> = {
+    const plugin: Parameters<
+      typeof createUtoopackConfig
+    >[0]["plugins"][number] = {
       name: "generated-alias",
+      active: true,
       emitIR(ctx) {
         const configModule = ctx.emit.data({
           id: "config",

--- a/packages/bundler-webpack/tests/create-config.test.ts
+++ b/packages/bundler-webpack/tests/create-config.test.ts
@@ -7,7 +7,6 @@ import {
   materializeFrameworkIR,
 } from "@evjs/ev/_internal/build";
 import type { ResolvedConfig } from "@evjs/ev/config";
-import type { Plugin } from "@evjs/ev/plugin";
 import type {
   CoreGraph,
   CoreRoutePattern,
@@ -580,8 +579,9 @@ describe("createWebpackConfigs", () => {
   });
 
   it("resolves generated alias contributions directly to generated files", async () => {
-    const plugin: Plugin<WebpackConfig> = {
+    const plugin: ResolvedConfig<WebpackConfig>["plugins"][number] = {
       name: "generated-alias",
+      active: true,
       emitIR(ctx) {
         const configModule = ctx.emit.data({
           id: "config",

--- a/packages/cli/src/inspect.ts
+++ b/packages/cli/src/inspect.ts
@@ -89,6 +89,29 @@ export function formatInspectText(result: InspectFrameworkBuildResult): string {
       `${document.id}: application=${document.applicationId}, owner=${document.owner.kind}, output=${document.output}`,
   );
 
+  appendList(lines, "Plugin Plan", result.plugins, (plugin) => {
+    const status = plugin.active
+      ? "active"
+      : `inactive${plugin.inactiveReason ? ` (${plugin.inactiveReason})` : ""}`;
+    const metadata = [
+      `order=${plugin.order}`,
+      status,
+      plugin.key ? `key=${plugin.key}` : undefined,
+      plugin.dependencies.length > 0
+        ? `dependencies=${plugin.dependencies.join(",")}`
+        : undefined,
+      plugin.optionalDependencies.length > 0
+        ? `optionalDependencies=${plugin.optionalDependencies.join(",")}`
+        : undefined,
+      plugin.declaredStages.length > 0
+        ? `declares=${plugin.declaredStages.join(",")}`
+        : "declares=none",
+    ]
+      .filter(Boolean)
+      .join(", ");
+    return `${formatCoreIdentifier(plugin.name)}: ${metadata}`;
+  });
+
   appendList(
     lines,
     "Plugins",

--- a/packages/cli/tests/inspect.test.ts
+++ b/packages/cli/tests/inspect.test.ts
@@ -437,9 +437,24 @@ describe("inspect", () => {
       "index.html": '<div id="app"></div>',
       "src/main.tsx": "console.log('app');",
     });
+    const events: string[] = [];
     const plugin: Plugin<Record<string, never>> = {
       name: "inspect-contribution",
+      configure(config) {
+        events.push("configure");
+        return config;
+      },
+      setup() {
+        events.push("setup");
+        return {
+          dispose() {
+            events.push("dispose");
+          },
+        };
+      },
       emitIR(ctx) {
+        events.push("emitIR");
+        ctx.addWatchFile("./inspect-input.json");
         const module = ctx.emit.module({
           id: "entry",
           scope: { kind: "application" },
@@ -477,6 +492,23 @@ describe("inspect", () => {
         }),
       ]),
     );
+    expect(result.pluginWatchFiles).toEqual([
+      path.join(cwd, "inspect-input.json"),
+    ]);
+    expect(result.plugins).toEqual([
+      {
+        order: 0,
+        name: "inspect-contribution",
+        active: true,
+        dependencies: [],
+        optionalDependencies: [],
+        declaredStages: ["configure", "setup", "emitIR"],
+      },
+    ]);
+    expect(formatInspectText(result)).toContain(
+      "inspect-contribution: order=0, active, declares=configure,setup,emitIR",
+    );
+    expect(events).toEqual(["configure", "emitIR"]);
     await expectPathMissing(path.join(cwd, ".ev"));
   });
 

--- a/packages/ev/src/_internal/build/commands.ts
+++ b/packages/ev/src/_internal/build/commands.ts
@@ -18,7 +18,6 @@ import {
   resolveBundlerConfig,
   resolveConfig,
 } from "../../config/index.js";
-import { createDefinedPluginApplicationSettingSnapshot } from "../../plugin/defined.js";
 import type {
   CliFlags,
   PluginContext,
@@ -239,6 +238,7 @@ export {
   type InspectFrameworkBuildResult,
   type InspectHtmlDocument,
   type InspectPageRoute,
+  type InspectPlugin,
   type InspectRouteFile,
   inspectFrameworkBuild,
 } from "./inspect.js";
@@ -246,6 +246,7 @@ export {
 interface InternalPrepareFrameworkBuildOptions<
   TBundlerCfg = DefaultBundlerConfig,
 > extends PrepareFrameworkBuildOptions<TBundlerCfg> {
+  activatePluginSetup: boolean;
   plan?: CreateBuildPlanOptions;
 }
 
@@ -557,8 +558,8 @@ function formatGraphDiagnostic(diagnostic: {
 async function prepareInternalFrameworkBuild<
   TBundlerCfg = DefaultBundlerConfig,
 >(
-  userConfig?: Config<TBundlerCfg>,
-  options: InternalPrepareFrameworkBuildOptions<TBundlerCfg> = {},
+  userConfig: Config<TBundlerCfg> | undefined,
+  options: InternalPrepareFrameworkBuildOptions<TBundlerCfg>,
 ): Promise<InternalPreparedFrameworkBuild<TBundlerCfg>> {
   const cwd = options.cwd ?? process.cwd();
   const command =
@@ -613,9 +614,7 @@ async function prepareInternalFrameworkBuild<
   const {
     registry: pluginSettings,
     applicationSettings: applicationPluginSettings,
-  } = resolvePluginSettingsState(baseConfig, undefined, {
-    reusePreparedApplicationSettings: true,
-  });
+  } = resolvePluginSettingsState(baseConfig);
   const config = baseConfig;
   const pluginWatchFiles = new Set<string>();
   const pluginContext: MutablePluginSetupContext<TBundlerCfg> = {
@@ -629,7 +628,9 @@ async function prepareInternalFrameworkBuild<
       pluginWatchFiles.add(path.resolve(cwd, file));
     },
   };
-  const hooks = await collectPluginHooks(config.plugins, pluginContext);
+  const hooks = options.activatePluginSetup
+    ? await collectPluginHooks(config.plugins, pluginContext)
+    : [];
   let disposed = false;
   const dispose = async () => {
     if (disposed) return;
@@ -679,7 +680,10 @@ export async function prepareFrameworkBuild<TBundlerCfg = DefaultBundlerConfig>(
 ): Promise<PreparedFrameworkBuild<TBundlerCfg>> {
   const cwd = options.cwd ?? process.cwd();
   return withProjectOperationLock(cwd, "prepare", async () => {
-    const prepared = await prepareInternalFrameworkBuild(userConfig, options);
+    const prepared = await prepareInternalFrameworkBuild(userConfig, {
+      ...options,
+      activatePluginSetup: false,
+    });
     return {
       cwd: prepared.cwd,
       mode: prepared.mode,
@@ -900,11 +904,8 @@ async function runDevSession<TBundlerCfg = DefaultBundlerConfig>(
 
   const bundler = resolveBundler(resolvedConfig.bundler, options?.bundler);
   const baseActiveConfig = withActiveBundler(resolvedConfig, bundler);
-  const initialPluginSettingsState = resolvePluginSettingsState(
-    baseActiveConfig,
-    undefined,
-    { reusePreparedApplicationSettings: true },
-  );
+  const initialPluginSettingsState =
+    resolvePluginSettingsState(baseActiveConfig);
   let activePluginSettings = initialPluginSettingsState.registry;
   let activeApplicationPluginSettings =
     initialPluginSettingsState.applicationSettings;
@@ -1377,9 +1378,6 @@ async function runDevSession<TBundlerCfg = DefaultBundlerConfig>(
     const reason: BuildPlanUpdate["reason"] = requiresBundlerConfigReload
       ? "config"
       : "route-declaration";
-    const applicationSettingSnapshot = requiresBundlerConfigReload
-      ? createDefinedPluginApplicationSettingSnapshot(activeConfig.plugins)
-      : undefined;
     let stagedPluginHooks:
       | Awaited<ReturnType<typeof stagePluginHooks>>
       | undefined;
@@ -1398,7 +1396,6 @@ async function runDevSession<TBundlerCfg = DefaultBundlerConfig>(
       runCleanupTasks([
         () => stagedPluginHooks?.rollback(),
         () => generatedStateSnapshot?.restore(),
-        () => applicationSettingSnapshot?.restore(),
       ]);
 
     try {
@@ -1434,7 +1431,6 @@ async function runDevSession<TBundlerCfg = DefaultBundlerConfig>(
         const nextPluginSettingsState = resolvePluginSettingsState(
           baseNextConfig,
           nextPluginSettings,
-          { reusePreparedApplicationSettings: true },
         );
         nextApplicationPluginSettings =
           nextPluginSettingsState.applicationSettings;
@@ -1516,7 +1512,6 @@ async function runDevSession<TBundlerCfg = DefaultBundlerConfig>(
         candidateCommitted = true;
         await commitStagedPluginHooks(stagedPluginHooks);
         await nextGeneratedStateSnapshot.commit();
-        applicationSettingSnapshot?.commit();
       };
 
       const previousConfig = activeConfig;
@@ -1755,6 +1750,7 @@ async function runBuild<TBundlerCfg = DefaultBundlerConfig>(
     bundler: options?.bundler,
     flags: options?.flags,
     requireBundler: true,
+    activatePluginSetup: true,
   });
   const bundler = prepared.config.bundler;
   if (!bundler) {

--- a/packages/ev/src/_internal/build/index.ts
+++ b/packages/ev/src/_internal/build/index.ts
@@ -33,6 +33,7 @@ export {
   type InspectFrameworkBuildResult,
   type InspectHtmlDocument,
   type InspectPageRoute,
+  type InspectPlugin,
   type InspectRouteFile,
   inspectFrameworkBuild,
   type PreparedFrameworkBuild,

--- a/packages/ev/src/_internal/build/inspect.ts
+++ b/packages/ev/src/_internal/build/inspect.ts
@@ -12,6 +12,7 @@ import {
   resolveBundlerConfig,
   resolveConfig,
 } from "../../config/index.js";
+import { getDefinedPluginDeclaration } from "../../plugin/defined.js";
 import type { CliFlags, PluginContext } from "../../plugin/index.js";
 import { analyzeAndMaterializeFrameworkIR } from "./analyze-and-materialize.js";
 import {
@@ -34,10 +35,8 @@ import { CANONICAL_PAGE_ROUTE_ROOT } from "./page-route-conventions.js";
 import { createPageRouteNodesFromCoreGraph } from "./page-route-types.js";
 import type { PageRouteDiscovery } from "./page-routes.js";
 import {
-  collectPluginHooks,
   orderPluginsByDependencies,
   runConfigureHooks,
-  runDisposeHooks,
 } from "./plugin-lifecycle.js";
 import { resolvePluginSettingsState } from "./plugin-settings.js";
 import { toProjectPath } from "./utils.js";
@@ -101,6 +100,19 @@ export interface InspectHtmlDocument {
   owner: unknown;
 }
 
+export interface InspectPlugin {
+  /** Position after stable dependency ordering. */
+  order: number;
+  name: string;
+  key?: string;
+  active: boolean;
+  inactiveReason?: string;
+  dependencies: string[];
+  optionalDependencies: string[];
+  /** Descriptor stages declared by the plugin, without activating setup(). */
+  declaredStages: Array<"configure" | "setup" | "emitIR">;
+}
+
 export interface InspectFrameworkBuildResult {
   cwd: string;
   mode: "development" | "production";
@@ -138,6 +150,8 @@ export interface InspectFrameworkBuildResult {
     html: InspectHtmlDocument[];
     generated?: GeneratedFrameworkPlan;
   };
+  /** Installed plugins and their non-activating execution plan. */
+  plugins: InspectPlugin[];
   diagnostics: InspectDiagnostic[];
   fileDependencies: string[];
   pluginWatchFiles: string[];
@@ -242,10 +256,32 @@ export async function inspectFrameworkBuild<TBundlerCfg = DefaultBundlerConfig>(
   const {
     registry: pluginSettings,
     applicationSettings: applicationPluginSettings,
-  } = resolvePluginSettingsState(baseConfig, undefined, {
-    reusePreparedApplicationSettings: true,
-  });
+  } = resolvePluginSettingsState(baseConfig);
   const config = baseConfig;
+  const plugins = config.plugins.map((plugin, order): InspectPlugin => {
+    const declaration = getDefinedPluginDeclaration(plugin);
+    return {
+      order,
+      name: plugin.name,
+      ...(declaration?.key ? { key: declaration.key } : {}),
+      active: declaration?.active ?? true,
+      ...(declaration?.inactiveReason
+        ? { inactiveReason: declaration.inactiveReason }
+        : {}),
+      dependencies: [...(plugin.dependencies ?? [])],
+      optionalDependencies: [...(plugin.optionalDependencies ?? [])],
+      declaredStages: declaration
+        ? [...declaration.stages]
+        : [
+            plugin.configure ? ("configure" as const) : undefined,
+            plugin.setup ? ("setup" as const) : undefined,
+            plugin.emitIR ? ("emitIR" as const) : undefined,
+          ].filter(
+            (stage): stage is "configure" | "setup" | "emitIR" =>
+              stage !== undefined,
+          ),
+    };
+  });
   const pluginWatchFiles = new Set<string>();
   const pluginContext: PluginContext<TBundlerCfg> = {
     mode,
@@ -258,130 +294,119 @@ export async function inspectFrameworkBuild<TBundlerCfg = DefaultBundlerConfig>(
       pluginWatchFiles.add(path.resolve(cwd, file));
     },
   };
-  const hooks = await collectPluginHooks(config.plugins, pluginContext);
-  let disposed = false;
-  const dispose = async () => {
-    if (disposed) return;
-    disposed = true;
-    await runDisposeHooks(hooks, pluginContext);
-  };
-
   try {
-    try {
-      validateHtmlTemplates(cwd, config);
-    } catch (err) {
-      diagnostics.push({
-        level: "error",
-        source: "html",
-        message: formatInspectError(err),
-      });
-    }
+    validateHtmlTemplates(cwd, config);
+  } catch (err) {
+    diagnostics.push({
+      level: "error",
+      source: "html",
+      message: formatInspectError(err),
+    });
+  }
 
-    let analysis: Awaited<ReturnType<typeof createCoreGraph>>;
-    let latestAnalysis: Awaited<ReturnType<typeof createCoreGraph>> | undefined;
-    let plan: BuildPlan | undefined;
-    try {
-      const materialized = await analyzeAndMaterializeFrameworkIR({
-        cwd,
-        mode,
-        command,
-        config,
-        pluginContext,
-        pluginSettings,
-        applicationPluginSettings,
-        write: false,
-        onAnalysis(currentAnalysis) {
-          latestAnalysis = currentAnalysis;
-        },
-      });
-      analysis = materialized.analysis;
-      plan = materialized.plan;
-    } catch (err) {
-      analysis =
-        latestAnalysis ??
-        (await createCoreGraph(config, cwd, {
-          pluginSettings,
-          applicationPluginSettings,
-        }));
-      diagnostics.push({
-        level: "error",
-        source: "contributions",
-        message: formatInspectError(err),
-      });
-    }
-    diagnostics.push(
-      ...analysis.diagnostics.map((diagnostic) =>
-        toInspectDiagnostic("graph", diagnostic),
-      ),
-    );
-    const bundlerGaps =
-      bundler && plan ? getBundlerBuildCapabilityGaps(bundler, plan) : [];
-    diagnostics.push(
-      ...bundlerGaps.map((gap) => ({
-        level: "error" as const,
-        source: "bundler" as const,
-        message: `Bundler "${bundler?.name}" lacks ${gap.capability}: ${gap.reason}.`,
-      })),
-    );
-
-    return {
+  let analysis: Awaited<ReturnType<typeof createCoreGraph>>;
+  let latestAnalysis: Awaited<ReturnType<typeof createCoreGraph>> | undefined;
+  let plan: BuildPlan | undefined;
+  try {
+    const materialized = await analyzeAndMaterializeFrameworkIR({
       cwd,
       mode,
       command,
-      routing: createInspectRouting(config, analysis.graph),
-      pageRoutes: createPageRouteNodesFromCoreGraph(analysis.graph).map(
-        (route) => ({
-          id: route.id,
-          path: route.path,
-          module: route.module,
-        }),
-      ),
-      routeFiles: createInspectRouteFiles(cwd, pageRouteDiscovery, diagnostics),
-      graph: analysis.graph,
-      runtime: {
-        server: config.server.runtime,
-        ...(config.transport.baseUrl ? { transport: config.transport } : {}),
+      config,
+      pluginContext,
+      pluginSettings,
+      applicationPluginSettings,
+      write: false,
+      onAnalysis(currentAnalysis) {
+        latestAnalysis = currentAnalysis;
       },
-      output: {
-        client: config.output.client,
-        server: config.output.server,
-      },
-      ...(bundler
-        ? {
-            bundler: {
-              name: bundler.name,
-              capabilities: {
-                build: { ...bundler.capabilities.build },
-                dev: { ...bundler.capabilities.dev },
-              },
-              gaps: bundlerGaps,
-            },
-          }
-        : {}),
-      buildPlan: plan
-        ? {
-            entries: plan.entries.map((entry) => ({
-              name: entry.name,
-              kind: entry.kind,
-              environment: entry.environment,
-              ...(entry.owner ? { owner: entry.owner } : {}),
-            })),
-            html: plan.html.map((document) => ({
-              id: document.id,
-              fileName: document.fileName,
-              ...(document.aliases ? { aliases: [...document.aliases] } : {}),
-              owner: document.owner,
-            })),
-            ...(plan.generated ? { generated: plan.generated } : {}),
-          }
-        : undefined,
-      diagnostics,
-      fileDependencies: analysis.fileDependencies,
-      pluginWatchFiles: [...pluginWatchFiles].sort(),
-    };
-  } finally {
-    await dispose();
+    });
+    analysis = materialized.analysis;
+    plan = materialized.plan;
+  } catch (err) {
+    analysis =
+      latestAnalysis ??
+      (await createCoreGraph(config, cwd, {
+        pluginSettings,
+        applicationPluginSettings,
+      }));
+    diagnostics.push({
+      level: "error",
+      source: "contributions",
+      message: formatInspectError(err),
+    });
   }
+  diagnostics.push(
+    ...analysis.diagnostics.map((diagnostic) =>
+      toInspectDiagnostic("graph", diagnostic),
+    ),
+  );
+  const bundlerGaps =
+    bundler && plan ? getBundlerBuildCapabilityGaps(bundler, plan) : [];
+  diagnostics.push(
+    ...bundlerGaps.map((gap) => ({
+      level: "error" as const,
+      source: "bundler" as const,
+      message: `Bundler "${bundler?.name}" lacks ${gap.capability}: ${gap.reason}.`,
+    })),
+  );
+
+  return {
+    cwd,
+    mode,
+    command,
+    routing: createInspectRouting(config, analysis.graph),
+    pageRoutes: createPageRouteNodesFromCoreGraph(analysis.graph).map(
+      (route) => ({
+        id: route.id,
+        path: route.path,
+        module: route.module,
+      }),
+    ),
+    routeFiles: createInspectRouteFiles(cwd, pageRouteDiscovery, diagnostics),
+    graph: analysis.graph,
+    runtime: {
+      server: config.server.runtime,
+      ...(config.transport.baseUrl ? { transport: config.transport } : {}),
+    },
+    output: {
+      client: config.output.client,
+      server: config.output.server,
+    },
+    ...(bundler
+      ? {
+          bundler: {
+            name: bundler.name,
+            capabilities: {
+              build: { ...bundler.capabilities.build },
+              dev: { ...bundler.capabilities.dev },
+            },
+            gaps: bundlerGaps,
+          },
+        }
+      : {}),
+    buildPlan: plan
+      ? {
+          entries: plan.entries.map((entry) => ({
+            name: entry.name,
+            kind: entry.kind,
+            environment: entry.environment,
+            ...(entry.owner ? { owner: entry.owner } : {}),
+          })),
+          html: plan.html.map((document) => ({
+            id: document.id,
+            fileName: document.fileName,
+            ...(document.aliases ? { aliases: [...document.aliases] } : {}),
+            owner: document.owner,
+          })),
+          ...(plan.generated ? { generated: plan.generated } : {}),
+        }
+      : undefined,
+    plugins,
+    diagnostics,
+    fileDependencies: analysis.fileDependencies,
+    pluginWatchFiles: [...pluginWatchFiles].sort(),
+  };
 }
 function toInspectDiagnostic(
   source: InspectDiagnostic["source"],

--- a/packages/ev/src/_internal/build/plugin-lifecycle.ts
+++ b/packages/ev/src/_internal/build/plugin-lifecycle.ts
@@ -4,11 +4,15 @@ import {
   resolveConfig,
   resolvePluginsConfig,
 } from "../../config/index.js";
+import { clonePluginPreset, isPluginPreset } from "../../config/plugins.js";
 import {
-  copyDefinedPluginRuntime,
+  copyDefinedPluginSnapshot,
   createPluginApplicationSettingContext,
-  hasSameDefinedPluginRuntime,
-  isDefinedPluginRuntimePropertyKey,
+  forkDefinedPluginPipeline,
+  getDefinedPluginDeclaration,
+  hasSameDefinedPluginPipeline,
+  isDefinedPluginOwnedPropertyKey,
+  isPluginActive,
   prepareDefinedPluginApplicationSetting,
 } from "../../plugin/defined.js";
 import { runPluginHook } from "../../plugin/errors.js";
@@ -17,6 +21,9 @@ import type {
   BeforeBuildContext,
   BuildResult,
   ConfigureBundlerContext,
+  FrameworkBundlerView,
+  FrameworkConfigView,
+  FrameworkPluginView,
   Plugin,
   PluginConfigureContext,
   PluginContext,
@@ -45,7 +52,6 @@ interface PluginOrderDeclaration {
   name: string;
   dependencies?: string[];
   optionalDependencies?: string[];
-  enforce?: "pre" | "normal" | "post";
 }
 
 export function orderPluginsByDependencies<
@@ -54,8 +60,9 @@ export function orderPluginsByDependencies<
   const pluginByName = new Map<string, TPlugin>();
   const dependentsByName = new Map<string, string[]>();
   const dependencyCountByName = new Map<string, number>();
+  const authoredIndexByName = new Map<string, number>();
 
-  for (const plugin of plugins) {
+  for (const [index, plugin] of plugins.entries()) {
     if (pluginByName.has(plugin.name)) {
       throw new Error(
         `[evjs] Duplicate plugin name "${plugin.name}". Plugin names must be unique.`,
@@ -64,6 +71,7 @@ export function orderPluginsByDependencies<
     pluginByName.set(plugin.name, plugin);
     dependentsByName.set(plugin.name, []);
     dependencyCountByName.set(plugin.name, 0);
+    authoredIndexByName.set(plugin.name, index);
   }
 
   function addDependency(
@@ -78,6 +86,15 @@ export function orderPluginsByDependencies<
         `[evjs] Plugin "${plugin.name}" depends on missing plugin "${dependencyName}".`,
       );
     }
+    if (!isPluginActive(dependency)) {
+      if (optional) return;
+      const reason =
+        getDefinedPluginDeclaration(dependency)?.inactiveReason ??
+        "its activation condition evaluated to false";
+      throw new Error(
+        `[evjs] Plugin "${plugin.name}" depends on inactive plugin "${dependencyName}": ${reason}.`,
+      );
+    }
     dependentsByName.get(dependencyName)?.push(plugin.name);
     dependencyCountByName.set(
       plugin.name,
@@ -86,6 +103,7 @@ export function orderPluginsByDependencies<
   }
 
   for (const plugin of plugins) {
+    if (!isPluginActive(plugin)) continue;
     for (const dependencyName of plugin.dependencies ?? []) {
       addDependency(plugin, dependencyName, false);
     }
@@ -94,9 +112,16 @@ export function orderPluginsByDependencies<
     }
   }
 
+  function compareAuthoredPluginOrder(left: TPlugin, right: TPlugin): number {
+    return (
+      (authoredIndexByName.get(left.name) ?? 0) -
+      (authoredIndexByName.get(right.name) ?? 0)
+    );
+  }
+
   const ready = plugins
     .filter((plugin) => dependencyCountByName.get(plugin.name) === 0)
-    .sort(comparePluginEnforce);
+    .sort(compareAuthoredPluginOrder);
   const ordered: TPlugin[] = [];
 
   while (ready.length > 0) {
@@ -112,7 +137,7 @@ export function orderPluginsByDependencies<
       const dependent = pluginByName.get(dependentName);
       if (dependent) {
         ready.push(dependent);
-        ready.sort(comparePluginEnforce);
+        ready.sort(compareAuthoredPluginOrder);
       }
     }
   }
@@ -147,10 +172,16 @@ function throwPluginDependencyCycle<TPlugin extends PluginOrderDeclaration>(
       seen.add(currentName);
       dependencyPath.push(currentName);
       const current = pluginByName.get(currentName);
+      if (!current || !isPluginActive(current)) break;
       const nextName = [
-        ...(current?.dependencies ?? []),
-        ...(current?.optionalDependencies ?? []),
-      ].find((name) => remaining.has(name));
+        ...(current.dependencies ?? []),
+        ...(current.optionalDependencies ?? []),
+      ].find((name) => {
+        const dependency = pluginByName.get(name);
+        return Boolean(
+          remaining.has(name) && dependency && isPluginActive(dependency),
+        );
+      });
       if (!nextName) break;
       currentName = nextName;
     }
@@ -167,19 +198,6 @@ function throwPluginDependencyCycle<TPlugin extends PluginOrderDeclaration>(
   throw new Error(
     `[evjs] Circular plugin dependency detected among: ${remainingNames.join(", ")}.`,
   );
-}
-
-function comparePluginEnforce(
-  left: PluginOrderDeclaration,
-  right: PluginOrderDeclaration,
-): number {
-  return pluginEnforceRank(left) - pluginEnforceRank(right);
-}
-
-function pluginEnforceRank(plugin: PluginOrderDeclaration): number {
-  if (plugin.enforce === "pre") return 0;
-  if (plugin.enforce === "post") return 2;
-  return 1;
 }
 
 export async function collectPluginHooks<TBundlerCfg>(
@@ -482,7 +500,7 @@ export async function runConfigureHooks<TBundlerCfg>(
   userConfig: Config<TBundlerCfg> | undefined,
   ctx: PluginConfigureContext,
 ): Promise<Config<TBundlerCfg> | undefined> {
-  let config = cloneConfigureHookInput(userConfig);
+  let config = cloneConfigureHookInput(userConfig, true);
   // Reject invalid author config before any plugin can be blamed for it.
   resolveConfig(config);
   const configuredPlugins = resolvePluginsConfig<TBundlerCfg>(config?.plugins);
@@ -506,9 +524,10 @@ export async function runConfigureHooks<TBundlerCfg>(
           ),
         );
       }
+      const nextPlugins = resolvePluginsConfig<TBundlerCfg>(config?.plugins);
       assertConfigurePluginListUnchanged(
         configuredPlugins,
-        resolvePluginsConfig<TBundlerCfg>(config?.plugins),
+        nextPlugins,
         plugin.name,
       );
       resolveConfig(config);
@@ -543,7 +562,6 @@ function hasSameConfiguredPlugin<TBundlerCfg>(
   return (
     left.name === right.name &&
     (left as { key?: string }).key === (right as { key?: string }).key &&
-    left.enforce === right.enforce &&
     haveSameStringArray(left.dependencies, right.dependencies) &&
     haveSameStringArray(
       left.optionalDependencies,
@@ -552,7 +570,7 @@ function hasSameConfiguredPlugin<TBundlerCfg>(
     left.configure === right.configure &&
     left.setup === right.setup &&
     left.emitIR === right.emitIR &&
-    hasSameDefinedPluginRuntime(left, right)
+    hasSameDefinedPluginPipeline(left, right)
   );
 }
 
@@ -571,21 +589,30 @@ function haveSameStringArray(
 
 function cloneConfigureHookInput<TBundlerCfg>(
   config: Config<TBundlerCfg> | undefined,
+  forkPluginPipelineState = false,
 ): Config<TBundlerCfg> | undefined {
-  return cloneConfigureHookValue(config, new WeakMap()) as
-    | Config<TBundlerCfg>
-    | undefined;
+  return cloneConfigureHookValue(
+    config,
+    new WeakMap(),
+    forkPluginPipelineState,
+  ) as Config<TBundlerCfg> | undefined;
 }
 
 function cloneConfigureHookValue(
   value: unknown,
   seen: WeakMap<object, object>,
+  forkPluginPipelineState: boolean,
 ): unknown {
   if (!value || typeof value !== "object") return value;
-  if (!Array.isArray(value) && !isPlainObject(value)) return value;
-
   const existing = seen.get(value);
   if (existing) return existing;
+  if (isPluginPreset(value)) {
+    return clonePluginPreset(value, (entries, clone) => {
+      seen.set(value, clone);
+      return cloneConfigureHookValue(entries, seen, forkPluginPipelineState);
+    });
+  }
+  if (!Array.isArray(value) && !isPlainObject(value)) return value;
   let clone: object;
   if (Array.isArray(value)) {
     const arrayClone: unknown[] = [];
@@ -599,7 +626,7 @@ function cloneConfigureHookValue(
   for (const key of Reflect.ownKeys(value)) {
     if (
       (Array.isArray(value) && key === "length") ||
-      isDefinedPluginRuntimePropertyKey(key)
+      isDefinedPluginOwnedPropertyKey(value, key)
     ) {
       continue;
     }
@@ -612,37 +639,116 @@ function cloneConfigureHookValue(
         ? {
             configurable: true,
             enumerable: descriptor.enumerable,
-            value: cloneConfigureHookValue(descriptor.value, seen),
+            value: cloneConfigureHookValue(
+              descriptor.value,
+              seen,
+              forkPluginPipelineState,
+            ),
             writable: true,
           }
         : descriptor,
     );
   }
-  copyDefinedPluginRuntime(value, clone);
+  if (forkPluginPipelineState) {
+    forkDefinedPluginPipeline(value, clone);
+  } else {
+    copyDefinedPluginSnapshot(value, clone);
+  }
   return clone;
 }
 
 /**
- * Give plugin hooks a detached, deeply frozen view of resolved framework
- * config. The hidden defined-plugin runtime is intentionally omitted so a
- * JavaScript plugin cannot mutate framework-owned Application setting state.
+ * Give plugin hooks a detached, deeply frozen metadata view of resolved
+ * framework config. Plugin and bundler implementation capabilities are
+ * intentionally omitted.
  */
 export function createPluginConfigSnapshot<TBundlerCfg>(
   config: PluginContext<TBundlerCfg>["config"],
-): PluginContext<TBundlerCfg>["config"] {
+): FrameworkConfigView<TBundlerCfg> {
   if (!config || typeof config !== "object") return config;
   const cached = pluginConfigSnapshots.get(config);
   if (cached) {
-    return cached as PluginContext<TBundlerCfg>["config"];
+    return cached as FrameworkConfigView<TBundlerCfg>;
   }
-  const snapshot = clonePluginConfigSnapshotValue(
-    config,
-    new WeakMap(),
-  ) as PluginContext<TBundlerCfg>["config"];
+  const snapshot = projectPluginConfigSnapshot(config, new WeakMap());
   freezePluginConfigSnapshotValue(snapshot, new WeakSet());
   pluginConfigSnapshots.set(config, snapshot);
   pluginConfigSnapshots.set(snapshot, snapshot);
   return snapshot;
+}
+
+function projectPluginConfigSnapshot<TBundlerCfg>(
+  config: PluginContext<TBundlerCfg>["config"],
+  seen: WeakMap<object, object>,
+): FrameworkConfigView<TBundlerCfg> {
+  const snapshot = Object.create(
+    Object.getPrototypeOf(config),
+  ) as FrameworkConfigView<TBundlerCfg>;
+  seen.set(config, snapshot);
+
+  for (const key of Reflect.ownKeys(config)) {
+    const descriptor = Object.getOwnPropertyDescriptor(config, key);
+    if (!descriptor) continue;
+
+    let propertyValue: unknown;
+    if (key === "plugins") {
+      propertyValue = config.plugins.map(projectFrameworkPluginView);
+    } else if (key === "bundler") {
+      propertyValue = config.bundler
+        ? projectFrameworkBundlerView(config.bundler)
+        : undefined;
+    } else {
+      propertyValue =
+        "value" in descriptor ? descriptor.value : Reflect.get(config, key);
+      propertyValue = clonePluginConfigSnapshotValue(propertyValue, seen);
+    }
+
+    Object.defineProperty(snapshot, key, {
+      configurable: true,
+      enumerable: descriptor.enumerable,
+      value: propertyValue,
+      writable: true,
+    });
+  }
+  return snapshot;
+}
+
+function projectFrameworkPluginView(
+  plugin: FrameworkPluginView,
+): FrameworkPluginView {
+  const declaration = getDefinedPluginDeclaration(plugin);
+  const key = declaration?.key ?? plugin.key;
+  return {
+    name: plugin.name,
+    ...(key === undefined ? {} : { key }),
+    active: declaration?.active ?? plugin.active,
+    ...(declaration?.inactiveReason
+      ? { inactiveReason: declaration.inactiveReason }
+      : {}),
+  };
+}
+
+function projectFrameworkBundlerView(
+  bundler: FrameworkBundlerView,
+): FrameworkBundlerView {
+  return {
+    name: bundler.name,
+    capabilities: {
+      build: {
+        server: bundler.capabilities.build.server,
+        rsc: bundler.capabilities.build.rsc,
+        ppr: bundler.capabilities.build.ppr,
+      },
+      dev: {
+        configuration: bundler.capabilities.dev.configuration,
+        html: bundler.capabilities.dev.html,
+        entries: bundler.capabilities.dev.entries,
+        routes: bundler.capabilities.dev.routes,
+        server: bundler.capabilities.dev.server,
+        resolution: bundler.capabilities.dev.resolution,
+      },
+    },
+  };
 }
 
 function clonePluginConfigSnapshotValue(
@@ -662,7 +768,7 @@ function clonePluginConfigSnapshotValue(
   for (const key of Reflect.ownKeys(value)) {
     if (
       (Array.isArray(value) && key === "length") ||
-      isDefinedPluginRuntimePropertyKey(key)
+      isDefinedPluginOwnedPropertyKey(value, key)
     ) {
       continue;
     }

--- a/packages/ev/src/_internal/build/plugin-settings.ts
+++ b/packages/ev/src/_internal/build/plugin-settings.ts
@@ -46,11 +46,6 @@ export interface ResolvedPluginSettingsState {
   readonly applicationSettings: CoreApplicationPluginSettings;
 }
 
-export interface ResolvePluginSettingsStateOptions {
-  /** Reuse the Application snapshot prepared at the start of config hooks. */
-  readonly reusePreparedApplicationSettings?: boolean;
-}
-
 export interface ApplyPluginSettingsOptions {
   readonly applicationSettings?: CoreApplicationPluginSettings;
   readonly canonicalPages?: Readonly<Record<string, ResolvedPageFileConfig>>;
@@ -102,7 +97,6 @@ export function resolvePluginSettingsState<TBundlerCfg>(
   registry: PluginSettingsRegistry = collectPluginSettingsRegistry(
     config.plugins,
   ),
-  options: ResolvePluginSettingsStateOptions = {},
 ): ResolvedPluginSettingsState {
   const applicationSettings: CoreApplicationPluginSettings = {};
   const context = createPluginApplicationSettingContext(config);
@@ -110,7 +104,6 @@ export function resolvePluginSettingsState<TBundlerCfg>(
     const setting = resolveDefinedPluginApplicationSetting(
       entry.plugin,
       context,
-      { reusePrepared: options.reusePreparedApplicationSettings === true },
     );
     if (setting && entry.key) {
       defineRecordValue(applicationSettings, entry.key, {

--- a/packages/ev/src/config/index.ts
+++ b/packages/ev/src/config/index.ts
@@ -25,16 +25,19 @@ import {
 } from "../_internal/build/output-path-conventions.js";
 import { CANONICAL_PAGE_ROUTE_ROOT } from "../_internal/build/page-route-conventions.js";
 import {
-  copyDefinedPluginRuntime,
+  copyDefinedPluginSnapshot,
   getDefinedPluginDeclaration,
-  isDefinedPluginRuntimePropertyKey,
+  isDefinedPluginOwnedPropertyKey,
 } from "../plugin/defined.js";
 import { isPluginLifecycleDescriptorField } from "../plugin/hook-names.js";
 import type { Plugin } from "../plugin/index.js";
 import {
   assertPluginKey,
+  getPluginPresetEntries,
+  isPluginPreset,
   type PagePluginConfigValues,
   type PagePluginConfigValuesCheck,
+  type PluginPreset,
 } from "./plugins.js";
 
 export type { PageMetadata } from "@evjs/shared/manifest";
@@ -134,8 +137,13 @@ export interface ResolvedConfig<TBundlerCfg = DefaultBundlerConfig> {
   transport: ResolvedTransportConfig;
   /** Bundler adapter. When omitted, defaults to utoopack. */
   bundler?: BundlerAdapter<TBundlerCfg>;
-  /** Active plugins. */
-  plugins: Plugin<TBundlerCfg>[];
+  /** Installed plugins in stable dependency order. */
+  plugins: ResolvedPlugin<TBundlerCfg>[];
+}
+
+interface ResolvedPlugin<TBundlerCfg> extends Plugin<TBundlerCfg> {
+  /** Whether this installed plugin participates in the current snapshot. */
+  readonly active: boolean;
 }
 
 /**
@@ -205,8 +213,15 @@ export interface Config<TBundlerCfg = DefaultBundlerConfig> {
   /**
    * Framework plugins to extend behavior or modify the bundler config.
    */
-  plugins?: readonly (Plugin<TBundlerCfg> | false | null | undefined)[];
+  plugins?: readonly ConfigPluginEntry<TBundlerCfg>[];
 }
+
+type ConfigPluginEntry<TBundlerCfg> =
+  | Plugin<TBundlerCfg>
+  | PluginPreset<readonly ConfigPluginEntry<TBundlerCfg>[]>
+  | false
+  | null
+  | undefined;
 
 /** Client dev server options. */
 export interface DevConfig {
@@ -544,7 +559,6 @@ const PUBLIC_PLUGIN_CONFIG_KEYS = new Set([
   "key",
   "dependencies",
   "optionalDependencies",
-  "enforce",
   "configure",
   "setup",
   "emitIR",
@@ -711,37 +725,95 @@ export function resolveConfig<TBundlerCfg = DefaultBundlerConfig>(
 
 export function resolvePluginsConfig<TBundlerCfg = DefaultBundlerConfig>(
   plugins: unknown,
-): Plugin<TBundlerCfg>[] {
+): ResolvedPlugin<TBundlerCfg>[] {
   if (plugins === undefined) return [];
   if (!Array.isArray(plugins)) {
     throw new Error("[evjs] plugins must be an array of plugin objects.");
   }
-  assertConfigArray(plugins, "plugins");
-  const resolved: Plugin<TBundlerCfg>[] = [];
-  for (let index = 0; index < plugins.length; index++) {
-    const plugin = plugins[index];
-    if (plugin === false || plugin === null || plugin === undefined) continue;
-    resolved.push(resolvePluginConfig<TBundlerCfg>(plugin, index));
-  }
+  const resolved: ResolvedPlugin<TBundlerCfg>[] = [];
+  resolvePluginConfigEntries(
+    plugins,
+    "plugins",
+    resolved,
+    new Set<PluginPreset>(),
+  );
   return resolved;
+}
+
+function resolvePluginConfigEntries<TBundlerCfg>(
+  entries: unknown[],
+  path: string,
+  resolved: ResolvedPlugin<TBundlerCfg>[],
+  activePresets: Set<PluginPreset>,
+): void {
+  assertConfigArray(entries, path);
+  for (let index = 0; index < entries.length; index++) {
+    const entry = entries[index];
+    const entryPath = `${path}[${index}]`;
+    if (entry === false || entry === null || entry === undefined) continue;
+
+    if (isPluginPreset(entry)) {
+      if (activePresets.has(entry)) {
+        throw new Error(
+          `[evjs] ${entryPath} contains a circular plugin preset.`,
+        );
+      }
+      const presetEntries = getPluginPresetEntries(entry);
+      if (!Array.isArray(presetEntries)) {
+        const detail =
+          presetEntries instanceof Promise
+            ? "must return an array synchronously, not a Promise"
+            : "must return an array";
+        throw new Error(
+          `[evjs] The definePluginPreset() factory used at ${entryPath} ${detail}.`,
+        );
+      }
+      activePresets.add(entry);
+      try {
+        resolvePluginConfigEntries(
+          presetEntries,
+          `${entryPath}.preset`,
+          resolved,
+          activePresets,
+        );
+      } finally {
+        activePresets.delete(entry);
+      }
+      continue;
+    }
+
+    if (Array.isArray(entry)) {
+      throw new Error(
+        `[evjs] ${entryPath} must not be a bare plugin array. Wrap reusable plugin tuples with definePluginPreset().`,
+      );
+    }
+    if (entry instanceof Promise) {
+      throw new Error(
+        `[evjs] ${entryPath} must not be a Promise. Plugin entries and presets must be created synchronously.`,
+      );
+    }
+    resolved.push(resolvePluginConfig<TBundlerCfg>(entry, entryPath));
+  }
 }
 
 function resolvePluginConfig<TBundlerCfg = DefaultBundlerConfig>(
   plugin: unknown,
-  index: number,
-): Plugin<TBundlerCfg> {
-  const path = `plugins[${index}]`;
+  path: string,
+): ResolvedPlugin<TBundlerCfg> {
   const pluginRecord = assertPlainConfigRecord(
     plugin,
     path,
     "a plugin object",
-    isDefinedPluginRuntimePropertyKey,
+    (key) =>
+      typeof plugin === "object" &&
+      plugin !== null &&
+      isDefinedPluginOwnedPropertyKey(plugin, key),
   );
   assertKnownConfigKeys(
     pluginRecord,
     PUBLIC_PLUGIN_CONFIG_KEYS,
     path,
-    "name, key, dependencies, optionalDependencies, enforce, configure, setup, or emitIR",
+    "name, key, dependencies, optionalDependencies, configure, setup, or emitIR",
     (key) =>
       isPluginLifecycleDescriptorField(key)
         ? `[evjs] ${path}.${key} is not a Plugin descriptor field. Return the hook from ${path}.setup() instead.`
@@ -752,7 +824,6 @@ function resolvePluginConfig<TBundlerCfg = DefaultBundlerConfig>(
     key: rawKey,
     dependencies: rawDependencies,
     optionalDependencies: rawOptionalDependencies,
-    enforce: rawEnforce,
     configure: rawConfigure,
     setup: rawSetup,
     emitIR: rawEmitIR,
@@ -808,17 +879,18 @@ function resolvePluginConfig<TBundlerCfg = DefaultBundlerConfig>(
     ...(key !== undefined ? { key } : {}),
     ...(dependencies !== undefined ? { dependencies } : {}),
     ...(optionalDependencies !== undefined ? { optionalDependencies } : {}),
-    ...(rawEnforce !== undefined
-      ? {
-          enforce: assertPluginEnforce(rawEnforce, `${path}.enforce`),
-        }
-      : {}),
     ...(rawConfigure !== undefined ? { configure: rawConfigure } : {}),
     ...(rawSetup !== undefined ? { setup: rawSetup } : {}),
     ...(rawEmitIR !== undefined ? { emitIR: rawEmitIR } : {}),
   };
-  copyDefinedPluginRuntime(plugin as Plugin<TBundlerCfg>, resolved);
-  return resolved;
+  Object.defineProperty(resolved, "active", {
+    configurable: false,
+    enumerable: false,
+    value: getDefinedPluginDeclaration(plugin as object)?.active ?? true,
+    writable: false,
+  });
+  copyDefinedPluginSnapshot(plugin as Plugin<TBundlerCfg>, resolved);
+  return resolved as ResolvedPlugin<TBundlerCfg>;
 }
 
 function assertDisjointPluginDependencies(
@@ -1853,13 +1925,6 @@ function assertFunction<
 >(value: unknown, path: string): asserts value is TFunction {
   if (typeof value === "function") return;
   throw new Error(`[evjs] ${path} must be a function.`);
-}
-
-function assertPluginEnforce(value: unknown, path: string): Plugin["enforce"] {
-  if (value === "pre" || value === "normal" || value === "post") {
-    return value;
-  }
-  throw new Error(`[evjs] ${path} must be "pre", "normal", or "post".`);
 }
 
 function cloneStringArray(value: unknown, path: string): string[] {

--- a/packages/ev/src/config/plugins.ts
+++ b/packages/ev/src/config/plugins.ts
@@ -14,6 +14,104 @@ import type { StaticConfigCompatible, StaticConfigValue } from "./static.js";
 const UNSAFE_PLUGIN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
 declare const installedPluginRegistry: unique symbol;
+declare const pluginPresetType: unique symbol;
+const PLUGIN_PRESET_REGISTRY = Symbol.for("@evjs/ev/plugin-preset-registry/v1");
+const pluginPresetEntries = getPluginPresetRegistry();
+
+type InactivePluginEntry = false | null | undefined;
+
+/**
+ * An entry accepted from a plugin preset factory.
+ *
+ * The complete bundler-specific Plugin constraint is enforced when the preset
+ * is installed in `Config.plugins`.
+ */
+export type PluginPresetEntry =
+  | Readonly<{ name: string }>
+  | PluginPreset<readonly PluginPresetEntry[]>
+  | InactivePluginEntry;
+
+/** A branded tuple of plugin entries. */
+export interface PluginPreset<
+  out TEntries extends readonly unknown[] = readonly unknown[],
+> {
+  readonly [pluginPresetType]: TEntries;
+}
+
+/** A plugin preset factory preserving its original arguments and exact tuple. */
+export type PluginPresetFactory<
+  TArguments extends readonly unknown[],
+  TEntries extends readonly PluginPresetEntry[],
+> = (...args: TArguments) => PluginPreset<TEntries>;
+
+/**
+ * Define a reusable, typed plugin composition.
+ *
+ * The returned factory keeps the input factory's arguments while branding its
+ * exact output tuple so config resolution can distinguish presets from arrays.
+ */
+export function definePluginPreset<
+  const TArguments extends readonly unknown[],
+  const TEntries extends readonly PluginPresetEntry[],
+>(
+  factory: (...args: TArguments) => TEntries,
+): PluginPresetFactory<TArguments, TEntries> {
+  if (typeof factory !== "function") {
+    throw new Error("[evjs] definePluginPreset() requires a factory function.");
+  }
+  return function createPluginPreset(...args): PluginPreset<TEntries> {
+    const preset = Object.freeze({});
+    pluginPresetEntries.set(preset, factory(...args));
+    return preset as PluginPreset<TEntries>;
+  };
+}
+
+/** @internal */
+export function isPluginPreset(value: unknown): value is PluginPreset {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    pluginPresetEntries.has(value)
+  );
+}
+
+/** @internal */
+export function getPluginPresetEntries(preset: PluginPreset): unknown {
+  return pluginPresetEntries.get(preset);
+}
+
+/** @internal Clone an opaque preset while projecting its hidden entries. */
+export function clonePluginPreset(
+  preset: PluginPreset,
+  cloneEntries: (entries: unknown, clone: PluginPreset) => unknown,
+): PluginPreset {
+  const clone = Object.freeze({}) as PluginPreset;
+  pluginPresetEntries.set(clone, undefined);
+  pluginPresetEntries.set(
+    clone,
+    cloneEntries(getPluginPresetEntries(preset), clone),
+  );
+  return clone;
+}
+
+function getPluginPresetRegistry(): WeakMap<object, unknown> {
+  const existing = Reflect.get(globalThis, PLUGIN_PRESET_REGISTRY);
+  if (existing !== undefined) {
+    if (existing instanceof WeakMap) {
+      return existing as WeakMap<object, unknown>;
+    }
+    throw new Error("[evjs] The global plugin preset registry is invalid.");
+  }
+
+  const registry = new WeakMap<object, unknown>();
+  Object.defineProperty(globalThis, PLUGIN_PRESET_REGISTRY, {
+    configurable: false,
+    enumerable: false,
+    value: registry,
+    writable: false,
+  });
+  return registry;
+}
 
 /**
  * Project configuration generated from `ev.config.ts`.
@@ -30,8 +128,6 @@ type GeneratedInstalledPluginConfig =
     ? TConfig
     : never;
 
-type InactivePluginEntry = false | null | undefined;
-
 type IsUnion<TValue, TCandidate = TValue> = TValue extends TCandidate
   ? [TCandidate] extends [TValue]
     ? false
@@ -43,17 +139,23 @@ type TupleIndex<TTuple extends readonly unknown[]> = Exclude<
   keyof unknown[]
 >;
 
+type DefinitelyInstalledPluginEntry<TEntry> = [
+  Extract<TEntry, InactivePluginEntry>,
+] extends [never]
+  ? IsUnion<TEntry> extends true
+    ? never
+    : TEntry extends PluginPreset<infer TEntries>
+      ? DefinitelyInstalledPluginEntries<TEntries>
+      : Exclude<TEntry, InactivePluginEntry>
+  : never;
+
 type DefinitelyInstalledPluginEntries<TPlugins extends readonly unknown[]> =
   IsUnion<TPlugins> extends true
     ? never
     : {
-        [TIndex in TupleIndex<TPlugins>]: [
-          Extract<TPlugins[TIndex], InactivePluginEntry>,
-        ] extends [never]
-          ? IsUnion<TPlugins[TIndex]> extends true
-            ? never
-            : Exclude<TPlugins[TIndex], InactivePluginEntry>
-          : never;
+        [TIndex in TupleIndex<TPlugins>]: DefinitelyInstalledPluginEntry<
+          TPlugins[TIndex]
+        >;
       }[TupleIndex<TPlugins>];
 
 type ConfiguredPlugin<TConfig> = [TConfig] extends [

--- a/packages/ev/src/plugin/defined.ts
+++ b/packages/ev/src/plugin/defined.ts
@@ -455,7 +455,6 @@ export type DefinedPluginDescriptor<
   readonly name: TName;
   readonly dependencies?: readonly string[];
   readonly optionalDependencies?: readonly string[];
-  readonly enforce?: "pre" | "normal" | "post";
   readonly configure?: DefinedPluginConfigureHook<TApplication, TBundlerCfg>;
   readonly setup?: DefinedPluginSetupHook<TApplication, TBundlerCfg>;
   /** Emit IR records shared by every enabled owner. */
@@ -489,6 +488,23 @@ export type DefinedPluginInstance<
   TBundlerCfg = unknown,
 > = Plugin<TBundlerCfg> & {
   readonly name: TName;
+  /**
+   * Keep the plugin installed for contracts and Page types while conditionally
+   * skipping its configuration, setup, and IR emission.
+   */
+  when(
+    active: boolean,
+    reason?: string,
+  ): DefinedPluginInstance<
+    TName,
+    TKey,
+    TApplicationInput,
+    TApplicationOutput,
+    TPageInput,
+    TPageOutput,
+    TPageDefaultable,
+    TBundlerCfg
+  >;
   readonly [definedPluginContract]: DefinedPluginTypeContract<
     TApplicationInput,
     TApplicationOutput,
@@ -540,23 +556,6 @@ type FactoryArgs<TContract> = TContract extends AnyPluginOptionsContract
     : [options: ContractInput<TContract> & object]
   : [];
 
-type DefinedPluginFactoryInstance<
-  TName extends string,
-  TKey extends string | undefined,
-  TApplication extends AnyPluginOptionsContract | undefined,
-  TPage extends AnyPluginOptionsContract | undefined,
-  TBundlerCfg = unknown,
-> = DefinedPluginInstance<
-  TName,
-  TKey,
-  ContractInput<TApplication>,
-  ContractOutput<TApplication>,
-  ContractInput<TPage>,
-  ContractOutput<TPage>,
-  ContractDefaultable<TPage>,
-  TBundlerCfg
->;
-
 export type DefinedPluginFactory<
   TName extends string,
   TKey extends string | undefined,
@@ -565,11 +564,14 @@ export type DefinedPluginFactory<
   TBundlerCfg = unknown,
 > = ((
   ...args: FactoryArgs<TApplication>
-) => DefinedPluginFactoryInstance<
+) => DefinedPluginInstance<
   TName,
   TKey,
-  TApplication,
-  TPage,
+  ContractInput<TApplication>,
+  ContractOutput<TApplication>,
+  ContractInput<TPage>,
+  ContractOutput<TPage>,
+  ContractDefaultable<TPage>,
   TBundlerCfg
 >) &
   (TPage extends AnyPluginOptionsContract
@@ -578,11 +580,14 @@ export type DefinedPluginFactory<
           /** Install the plugin while requiring Pages to opt in explicitly. */
           withPageOptIn(
             ...args: FactoryArgs<TApplication>
-          ): DefinedPluginFactoryInstance<
+          ): DefinedPluginInstance<
             TName,
             TKey,
-            TApplication,
-            TPage,
+            ContractInput<TApplication>,
+            ContractOutput<TApplication>,
+            ContractInput<TPage>,
+            ContractOutput<TPage>,
+            ContractDefaultable<TPage>,
             TBundlerCfg
           >;
         }
@@ -601,15 +606,24 @@ interface DefinedPluginRuntime {
   readonly page?: AnyPluginOptionsContract;
   readonly applicationConfigured: unknown;
   readonly pagesByDefault: boolean;
-  applicationSetting?: RuntimePluginSetting;
-  applicationSettingPrepared: boolean;
+  readonly active: boolean;
+  readonly inactiveReason?: string;
+  readonly stages: readonly ("configure" | "setup" | "emitIR")[];
 }
 
-const DEFINED_PLUGIN_RUNTIME = Symbol.for("@evjs/ev/defined-plugin-runtime");
+/** One-assignment cell shared by every copy in one config pipeline. */
+interface DefinedPluginPipelineState {
+  applicationSetting?: RuntimePluginSetting;
+}
 
-type DefinedPluginRuntimeCarrier = object & {
-  readonly [DEFINED_PLUGIN_RUNTIME]?: DefinedPluginRuntime;
-};
+const DEFINED_PLUGIN_RUNTIME_REGISTRY = Symbol.for(
+  "@evjs/ev/defined-plugin-runtime-registry/v1",
+);
+const DEFINED_PLUGIN_PIPELINE_STATE_REGISTRY = Symbol.for(
+  "@evjs/ev/defined-plugin-pipeline-state-registry/v1",
+);
+const definedPluginRuntimes = getDefinedPluginRuntimeRegistry();
+const definedPluginPipelineStates = getDefinedPluginPipelineStateRegistry();
 
 /**
  * Define a bundler-agnostic typed plugin factory from one owner-aware
@@ -662,11 +676,18 @@ export function definePlugin<
   const create = (
     installMode: "all" | "pages",
     args: readonly unknown[],
-  ): DefinedPluginFactoryInstance<
+    activation: {
+      readonly active: boolean;
+      readonly reason?: string;
+    } = { active: true },
+  ): DefinedPluginInstance<
     TName,
     TKey,
-    TApplication,
-    TPage,
+    ContractInput<TApplication>,
+    ContractOutput<TApplication>,
+    ContractInput<TPage>,
+    ContractOutput<TPage>,
+    ContractDefaultable<TPage>,
     TBundlerCfg
   > => {
     const application = descriptor.application;
@@ -686,15 +707,30 @@ export function definePlugin<
       );
     }
 
-    const runtime: DefinedPluginRuntime = {
+    const runtime: DefinedPluginRuntime = Object.freeze({
       name: descriptor.name,
       ...(descriptor.key ? { key: descriptor.key } : {}),
       ...(application ? { application } : {}),
       ...(descriptor.page ? { page: descriptor.page } : {}),
       applicationConfigured: args[0],
       pagesByDefault: installMode === "all",
-      applicationSettingPrepared: false,
-    };
+      active: activation.active,
+      ...(!activation.active && activation.reason
+        ? { inactiveReason: activation.reason }
+        : {}),
+      stages: Object.freeze(
+        [
+          descriptor.configure ? ("configure" as const) : undefined,
+          descriptor.setup ? ("setup" as const) : undefined,
+          descriptor.emitIR || descriptor.emitPageIR
+            ? ("emitIR" as const)
+            : undefined,
+        ].filter(
+          (stage): stage is "configure" | "setup" | "emitIR" =>
+            stage !== undefined,
+        ),
+      ),
+    });
     const emitPageIR = descriptor.emitPageIR as
       | DefinedPluginEmitPageIRHook<TApplication, TPage, TBundlerCfg>
       | undefined;
@@ -707,33 +743,35 @@ export function definePlugin<
       ...(descriptor.optionalDependencies
         ? { optionalDependencies: [...descriptor.optionalDependencies] }
         : {}),
-      ...(descriptor.enforce ? { enforce: descriptor.enforce } : {}),
-      ...(descriptor.configure
+      ...(activation.active && descriptor.configure
         ? {
-            configure: (config, context) =>
-              descriptor.configure?.(config, {
+            configure: function (this: Plugin<TBundlerCfg>, config, context) {
+              return descriptor.configure?.(config, {
                 ...context,
                 options: resolveConfigureHookApplicationSetting(
-                  runtime,
+                  this,
                   createPluginApplicationSettingContext(config),
                 ).config as ResolvedContractOptions<TApplication>,
-              }),
+              });
+            },
           }
         : {}),
-      ...(descriptor.setup
+      ...(activation.active && descriptor.setup
         ? {
-            setup: (context) =>
-              descriptor.setup?.({
+            setup: function (this: Plugin<TBundlerCfg>, context) {
+              return descriptor.setup?.({
                 ...context,
-                options: getRuntimeApplicationSetting(runtime)
+                options: getRuntimeApplicationSetting(this)
                   .config as ResolvedContractOptions<TApplication>,
-              }),
+              });
+            },
           }
         : {}),
-      ...(descriptor.emitIR || emitPageIR
+      ...(activation.active && (descriptor.emitIR || emitPageIR)
         ? {
-            emitIR: async (context) => {
-              const options = getRuntimeApplicationSetting(runtime)
+            emitIR: async function (this: Plugin<TBundlerCfg>, context) {
+              const runtime = requireDefinedPluginRuntime(this);
+              const options = getRuntimeApplicationSetting(this)
                 .config as ResolvedContractOptions<TApplication>;
               const pages = readPageOptions(
                 context,
@@ -765,11 +803,40 @@ export function definePlugin<
         : {}),
     };
     attachDefinedPluginRuntime(plugin, runtime);
-    return plugin as DefinedPluginFactoryInstance<
+    Object.defineProperty(plugin, "when", {
+      configurable: false,
+      enumerable: false,
+      value: (active: boolean, reason?: string) => {
+        if (typeof active !== "boolean") {
+          throw new Error(
+            `[evjs] Plugin "${descriptor.name}" when() expects a boolean condition.`,
+          );
+        }
+        if (
+          reason !== undefined &&
+          (typeof reason !== "string" ||
+            reason.length === 0 ||
+            reason !== reason.trim())
+        ) {
+          throw new Error(
+            `[evjs] Plugin "${descriptor.name}" when() reason must be a non-empty string without surrounding whitespace.`,
+          );
+        }
+        return create(installMode, args, {
+          active,
+          ...(!active && reason ? { reason } : {}),
+        });
+      },
+      writable: false,
+    });
+    return plugin as DefinedPluginInstance<
       TName,
       TKey,
-      TApplication,
-      TPage,
+      ContractInput<TApplication>,
+      ContractOutput<TApplication>,
+      ContractInput<TPage>,
+      ContractOutput<TPage>,
+      ContractDefaultable<TPage>,
       TBundlerCfg
     >;
   };
@@ -796,6 +863,9 @@ export function definePlugin<
 export interface DefinedPluginDeclaration {
   readonly name: string;
   readonly key?: string;
+  readonly active: boolean;
+  readonly inactiveReason?: string;
+  readonly stages: readonly ("configure" | "setup" | "emitIR")[];
   readonly application?: {
     readonly schemaVersion?: string;
     readonly defaultable: boolean;
@@ -814,6 +884,11 @@ export function getDefinedPluginDeclaration(
   return {
     name: runtime.name,
     ...(runtime.key ? { key: runtime.key } : {}),
+    active: runtime.active,
+    ...(runtime.inactiveReason
+      ? { inactiveReason: runtime.inactiveReason }
+      : {}),
+    stages: runtime.stages,
     ...(runtime.application
       ? {
           application: {
@@ -837,93 +912,150 @@ export function getDefinedPluginDeclaration(
   };
 }
 
-export function copyDefinedPluginRuntime(source: object, target: object): void {
+/** @internal Preserve one defined-plugin pipeline across an object clone. */
+export function copyDefinedPluginSnapshot(
+  source: object,
+  target: object,
+): void {
   const runtime = getDefinedPluginRuntime(source);
   if (runtime) attachDefinedPluginRuntime(target, runtime);
+  const pipelineState = definedPluginPipelineStates.get(source);
+  if (pipelineState) {
+    definedPluginPipelineStates.set(target, pipelineState);
+  }
 }
 
-/** @internal Compare the hidden factory contract carried by resolved copies. */
-export function hasSameDefinedPluginRuntime(
+/**
+ * Copy one factory declaration into a fresh config pipeline without carrying
+ * a previously resolved Application snapshot across the pipeline boundary.
+ */
+export function forkDefinedPluginPipeline(
+  source: object,
+  target: object,
+): void {
+  const runtime = getDefinedPluginRuntime(source);
+  if (!runtime) return;
+  attachDefinedPluginRuntime(target, runtime);
+  definedPluginPipelineStates.set(target, {});
+}
+
+/** Whether an installed plugin participates in this configuration snapshot. */
+export function isPluginActive(plugin: object): boolean {
+  return getDefinedPluginRuntime(plugin)?.active ?? true;
+}
+
+/** @internal Compare declaration and pipeline identity across resolved copies. */
+export function hasSameDefinedPluginPipeline(
   left: object,
   right: object,
 ): boolean {
-  return getDefinedPluginRuntime(left) === getDefinedPluginRuntime(right);
+  const runtime = getDefinedPluginRuntime(left);
+  return (
+    runtime === getDefinedPluginRuntime(right) &&
+    (runtime === undefined ||
+      definedPluginPipelineStates.get(left) ===
+        definedPluginPipelineStates.get(right))
+  );
 }
 
-/** @internal Snapshot the mutable Application cache shared by resolved plugin copies. */
-export function createDefinedPluginApplicationSettingSnapshot(
-  plugins: readonly object[],
-): { commit(): void; restore(): void } {
-  const snapshots = new Map<
-    DefinedPluginRuntime,
-    {
-      readonly setting: RuntimePluginSetting | undefined;
-      readonly prepared: boolean;
-    }
-  >();
-  for (const plugin of plugins) {
-    const runtime = getDefinedPluginRuntime(plugin);
-    if (!runtime || snapshots.has(runtime)) continue;
-    snapshots.set(runtime, {
-      setting: runtime.applicationSetting,
-      prepared: runtime.applicationSettingPrepared,
-    });
-  }
-
-  let settled = false;
-  return Object.freeze({
-    commit() {
-      settled = true;
-    },
-    restore() {
-      if (settled) return;
-      settled = true;
-      for (const [runtime, snapshot] of snapshots) {
-        runtime.applicationSetting = snapshot.setting;
-        runtime.applicationSettingPrepared = snapshot.prepared;
-      }
-    },
-  });
-}
-
-/** @internal Allow config isolation to preserve only the framework runtime marker. */
-export function isDefinedPluginRuntimePropertyKey(key: PropertyKey): boolean {
-  return key === DEFINED_PLUGIN_RUNTIME;
+/** @internal Identify factory-owned fields omitted from resolved config copies. */
+export function isDefinedPluginOwnedPropertyKey(
+  plugin: object,
+  key: PropertyKey,
+): boolean {
+  return getDefinedPluginRuntime(plugin) !== undefined && key === "when";
 }
 
 function getDefinedPluginRuntime(
   plugin: object,
 ): DefinedPluginRuntime | undefined {
-  return (plugin as DefinedPluginRuntimeCarrier)[DEFINED_PLUGIN_RUNTIME];
+  return definedPluginRuntimes.get(plugin);
+}
+
+function requireDefinedPluginRuntime(plugin: object): DefinedPluginRuntime {
+  const runtime = getDefinedPluginRuntime(plugin);
+  if (!runtime) {
+    throw new Error(
+      "[evjs] A definePlugin() lifecycle hook must be invoked with its plugin instance as the receiver.",
+    );
+  }
+  return runtime;
+}
+
+function getOrCreateDefinedPluginPipelineState(
+  plugin: object,
+): DefinedPluginPipelineState {
+  const existing = definedPluginPipelineStates.get(plugin);
+  if (existing) return existing;
+  const state: DefinedPluginPipelineState = {};
+  definedPluginPipelineStates.set(plugin, state);
+  return state;
 }
 
 function attachDefinedPluginRuntime(
   plugin: object,
   runtime: DefinedPluginRuntime,
 ): void {
-  Object.defineProperty(plugin, DEFINED_PLUGIN_RUNTIME, {
+  definedPluginRuntimes.set(plugin, runtime);
+}
+
+function getDefinedPluginRuntimeRegistry(): WeakMap<
+  object,
+  DefinedPluginRuntime
+> {
+  const existing = Reflect.get(globalThis, DEFINED_PLUGIN_RUNTIME_REGISTRY);
+  if (existing !== undefined) {
+    if (existing instanceof WeakMap) {
+      return existing as WeakMap<object, DefinedPluginRuntime>;
+    }
+    throw new Error("[evjs] The global defined-plugin registry is invalid.");
+  }
+
+  const registry = new WeakMap<object, DefinedPluginRuntime>();
+  Object.defineProperty(globalThis, DEFINED_PLUGIN_RUNTIME_REGISTRY, {
     configurable: false,
     enumerable: false,
-    value: runtime,
+    value: registry,
     writable: false,
   });
+  return registry;
+}
+
+function getDefinedPluginPipelineStateRegistry(): WeakMap<
+  object,
+  DefinedPluginPipelineState
+> {
+  const existing = Reflect.get(
+    globalThis,
+    DEFINED_PLUGIN_PIPELINE_STATE_REGISTRY,
+  );
+  if (existing !== undefined) {
+    if (existing instanceof WeakMap) {
+      return existing as WeakMap<object, DefinedPluginPipelineState>;
+    }
+    throw new Error(
+      "[evjs] The global defined-plugin pipeline state registry is invalid.",
+    );
+  }
+
+  const registry = new WeakMap<object, DefinedPluginPipelineState>();
+  Object.defineProperty(globalThis, DEFINED_PLUGIN_PIPELINE_STATE_REGISTRY, {
+    configurable: false,
+    enumerable: false,
+    value: registry,
+    writable: false,
+  });
+  return registry;
 }
 
 export function resolveDefinedPluginApplicationSetting(
   plugin: object,
   context: PluginOptionsContext,
-  options: { readonly reusePrepared?: boolean } = {},
 ): RuntimePluginSetting | undefined {
   const runtime = getDefinedPluginRuntime(plugin);
   if (!runtime) return undefined;
-  if (
-    options.reusePrepared === true &&
-    runtime.applicationSettingPrepared === true &&
-    runtime.applicationSetting
-  ) {
-    return runtime.applicationSetting;
-  }
-  return resolveRuntimeApplicationSetting(runtime, context);
+  const pipelineState = getOrCreateDefinedPluginPipelineState(plugin);
+  return resolveRuntimeApplicationSetting(runtime, pipelineState, context);
 }
 
 /** @internal Resolve one build-scoped Application snapshot before configure hooks. */
@@ -933,28 +1065,33 @@ export function prepareDefinedPluginApplicationSetting(
 ): void {
   const runtime = getDefinedPluginRuntime(plugin);
   if (!runtime) return;
-  resolveRuntimeApplicationSetting(runtime, context);
-  runtime.applicationSettingPrepared = true;
+  const pipelineState = getOrCreateDefinedPluginPipelineState(plugin);
+  resolveRuntimeApplicationSetting(runtime, pipelineState, context);
 }
 
 function resolveConfigureHookApplicationSetting(
-  runtime: DefinedPluginRuntime,
+  plugin: object,
   context: PluginOptionsContext,
 ): RuntimePluginSetting {
-  if (
-    runtime.applicationSettingPrepared === true &&
-    runtime.applicationSetting
-  ) {
-    return runtime.applicationSetting;
-  }
-  return resolveRuntimeApplicationSetting(runtime, context);
+  const runtime = requireDefinedPluginRuntime(plugin);
+  const pipelineState = getOrCreateDefinedPluginPipelineState(plugin);
+  return resolveRuntimeApplicationSetting(runtime, pipelineState, context);
 }
 
 function resolveRuntimeApplicationSetting(
   runtime: DefinedPluginRuntime,
+  pipelineState: DefinedPluginPipelineState,
   context: PluginOptionsContext,
 ): RuntimePluginSetting {
-  runtime.applicationSettingPrepared = false;
+  if (pipelineState.applicationSetting) {
+    return pipelineState.applicationSetting;
+  }
+  if (!runtime.active) {
+    return storeRuntimeApplicationSetting(
+      pipelineState,
+      Object.freeze({ enabled: false }),
+    );
+  }
   let config: object | undefined;
   if (runtime.application) {
     if (
@@ -978,7 +1115,15 @@ function resolveRuntimeApplicationSetting(
     enabled: true,
     ...(config ? { config } : {}),
   });
-  runtime.applicationSetting = setting;
+  return storeRuntimeApplicationSetting(pipelineState, setting);
+}
+
+function storeRuntimeApplicationSetting(
+  pipelineState: DefinedPluginPipelineState,
+  setting: RuntimePluginSetting,
+): RuntimePluginSetting {
+  pipelineState.applicationSetting = setting;
+  Object.freeze(pipelineState);
   return setting;
 }
 
@@ -989,6 +1134,7 @@ export function resolveDefinedPluginPageSetting(
 ): RuntimePluginSetting | undefined {
   const runtime = getDefinedPluginRuntime(plugin);
   if (!runtime) return undefined;
+  if (!runtime.active) return Object.freeze({ enabled: false });
   if (!runtime.page) {
     if (configured !== undefined) {
       throw new Error(
@@ -1104,15 +1250,15 @@ function resolvePluginContract(
   return resolved;
 }
 
-function getRuntimeApplicationSetting(
-  runtime: DefinedPluginRuntime,
-): RuntimePluginSetting {
-  if (!runtime.applicationSetting) {
+function getRuntimeApplicationSetting(plugin: object): RuntimePluginSetting {
+  const runtime = requireDefinedPluginRuntime(plugin);
+  const setting = definedPluginPipelineStates.get(plugin)?.applicationSetting;
+  if (!setting) {
     throw new Error(
       `[evjs] Plugin "${runtime.name}" Application options were not resolved before setup().`,
     );
   }
-  return runtime.applicationSetting;
+  return setting;
 }
 
 function readPageOptions<TBundlerCfg>(
@@ -1143,7 +1289,6 @@ interface RuntimeDefinedPluginDescriptor {
   readonly page?: AnyPluginOptionsContract;
   readonly dependencies?: unknown;
   readonly optionalDependencies?: unknown;
-  readonly enforce?: unknown;
   readonly configure?: unknown;
   readonly setup?: unknown;
   readonly emitIR?: unknown;
@@ -1165,7 +1310,6 @@ function assertDefinedPluginDescriptor(
       "page",
       "dependencies",
       "optionalDependencies",
-      "enforce",
       "configure",
       "setup",
       "emitIR",
@@ -1211,16 +1355,6 @@ function assertDefinedPluginDescriptor(
   if (overlappingDependency !== undefined) {
     throw new Error(
       `[evjs] definePlugin() optionalDependencies must not repeat required dependency "${overlappingDependency}".`,
-    );
-  }
-  if (
-    descriptor.enforce !== undefined &&
-    descriptor.enforce !== "pre" &&
-    descriptor.enforce !== "normal" &&
-    descriptor.enforce !== "post"
-  ) {
-    throw new Error(
-      '[evjs] definePlugin() enforce must be "pre", "normal", or "post".',
     );
   }
   for (const field of ["configure", "setup", "emitIR", "emitPageIR"] as const) {

--- a/packages/ev/src/plugin/index.ts
+++ b/packages/ev/src/plugin/index.ts
@@ -37,6 +37,12 @@ import type {
   DefaultBundlerConfig,
   ResolvedFrameworkConfig,
 } from "../config/index.js";
+import {
+  type PluginPreset as ConfigPluginPreset,
+  type PluginPresetEntry as ConfigPluginPresetEntry,
+  type PluginPresetFactory as ConfigPluginPresetFactory,
+  definePluginPreset as defineConfigPluginPreset,
+} from "../config/plugins.js";
 
 export type { StaticJsonValue } from "@evjs/shared/_internal/static-json";
 export type {
@@ -73,6 +79,30 @@ export {
   PluginHookError,
   type PluginHookName,
 } from "./errors.js";
+
+/** An entry accepted from a plugin preset factory. */
+export type PluginPresetEntry = ConfigPluginPresetEntry;
+
+/** An opaque tuple of plugin entries created by definePluginPreset(). */
+export type PluginPreset<
+  TEntries extends readonly unknown[] = readonly unknown[],
+> = ConfigPluginPreset<TEntries>;
+
+/** A preset factory preserving its original arguments and exact plugin tuple. */
+export type PluginPresetFactory<
+  TArguments extends readonly unknown[],
+  TEntries extends readonly PluginPresetEntry[],
+> = ConfigPluginPresetFactory<TArguments, TEntries>;
+
+/** Define a reusable synchronous plugin composition with exact tuple types. */
+export function definePluginPreset<
+  const TArguments extends readonly unknown[],
+  const TEntries extends readonly PluginPresetEntry[],
+>(
+  factory: (...args: TArguments) => TEntries,
+): PluginPresetFactory<TArguments, TEntries> {
+  return defineConfigPluginPreset(factory);
+}
 
 /**
  * Minimal DOM element / document interface for plugin HTML manipulation.
@@ -168,7 +198,7 @@ export interface ConfigureBundlerContext<TBundlerCfg = DefaultBundlerConfig> {
   /** The current working directory. */
   readonly cwd: string;
   /** The fully resolved, read-only framework config. */
-  readonly config: ReadonlyFrameworkConfig<TBundlerCfg>;
+  readonly config: FrameworkConfigView<TBundlerCfg>;
   /** The current command. */
   readonly command: "dev" | "build";
   /** Selected bundler adapter name. */
@@ -223,18 +253,42 @@ type DeepReadonly<T> = T extends AnyFunction
       ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
       : T;
 
-type ReadonlyPlugin<TBundlerCfg> = Readonly<
-  Omit<Plugin<TBundlerCfg>, "dependencies" | "optionalDependencies">
-> & {
-  readonly dependencies?: readonly string[];
-  readonly optionalDependencies?: readonly string[];
-};
+/** Installed-plugin metadata visible to public plugin contexts. */
+export interface FrameworkPluginView {
+  /** Stable plugin identity. */
+  readonly name: string;
+  /** Short Application/Page options key when the plugin declares one. */
+  readonly key?: string;
+  /** Whether this installed plugin participates in the current snapshot. */
+  readonly active: boolean;
+  /** Why a defined plugin was kept installed but made inactive. */
+  readonly inactiveReason?: string;
+}
 
-type ReadonlyFrameworkConfig<TBundlerCfg> = DeepReadonly<
-  Omit<ResolvedFrameworkConfig<TBundlerCfg>, "plugins">
-> & {
-  readonly plugins: readonly ReadonlyPlugin<TBundlerCfg>[];
-};
+/** Selected-bundler metadata visible to public plugin contexts. */
+export interface FrameworkBundlerView {
+  /** Human-readable adapter name. */
+  readonly name: string;
+  /** Stable framework capabilities advertised by the adapter. */
+  readonly capabilities: DeepReadonly<
+    NonNullable<ResolvedFrameworkConfig["bundler"]>["capabilities"]
+  >;
+}
+
+/**
+ * Framework metadata exposed through public plugin contexts.
+ *
+ * Executable plugin and bundler implementation methods are intentionally
+ * projected out. Hooks receive supported operations from phase-specific
+ * context fields instead.
+ */
+export type FrameworkConfigView<TBundlerCfg = DefaultBundlerConfig> =
+  DeepReadonly<
+    Omit<ResolvedFrameworkConfig<TBundlerCfg>, "bundler" | "plugins">
+  > & {
+    readonly bundler?: FrameworkBundlerView;
+    readonly plugins: readonly FrameworkPluginView[];
+  };
 
 type PluginConfigureHook<TBundlerCfg> = <
   TActualBundlerCfg extends TBundlerCfg = TBundlerCfg,
@@ -306,13 +360,6 @@ export interface Plugin<TBundlerCfg = unknown> {
    * hook deterministic and free of external side effects.
    */
   emitIR?: PluginEmitIRHook<TBundlerCfg>;
-
-  /**
-   * Relative ordering tier for plugins without an explicit dependency edge.
-   *
-   * Dependencies still win over enforce ordering.
-   */
-  enforce?: "pre" | "normal" | "post";
 }
 
 interface PluginBaseContext<TBundlerCfg = DefaultBundlerConfig> {
@@ -321,7 +368,7 @@ interface PluginBaseContext<TBundlerCfg = DefaultBundlerConfig> {
   /** The current working directory. */
   readonly cwd: string;
   /** The fully resolved, read-only framework config. */
-  readonly config: ReadonlyFrameworkConfig<TBundlerCfg>;
+  readonly config: FrameworkConfigView<TBundlerCfg>;
   /** Extra CLI flags made available to plugins. */
   readonly flags?: DeepReadonly<CliFlags>;
   /** Current command. */
@@ -796,9 +843,10 @@ export interface PluginHooks<TBundlerCfg = unknown> {
   afterBuild?: (result: BuildResult) => void | Promise<void>;
 
   /**
-   * Tear down this plugin snapshot after a one-shot build or prepare completes,
+   * Tear down this activated plugin snapshot after a one-shot build completes,
    * when dev stops, or when config reload replaces or rolls back the snapshot.
-   * This hook does not run after each development rebuild.
+   * Non-activating prepare/inspect commands and ordinary dev rebuilds do not
+   * call this hook.
    */
   dispose?: DisposeHook<TBundlerCfg>;
 }

--- a/packages/ev/tests/build-tools-config-module.test.ts
+++ b/packages/ev/tests/build-tools-config-module.test.ts
@@ -166,6 +166,33 @@ describe("loadConfigFile", () => {
     }
   });
 
+  it("preserves plugin presets across the config loader boundary", async () => {
+    const cwd = await createFixture({
+      "ev.config.ts": `
+        import { defineConfig } from "@evjs/ev";
+        import {
+          definePlugin,
+          definePluginPreset,
+        } from "@evjs/ev/plugin";
+
+        const analytics = definePlugin({ name: "@company/analytics" });
+        const observability = definePluginPreset(
+          () => [analytics().when(true), false] as const,
+        );
+
+        export default defineConfig({ plugins: [observability()] });
+      `,
+    });
+
+    const loaded = await loadConfigFile(path.join(cwd, "ev.config.ts"));
+    const resolved = resolveConfig(loaded);
+
+    expect(resolved.plugins.map((plugin) => plugin.name)).toEqual([
+      "@company/analytics",
+    ]);
+    expect(resolved.plugins[0]?.active).toBe(true);
+  });
+
   it("does not expose unpublished framework source paths through aliases", async () => {
     const cwd = await createFixture({
       "ev.config.ts": `

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -579,7 +579,7 @@ describe("prepareFrameworkBuild", () => {
     ).rejects.toThrow("[evjs] options.bundler.dev must be a function.");
   });
 
-  it("prepares framework inputs without exposing graph and plan internals", async () => {
+  it("prepares framework inputs without activating plugin setup", async () => {
     const cwd = await createProject();
     const events: string[] = [];
     const plugin: Plugin<Record<string, never>> = {
@@ -588,9 +588,12 @@ describe("prepareFrameworkBuild", () => {
         events.push(`config:${ctx.command}`);
         return config;
       },
+      emitIR(ctx) {
+        ctx.addWatchFile("./framework-extra.json");
+        events.push(`emitIR:${ctx.command}`);
+      },
       setup(ctx) {
         expect(ctx.config.bundler).toBeUndefined();
-        ctx.addWatchFile("./framework-extra.json");
         events.push(`setup:${ctx.command}`);
         return {
           beforeBuild() {
@@ -619,12 +622,12 @@ describe("prepareFrameworkBuild", () => {
     expect(prepared.pluginWatchFiles).toEqual([
       path.join(cwd, "framework-extra.json"),
     ]);
-    expect(events).toEqual(["config:build", "setup:build"]);
+    expect(events).toEqual(["config:build", "emitIR:build"]);
 
     await prepared.dispose();
     await prepared.dispose();
 
-    expect(events).toEqual(["config:build", "setup:build", "dispose"]);
+    expect(events).toEqual(["config:build", "emitIR:build"]);
   });
 
   it("syncs one stable static-config bridge regardless of active plugins", async () => {
@@ -747,7 +750,7 @@ describe("prepareFrameworkBuild", () => {
     const events: string[] = [];
 
     await expect(
-      prepareFrameworkBuild(
+      build(
         {
           output: { client: "dist/client", server: "dist/server" },
           plugins: [
@@ -771,7 +774,7 @@ describe("prepareFrameworkBuild", () => {
             },
           ],
         },
-        { cwd },
+        { cwd, bundler: createMockBundler([]) },
       ),
     ).rejects.toThrow("setup blocked");
 
@@ -867,7 +870,7 @@ describe("prepareFrameworkBuild", () => {
     const events: string[] = [];
 
     await expect(
-      prepareFrameworkBuild(
+      build(
         {
           plugins: [
             {
@@ -885,7 +888,7 @@ describe("prepareFrameworkBuild", () => {
             },
           ],
         },
-        { cwd },
+        { cwd, bundler: createMockBundler([]) },
       ),
     ).rejects.toThrow("setup aborted");
 
@@ -897,7 +900,7 @@ describe("prepareFrameworkBuild", () => {
     const events: string[] = [];
 
     await expect(
-      prepareFrameworkBuild(
+      build(
         {
           plugins: [
             {
@@ -919,7 +922,7 @@ describe("prepareFrameworkBuild", () => {
             },
           ],
         },
-        { cwd },
+        { cwd, bundler: createMockBundler([]) },
       ),
     ).rejects.toThrow(
       'Plugin "invalid-hooks-rollback" setup hook returned beforeBuild must be a function',
@@ -972,7 +975,7 @@ describe("prepareFrameworkBuild", () => {
   ])("rejects setup results with $label", async ({ create }) => {
     const cwd = await createProject();
     let getterReads = 0;
-    const preparing = prepareFrameworkBuild(
+    const preparing = build(
       {
         plugins: [
           {
@@ -985,7 +988,7 @@ describe("prepareFrameworkBuild", () => {
           },
         ],
       },
-      { cwd },
+      { cwd, bundler: createMockBundler([]) },
     );
 
     await expect(preparing).rejects.toMatchObject({
@@ -1011,7 +1014,7 @@ describe("prepareFrameworkBuild", () => {
         throw new Error("own getter must not run");
       },
     });
-    const preparing = prepareFrameworkBuild(
+    const preparing = build(
       {
         plugins: [
           {
@@ -1022,7 +1025,7 @@ describe("prepareFrameworkBuild", () => {
           },
         ],
       },
-      { cwd },
+      { cwd, bundler: createMockBundler([]) },
     );
 
     await expect(preparing).rejects.toMatchObject({
@@ -1044,7 +1047,7 @@ describe("prepareFrameworkBuild", () => {
     returnedHooks.dispose = function () {
       events.push(this === returnedHooks ? "dispose:bound" : "dispose:unbound");
     };
-    const prepared = await prepareFrameworkBuild(
+    await build(
       {
         plugins: [
           {
@@ -1055,10 +1058,9 @@ describe("prepareFrameworkBuild", () => {
           },
         ],
       },
-      { cwd },
+      { cwd, bundler: createMockBundler([]) },
     );
 
-    await prepared.dispose();
     expect(events).toEqual(["dispose:bound"]);
   });
 
@@ -1174,7 +1176,7 @@ describe("prepareFrameworkBuild", () => {
   it("disposes plugins in reverse order and continues after failures", async () => {
     const cwd = await createProject();
     const events: string[] = [];
-    const prepared = await prepareFrameworkBuild(
+    const building = build(
       {
         output: { client: "dist/client", server: "dist/server" },
         plugins: [
@@ -1201,10 +1203,10 @@ describe("prepareFrameworkBuild", () => {
           },
         ],
       },
-      { cwd },
+      { cwd, bundler: createMockBundler([]) },
     );
 
-    await expect(prepared.dispose()).rejects.toThrow("dispose blocked");
+    await expect(building).rejects.toThrow("dispose blocked");
     expect(events).toEqual(["dispose:second", "dispose:first"]);
   });
 
@@ -8084,52 +8086,6 @@ describe("build", () => {
       "setup:plugin-b",
       "setup:plugin-c",
       "setup:plugin-a",
-      "bundler.build",
-      "bundler.entries:",
-    ]);
-  });
-
-  it("orders unrelated plugins by enforce tier", async () => {
-    const cwd = await createProject();
-    const events: string[] = [];
-    const bundler = createMockBundler(events);
-
-    await build(
-      {
-        output: { client: "dist/client", server: "dist/server" },
-        plugins: [
-          {
-            name: "post",
-            enforce: "post",
-            setup() {
-              events.push("setup:post");
-            },
-          },
-          {
-            name: "normal",
-            setup() {
-              events.push("setup:normal");
-            },
-          },
-          {
-            name: "pre",
-            enforce: "pre",
-            setup() {
-              events.push("setup:pre");
-            },
-          },
-        ],
-      },
-      {
-        cwd,
-        bundler,
-      },
-    );
-
-    expect(events).toEqual([
-      "setup:pre",
-      "setup:normal",
-      "setup:post",
       "bundler.build",
       "bundler.entries:",
     ]);

--- a/packages/ev/tests/config.test.ts
+++ b/packages/ev/tests/config.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../src/deployment/index.js";
 import {
   definePlugin,
+  definePluginPreset,
   type Plugin,
   pluginOptions,
 } from "../src/plugin/index.js";
@@ -116,6 +117,21 @@ const emptyPagePlugin = definePlugin({
 });
 const installedEmptyPagePlugin = emptyPagePlugin();
 
+const accessPreset = definePluginPreset(() => [installedAccessPlugin] as const);
+const pagePluginsPreset = definePluginPreset((channel: string) => {
+  void channel;
+  return [installedAnalyticsPlugin, false, accessPreset(), null] as const;
+});
+const installedPagePluginsPreset = pagePluginsPreset("checkout");
+const analyticsPreset = definePluginPreset(
+  () => [installedAnalyticsPlugin] as const,
+);
+const widenedPreset = definePluginPreset(
+  (): readonly (typeof installedAnalyticsPlugin)[] => [
+    installedAnalyticsPlugin,
+  ],
+);
+
 const ambientOnlyPlugin = definePlugin({
   name: "@test/ambient-only",
   key: "ambient-only",
@@ -152,6 +168,26 @@ type ConditionalTuplePlugin = ExtractInstalledPlugin<
 >;
 type WidenedArrayPlugin = ExtractInstalledPlugin<
   { readonly plugins: readonly (typeof installedAnalyticsPlugin)[] },
+  "analytics"
+>;
+type NestedPresetAnalyticsPlugin = ExtractInstalledPlugin<
+  { readonly plugins: readonly [typeof installedPagePluginsPreset] },
+  "analytics"
+>;
+type NestedPresetAccessPlugin = ExtractInstalledPlugin<
+  { readonly plugins: readonly [typeof installedPagePluginsPreset] },
+  "access"
+>;
+type ConditionalPresetPlugin = ExtractInstalledPlugin<
+  {
+    readonly plugins: readonly [
+      ReturnType<typeof analyticsPreset> | ReturnType<typeof accessPreset>,
+    ];
+  },
+  "analytics"
+>;
+type WidenedPresetPlugin = ExtractInstalledPlugin<
+  { readonly plugins: readonly [ReturnType<typeof widenedPreset>] },
   "analytics"
 >;
 
@@ -282,9 +318,17 @@ describe("config authoring", () => {
     expectTypeOf<DeterministicTuplePlugin>().toEqualTypeOf<
       typeof installedAnalyticsPlugin
     >();
+    expectTypeOf<NestedPresetAnalyticsPlugin>().toEqualTypeOf<
+      typeof installedAnalyticsPlugin
+    >();
+    expectTypeOf<NestedPresetAccessPlugin>().toEqualTypeOf<
+      typeof installedAccessPlugin
+    >();
     expectTypeOf<ConditionalConfigPlugin>().toEqualTypeOf<never>();
     expectTypeOf<ConditionalTuplePlugin>().toEqualTypeOf<never>();
     expectTypeOf<WidenedArrayPlugin>().toEqualTypeOf<never>();
+    expectTypeOf<ConditionalPresetPlugin>().toEqualTypeOf<never>();
+    expectTypeOf<WidenedPresetPlugin>().toEqualTypeOf<never>();
   });
 
   it("accepts Page plugin settings widened to the public config type", () => {
@@ -1139,7 +1183,6 @@ describe("resolveConfig", () => {
       name: "@test/plugin",
       dependencies: ["required"],
       optionalDependencies: ["optional"],
-      enforce: "pre" as const,
       setup,
     };
     const resolved = resolveConfig({
@@ -1150,6 +1193,7 @@ describe("resolveConfig", () => {
     expect(resolved.plugins[0]).toMatchObject({
       name: "@test/plugin",
     });
+    expect(resolved.plugins[0]?.active).toBe(true);
     expect(() =>
       resolveConfig({
         plugins: [{ name: "@test/plugin", key: "test-plugin" } as never],
@@ -1190,6 +1234,26 @@ describe("resolveConfig", () => {
       resolveConfig({
         plugins: [
           {
+            name: "removed-ordering-tier",
+            enforce: "pre",
+          } as never,
+        ],
+      }),
+    ).toThrow("plugins[0].enforce is not supported");
+    expect(() =>
+      resolveConfig({
+        plugins: [
+          {
+            name: "raw-conditional-plugin",
+            when() {},
+          } as never,
+        ],
+      }),
+    ).toThrow("plugins[0].when is not supported");
+    expect(() =>
+      resolveConfig({
+        plugins: [
+          {
             name: "test-plugin",
             beforeBuild() {},
           } as never,
@@ -1206,6 +1270,115 @@ describe("resolveConfig", () => {
         ],
       }),
     ).toThrow("Return the hook from plugins[0].setup() instead");
+  });
+
+  it("expands branded plugin presets recursively in declaration order", () => {
+    const first = { name: "first" };
+    const second = { name: "second" };
+    const nested = definePluginPreset(
+      (plugin: Plugin) => [false, plugin, null] as const,
+    );
+    const composed = definePluginPreset(
+      (plugin: Plugin) => [first, nested(plugin), undefined, second] as const,
+    );
+
+    expect(
+      resolveConfig({
+        plugins: [composed({ name: "nested" })],
+      }).plugins.map((plugin) => plugin.name),
+    ).toEqual(["first", "nested", "second"]);
+  });
+
+  it("rejects unbranded arrays and Promises in plugin compositions", () => {
+    const plugin = { name: "@test/plugin" };
+    const nestedArrayPreset = definePluginPreset(
+      () => [[plugin] as unknown as Plugin] as const,
+    );
+    const promisedEntryPreset = definePluginPreset(
+      () => [Promise.resolve(plugin) as unknown as Plugin] as const,
+    );
+    const asyncPreset = definePluginPreset((() =>
+      Promise.resolve([plugin] as const)) as unknown as () => readonly [
+      Plugin,
+    ]);
+    const circularEntries: Plugin[] = [];
+    const circularPreset = definePluginPreset(() => circularEntries)();
+    circularEntries.push(circularPreset as unknown as Plugin);
+
+    expect(() => resolveConfig({ plugins: [[plugin]] as never })).toThrow(
+      "plugins[0] must not be a bare plugin array",
+    );
+    expect(() =>
+      resolveConfig({ plugins: [Promise.resolve(plugin)] as never }),
+    ).toThrow("plugins[0] must not be a Promise");
+    expect(() => resolveConfig({ plugins: [nestedArrayPreset()] })).toThrow(
+      "plugins[0].preset[0] must not be a bare plugin array",
+    );
+    expect(() => resolveConfig({ plugins: [promisedEntryPreset()] })).toThrow(
+      "plugins[0].preset[0] must not be a Promise",
+    );
+    expect(() => resolveConfig({ plugins: [asyncPreset()] })).toThrow(
+      "must return an array synchronously, not a Promise",
+    );
+    expect(() => resolveConfig({ plugins: [circularPreset] })).toThrow(
+      "plugins[0].preset[0] contains a circular plugin preset",
+    );
+  });
+
+  it("does not trust forged plugin preset brands", () => {
+    let getterCalls = 0;
+    const forgedPreset = {};
+    Object.defineProperty(forgedPreset, Symbol.for("@evjs/ev/plugin-preset"), {
+      get() {
+        getterCalls++;
+        return [{ name: "forged" }];
+      },
+    });
+
+    expect(() => resolveConfig({ plugins: [forgedPreset as never] })).toThrow(
+      "plugins[0] must not contain symbol fields",
+    );
+    expect(getterCalls).toBe(0);
+  });
+
+  it("does not trust forged defined-plugin runtime brands", () => {
+    let getterCalls = 0;
+    const forgedPlugin = { name: "forged" };
+    Object.defineProperty(
+      forgedPlugin,
+      Symbol.for("@evjs/ev/defined-plugin-runtime"),
+      {
+        get() {
+          getterCalls++;
+          return { key: "forged" };
+        },
+      },
+    );
+
+    expect(() => resolveConfig({ plugins: [forgedPlugin as never] })).toThrow(
+      "plugins[0] must not contain symbol fields",
+    );
+    expect(getterCalls).toBe(0);
+  });
+
+  it("rejects invalid plugin preset entries at compile time", () => {
+    const plugin = { name: "@test/plugin" };
+    const assertInvalidPresets = () => {
+      // @ts-expect-error Bare arrays are not plugin entries.
+      defineConfig({
+        plugins: [[plugin]],
+      });
+      // @ts-expect-error Promises are not plugin entries.
+      defineConfig({
+        plugins: [Promise.resolve(plugin)],
+      });
+      // @ts-expect-error Presets may nest only branded presets, not arrays.
+      definePluginPreset(() => [[plugin] as const] as const);
+      // @ts-expect-error Preset factories must return their tuple synchronously.
+      definePluginPreset(async () => [plugin] as const);
+    };
+
+    expect(assertInvalidPresets).toBeTypeOf("function");
   });
 
   it("does not share resolved mutable state between calls", () => {

--- a/packages/ev/tests/package-surface.test.ts
+++ b/packages/ev/tests/package-surface.test.ts
@@ -538,6 +538,7 @@ describe("workspace package surface", () => {
       "PLUGIN_HOOK_ERROR_CODE",
       "PluginHookError",
       "definePlugin",
+      "definePluginPreset",
       "pluginOptions",
     ]);
 

--- a/packages/ev/tests/plugin-activation.test.ts
+++ b/packages/ev/tests/plugin-activation.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import { orderPluginsByDependencies } from "../src/_internal/build/plugin-lifecycle.js";
+import {
+  collectPluginSettingsRegistry,
+  resolvePluginSettingsState,
+} from "../src/_internal/build/plugin-settings.js";
+import { resolveConfig } from "../src/config/index.js";
+import { definePlugin, pluginOptions } from "../src/plugin/index.js";
+
+describe("defined plugin activation", () => {
+  it("keeps contracts installed while when(false) removes executable hooks", () => {
+    const configure = vi.fn();
+    const setup = vi.fn();
+    const emitIR = vi.fn();
+    const analytics = definePlugin({
+      name: "@company/analytics",
+      key: "analytics",
+      application: pluginOptions({
+        defaults: { endpoint: "/events" },
+      }),
+      page: pluginOptions({
+        defaults: { channel: "default" },
+      }),
+      configure,
+      setup,
+      emitIR,
+    });
+
+    const authored = analytics({ endpoint: "/custom" }).when(
+      false,
+      "disabled outside production",
+    );
+    expect(Object.keys(authored)).not.toContain("when");
+    expect(authored.configure).toBeUndefined();
+    expect(authored.setup).toBeUndefined();
+    expect(authored.emitIR).toBeUndefined();
+
+    const config = resolveConfig({ plugins: [authored] });
+    expect(config.plugins[0]?.active).toBe(false);
+    const registry = collectPluginSettingsRegistry(config.plugins);
+    const settings = resolvePluginSettingsState(config, registry);
+
+    expect(registry.entries[0]).toMatchObject({
+      name: "@company/analytics",
+      key: "analytics",
+      active: false,
+      inactiveReason: "disabled outside production",
+      stages: ["configure", "setup", "emitIR"],
+    });
+    expect(registry.catalog.entries.analytics).toMatchObject({
+      name: "@company/analytics",
+      application: {},
+      page: { defaultable: true },
+    });
+    expect(settings.applicationSettings).toEqual({
+      analytics: { enabled: false },
+    });
+    expect(configure).not.toHaveBeenCalled();
+    expect(setup).not.toHaveBeenCalled();
+    expect(emitIR).not.toHaveBeenCalled();
+  });
+
+  it("keeps the same precise plugin type when the condition is true", () => {
+    const analytics = definePlugin({
+      name: "@company/analytics",
+      key: "analytics",
+      page: pluginOptions({
+        defaults: { channel: "default" },
+      }),
+      setup() {},
+    });
+
+    const plugin = analytics().when(true);
+    const key: "analytics" = plugin.key;
+
+    expect(key).toBe("analytics");
+    expect(plugin.setup).toBeTypeOf("function");
+  });
+
+  it("validates the condition and diagnostic reason", () => {
+    const analytics = definePlugin({ name: "@company/analytics" });
+    const plugin = analytics();
+
+    expect(() => plugin.when("yes" as unknown as boolean)).toThrow(
+      "when() expects a boolean condition",
+    );
+    expect(() => plugin.when(false, " disabled ")).toThrow(
+      "when() reason must be a non-empty string",
+    );
+  });
+
+  it("does not let an inactive plugin satisfy a required dependency", () => {
+    const base = definePlugin({ name: "@company/base" });
+    const inactiveBase = base().when(false, "not available in this target");
+    const required = {
+      name: "@company/required",
+      dependencies: ["@company/base"],
+    };
+
+    expect(() => orderPluginsByDependencies([required, inactiveBase])).toThrow(
+      'Plugin "@company/required" depends on inactive plugin "@company/base": not available in this target',
+    );
+
+    const optional = {
+      name: "@company/optional",
+      optionalDependencies: ["@company/base"],
+    };
+    expect(
+      orderPluginsByDependencies([optional, inactiveBase]).map(
+        (plugin) => plugin.name,
+      ),
+    ).toEqual(["@company/optional", "@company/base"]);
+  });
+});

--- a/packages/ev/tests/plugin-settings.test.ts
+++ b/packages/ev/tests/plugin-settings.test.ts
@@ -2,8 +2,13 @@ import type { CoreGraph, CorePagePluginSetting } from "@evjs/shared/manifest";
 import { PAGE_ANCHOR_PROVIDER_ID } from "@evjs/shared/manifest";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { describe, expect, it } from "vitest";
+import type { BundlerAdapter } from "../src/_internal/build/bundler.js";
+import { inspectFrameworkBuild } from "../src/_internal/build/inspect.js";
 import type { ResolvedPageFileConfig } from "../src/_internal/build/page-config-module.js";
-import { runConfigureHooks } from "../src/_internal/build/plugin-lifecycle.js";
+import {
+  createPluginConfigSnapshot,
+  runConfigureHooks,
+} from "../src/_internal/build/plugin-lifecycle.js";
 import {
   applyPluginSettings,
   collectPluginSettingsRegistry,
@@ -17,6 +22,7 @@ import {
 } from "../src/config/plugins.js";
 import {
   definePlugin,
+  definePluginPreset,
   PLUGIN_HOOK_ERROR_CODE,
   type Plugin,
   PluginHookError,
@@ -160,8 +166,12 @@ describe("definePlugin and pluginOptions", () => {
         ctx.config.dev.port = 4000;
         // @ts-expect-error The installed plugin list is read-only after configure().
         ctx.config.plugins.push({ name: "late-plugin" });
-        // @ts-expect-error Plugin dependency lists are read-only after configure().
-        ctx.config.plugins[0]?.dependencies?.push("late-dependency");
+        // @ts-expect-error Plugin implementation hooks are not context metadata.
+        ctx.config.plugins[0]?.setup;
+        // @ts-expect-error Bundler execution methods are not context metadata.
+        ctx.config.bundler?.build;
+        // @ts-expect-error Bundler dev methods are not context metadata.
+        ctx.config.bundler?.dev;
         return {
           configureBundler(_config, bundlerCtx) {
             // @ts-expect-error The framework config view stays read-only here.
@@ -207,6 +217,114 @@ describe("definePlugin and pluginOptions", () => {
     expect(crossBundlerPlugin.name).toBe("@company/agnostic");
     expect(fixedPlugin.name).toBe("@company/fixed");
     expect(assertFixedBundlerContract).toBeTypeOf("function");
+  });
+
+  it("projects context config to framework metadata without mutating it", () => {
+    const analytics = definePlugin({
+      name: "@company/analytics",
+      key: "analytics",
+      application: pluginOptions({ defaults: {} }),
+      configure() {},
+      setup() {},
+      emitIR() {},
+    });
+    const monitoring = definePlugin({
+      name: "@company/monitoring",
+      setup() {},
+    });
+    const rawPlugin: Plugin = {
+      name: "raw-plugin",
+      setup() {},
+      emitIR() {},
+    };
+    const build = async () => ({});
+    const dev = async () => undefined;
+    const bundler = {
+      name: "test-bundler",
+      capabilities: {
+        build: { server: true, rsc: false, ppr: false },
+        dev: {
+          configuration: false,
+          html: true,
+          entries: false,
+          routes: false,
+          server: false,
+          resolution: false,
+        },
+      },
+      build,
+      dev,
+    } satisfies BundlerAdapter<Record<string, never>>;
+    const config = {
+      ...resolveConfig({
+        dev: {
+          proxy: [
+            {
+              context: ["/api"],
+              target: "http://localhost:8080",
+              pathRewrite: { when: "/preserved" },
+            },
+          ],
+        },
+        plugins: [
+          analytics(),
+          monitoring().when(false, "disabled in this environment"),
+          rawPlugin,
+        ],
+      }),
+      bundler,
+    };
+
+    const snapshot = createPluginConfigSnapshot(config);
+
+    expect(snapshot.plugins).toEqual([
+      {
+        name: "@company/analytics",
+        key: "analytics",
+        active: true,
+      },
+      {
+        name: "@company/monitoring",
+        active: false,
+        inactiveReason: "disabled in this environment",
+      },
+      { name: "raw-plugin", active: true },
+    ]);
+    for (const plugin of snapshot.plugins) {
+      expect(plugin).not.toHaveProperty("configure");
+      expect(plugin).not.toHaveProperty("setup");
+      expect(plugin).not.toHaveProperty("emitIR");
+    }
+    expect(snapshot.bundler).toEqual({
+      name: "test-bundler",
+      capabilities: bundler.capabilities,
+    });
+    expect(snapshot.bundler).not.toHaveProperty("build");
+    expect(snapshot.bundler).not.toHaveProperty("dev");
+    expect(snapshot.dev.proxy[0]?.pathRewrite).toEqual({
+      when: "/preserved",
+    });
+    expect(snapshot.plugins[0]).not.toBe(config.plugins[0]);
+    expect(snapshot.bundler).not.toBe(config.bundler);
+    expect(snapshot.bundler?.capabilities).not.toBe(
+      config.bundler.capabilities,
+    );
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot.plugins)).toBe(true);
+    expect(Object.isFrozen(snapshot.plugins[0])).toBe(true);
+    expect(Object.isFrozen(snapshot.bundler)).toBe(true);
+    expect(Object.isFrozen(snapshot.bundler?.capabilities)).toBe(true);
+
+    expect(config.plugins[0]?.configure).toBeTypeOf("function");
+    expect(config.plugins[0]?.setup).toBeTypeOf("function");
+    expect(config.plugins[0]?.emitIR).toBeTypeOf("function");
+    expect(config.plugins[2]?.setup).toBeTypeOf("function");
+    expect(config.plugins[2]?.emitIR).toBeTypeOf("function");
+    expect(config.bundler.build).toBe(build);
+    expect(config.bundler.dev).toBe(dev);
+    expect(Object.isFrozen(config.plugins[0])).toBe(false);
+    expect(Object.isFrozen(config.bundler)).toBe(false);
+    expect(Object.isFrozen(config.bundler.capabilities)).toBe(false);
   });
 
   it("validates descriptor identity and owner contracts", () => {
@@ -276,7 +394,7 @@ describe("definePlugin and pluginOptions", () => {
     expect(assertStaticKey).toBeTypeOf("function");
   });
 
-  it("validates descriptor ordering and hook fields at definition time", () => {
+  it("validates descriptor dependencies and hook fields at definition time", () => {
     expect(() =>
       definePlugin({
         name: "@company/invalid-dependencies",
@@ -300,12 +418,15 @@ describe("definePlugin and pluginOptions", () => {
     ).toThrow(
       'definePlugin() optionalDependencies must not repeat required dependency "@company/base"',
     );
-    expect(() =>
+    const assertRemovedEnforceField = () =>
       definePlugin({
-        name: "@company/invalid-enforce",
-        enforce: "first",
-      } as never),
-    ).toThrow('definePlugin() enforce must be "pre", "normal", or "post"');
+        name: "@company/removed-enforce",
+        // @ts-expect-error Global ordering tiers are not part of the plugin API.
+        enforce: "pre",
+      });
+    expect(assertRemovedEnforceField).toThrow(
+      "definePlugin() descriptor contains unsupported field enforce",
+    );
     expect(() =>
       definePlugin({
         name: "@company/invalid-setup",
@@ -408,7 +529,7 @@ describe("definePlugin and pluginOptions", () => {
     });
     const plugin = analytics({ retry: { count: 3 } });
     const state = resolveInstalled(plugin);
-    plugin.setup?.({} as never);
+    state.plugin.setup?.({} as never);
     const graph = applyPluginSettings(createSpaGraph(), state.registry, {
       applicationSettings: state.applicationSettings,
       canonicalPages: {
@@ -456,8 +577,8 @@ describe("definePlugin and pluginOptions", () => {
       retry: { count: 3, backoff: undefined },
     });
 
-    resolveInstalled(plugin);
-    plugin.setup?.({} as never);
+    const state = resolveInstalled(plugin);
+    state.plugin.setup?.({} as never);
 
     expect(setupSettings).toEqual([
       {
@@ -638,10 +759,9 @@ describe("definePlugin and pluginOptions", () => {
         mode: "production",
       },
     );
-    resolvePluginSettingsState(resolveConfig(configured), undefined, {
-      reusePreparedApplicationSettings: true,
-    });
-    plugin.setup?.({} as never);
+    const resolved = resolveConfig(configured);
+    resolvePluginSettingsState(resolved);
+    resolved.plugins[0]?.setup?.({} as never);
 
     expect(defaultsCalls).toBe(1);
     expect(validationCalls).toBe(1);
@@ -650,6 +770,312 @@ describe("definePlugin and pluginOptions", () => {
       { sequence: 1, routingMode: "mpa" },
     ]);
     expect(seen[0]).toBe(seen[1]);
+  });
+
+  it.each([
+    "direct",
+    "preset",
+  ] as const)("isolates Application snapshots across concurrent %s config pipelines", async (installation) => {
+    type Snapshot = Readonly<{
+      routingMode: "spa" | "mpa";
+      sequence: number;
+    }>;
+    type Stage = "configure" | "setup" | "emitIR";
+
+    let defaultsCalls = 0;
+    const seen: { stage: Stage; options: Snapshot }[] = [];
+    let releaseFirstPipeline: (() => void) | undefined;
+    const firstPipelinePaused = new Promise<void>((resolve) => {
+      releaseFirstPipeline = resolve;
+    });
+    let markFirstPipelinePaused: (() => void) | undefined;
+    const waitForFirstPipeline = new Promise<void>((resolve) => {
+      markFirstPipelinePaused = resolve;
+    });
+    const gate: Plugin = {
+      name: "pipeline-gate",
+      async configure(_config, context) {
+        if (context.cwd !== "/pipeline-a") return;
+        markFirstPipelinePaused?.();
+        await firstPipelinePaused;
+      },
+    };
+    const contextual = definePlugin({
+      name: "@company/concurrent-contextual",
+      key: "concurrent-contextual",
+      application: pluginOptions<Snapshot>({
+        defaults(context) {
+          return {
+            routingMode: context.routingMode,
+            sequence: ++defaultsCalls,
+          };
+        },
+      }),
+      configure(config, context) {
+        seen.push({ stage: "configure", options: context.options });
+        return { ...config };
+      },
+      setup(context) {
+        seen.push({ stage: "setup", options: context.options });
+      },
+      emitIR(context) {
+        seen.push({ stage: "emitIR", options: context.options });
+      },
+    });
+    const sharedPlugin = contextual();
+    const installedPreset = definePluginPreset(() => [sharedPlugin] as const)();
+    const installed =
+      installation === "preset" ? installedPreset : sharedPlugin;
+    const firstConfiguring = runConfigureHooks(
+      {
+        routing: { mode: "spa" },
+        plugins: [gate, installed],
+      },
+      {
+        command: "build",
+        cwd: "/pipeline-a",
+        mode: "production",
+      },
+    );
+
+    await Promise.race([
+      waitForFirstPipeline,
+      firstConfiguring.then(() => {
+        throw new Error(
+          "First config pipeline completed before reaching the configure gate.",
+        );
+      }),
+    ]);
+    let secondConfigured: Awaited<ReturnType<typeof runConfigureHooks>>;
+    try {
+      secondConfigured = await runConfigureHooks(
+        {
+          routing: { mode: "mpa" },
+          plugins: [gate, installed],
+        },
+        {
+          command: "build",
+          cwd: "/pipeline-b",
+          mode: "production",
+        },
+      );
+    } finally {
+      releaseFirstPipeline?.();
+      await firstConfiguring;
+    }
+    const firstConfigured = await firstConfiguring;
+    const firstResolved = resolveConfig(firstConfigured);
+    const secondResolved = resolveConfig(secondConfigured);
+
+    resolvePluginSettingsState(firstResolved);
+    resolvePluginSettingsState(secondResolved);
+    const firstPlugin = firstResolved.plugins.find(
+      (plugin) => plugin.name === "@company/concurrent-contextual",
+    );
+    const secondPlugin = secondResolved.plugins.find(
+      (plugin) => plugin.name === "@company/concurrent-contextual",
+    );
+    if (!firstPlugin || !secondPlugin) {
+      throw new Error(
+        "Expected the contextual plugin in both config pipelines.",
+      );
+    }
+
+    await firstPlugin.setup?.({} as never);
+    await secondPlugin.setup?.({} as never);
+    await firstPlugin.emitIR?.({
+      framework: { pages: [] },
+    } as never);
+    await secondPlugin.emitIR?.({
+      framework: { pages: [] },
+    } as never);
+
+    expect(defaultsCalls).toBe(2);
+    expect(seen.map(({ stage, options }) => ({ stage, ...options }))).toEqual([
+      { stage: "configure", routingMode: "mpa", sequence: 2 },
+      { stage: "configure", routingMode: "spa", sequence: 1 },
+      { stage: "setup", routingMode: "spa", sequence: 1 },
+      { stage: "setup", routingMode: "mpa", sequence: 2 },
+      { stage: "emitIR", routingMode: "spa", sequence: 1 },
+      { stage: "emitIR", routingMode: "mpa", sequence: 2 },
+    ]);
+    expect(seen[1]?.options).toBe(seen[2]?.options);
+    expect(seen[1]?.options).toBe(seen[4]?.options);
+    expect(seen[0]?.options).toBe(seen[3]?.options);
+    expect(seen[0]?.options).toBe(seen[5]?.options);
+  });
+
+  it.each([
+    "direct",
+    "preset",
+  ] as const)("preserves %s Application snapshots through concurrent inspect pipelines", async (installation) => {
+    type Snapshot = Readonly<{
+      routingMode: "spa" | "mpa";
+      sequence: number;
+    }>;
+    type Stage = "configure" | "emitIR";
+
+    let defaultsCalls = 0;
+    const seen: { stage: Stage; options: Snapshot }[] = [];
+    let releaseDevelopmentInspect: (() => void) | undefined;
+    const developmentInspectPaused = new Promise<void>((resolve) => {
+      releaseDevelopmentInspect = resolve;
+    });
+    let markDevelopmentInspectPaused: (() => void) | undefined;
+    const waitForDevelopmentInspect = new Promise<void>((resolve) => {
+      markDevelopmentInspectPaused = resolve;
+    });
+    const gate: Plugin = {
+      name: "inspect-pipeline-gate",
+      async configure(_config, context) {
+        if (context.mode !== "development") return;
+        markDevelopmentInspectPaused?.();
+        await developmentInspectPaused;
+      },
+    };
+    const contextual = definePlugin({
+      name: "@company/inspect-contextual",
+      key: "inspect-contextual",
+      application: pluginOptions<Snapshot>({
+        defaults(context) {
+          return {
+            routingMode: context.routingMode,
+            sequence: ++defaultsCalls,
+          };
+        },
+      }),
+      configure(config, context) {
+        seen.push({ stage: "configure", options: context.options });
+        return { ...config };
+      },
+      emitIR(context) {
+        seen.push({ stage: "emitIR", options: context.options });
+      },
+    });
+    const sharedPlugin = contextual();
+    const installedPreset = definePluginPreset(() => [sharedPlugin] as const)();
+    const installed =
+      installation === "preset" ? installedPreset : sharedPlugin;
+    const developmentInspect = inspectFrameworkBuild(
+      {
+        plugins: [gate, installed],
+        routing: { mode: "spa" },
+      },
+      {
+        command: "dev",
+        cwd: process.cwd(),
+        mode: "development",
+      },
+    );
+
+    await Promise.race([
+      waitForDevelopmentInspect,
+      developmentInspect.then(() => {
+        throw new Error(
+          "Development inspect completed before reaching the configure gate.",
+        );
+      }),
+    ]);
+    try {
+      await inspectFrameworkBuild(
+        {
+          plugins: [gate, installed],
+          routing: { mode: "mpa" },
+        },
+        {
+          command: "build",
+          cwd: process.cwd(),
+          mode: "production",
+        },
+      );
+    } finally {
+      releaseDevelopmentInspect?.();
+      await developmentInspect;
+    }
+
+    expect(defaultsCalls).toBe(2);
+    expect(seen.map(({ stage, options }) => ({ stage, ...options }))).toEqual([
+      { stage: "configure", routingMode: "mpa", sequence: 2 },
+      { stage: "emitIR", routingMode: "mpa", sequence: 2 },
+      { stage: "configure", routingMode: "spa", sequence: 1 },
+      { stage: "emitIR", routingMode: "spa", sequence: 1 },
+    ]);
+    expect(seen[0]?.options).toBe(seen[1]?.options);
+    expect(seen[2]?.options).toBe(seen[3]?.options);
+    expect(seen[0]?.options).not.toBe(seen[2]?.options);
+  });
+
+  it.each([
+    "direct",
+    "preset",
+  ] as const)("forks a fresh Application snapshot when a configured %s pipeline is reused", async (installation) => {
+    type Snapshot = Readonly<{
+      routingMode: "spa" | "mpa";
+      sequence: number;
+    }>;
+    const configuredOptions: Snapshot[] = [];
+    const setupOptions: Snapshot[] = [];
+    let defaultsCalls = 0;
+    const contextual = definePlugin({
+      name: "@company/reentered-contextual",
+      key: "reentered-contextual",
+      application: pluginOptions<Snapshot>({
+        defaults(context) {
+          return {
+            routingMode: context.routingMode,
+            sequence: ++defaultsCalls,
+          };
+        },
+      }),
+      configure(_config, context) {
+        configuredOptions.push(context.options);
+      },
+      setup(context) {
+        setupOptions.push(context.options);
+      },
+    });
+    const sharedPlugin = contextual();
+    const installedPreset = definePluginPreset(() => [sharedPlugin] as const)();
+    const installed =
+      installation === "preset" ? installedPreset : sharedPlugin;
+    const firstConfigured = await runConfigureHooks(
+      {
+        routing: { mode: "spa" },
+        plugins: [installed],
+      },
+      {
+        command: "build",
+        cwd: "/pipeline-first",
+        mode: "production",
+      },
+    );
+    const secondConfigured = await runConfigureHooks(
+      {
+        ...firstConfigured,
+        routing: { mode: "mpa" },
+      },
+      {
+        command: "build",
+        cwd: "/pipeline-second",
+        mode: "production",
+      },
+    );
+    const firstResolved = resolveConfig(firstConfigured);
+    const secondResolved = resolveConfig(secondConfigured);
+    resolvePluginSettingsState(firstResolved);
+    resolvePluginSettingsState(secondResolved);
+    await firstResolved.plugins[0]?.setup?.({} as never);
+    await secondResolved.plugins[0]?.setup?.({} as never);
+
+    expect(defaultsCalls).toBe(2);
+    expect(configuredOptions).toEqual([
+      { routingMode: "spa", sequence: 1 },
+      { routingMode: "mpa", sequence: 2 },
+    ]);
+    expect(setupOptions).toEqual(configuredOptions);
+    expect(setupOptions[0]).toBe(configuredOptions[0]);
+    expect(setupOptions[1]).toBe(configuredOptions[1]);
+    expect(setupOptions[0]).not.toBe(setupOptions[1]);
   });
 
   it("isolates in-place configure hook mutations from the caller", async () => {
@@ -797,7 +1223,7 @@ describe("definePlugin and pluginOptions", () => {
     );
   });
 
-  it("preserves length fields on ordinary config objects", async () => {
+  it("preserves internal-looking keys on ordinary config objects", async () => {
     const plugin: Plugin = {
       name: "observes-length-field",
       configure(config) {
@@ -810,7 +1236,10 @@ describe("definePlugin and pluginOptions", () => {
           {
             context: ["/api"],
             target: "http://localhost:8080",
-            pathRewrite: { length: "/preserved" },
+            pathRewrite: {
+              length: "/preserved-length",
+              when: "/preserved-when",
+            },
           },
         ],
       },
@@ -824,8 +1253,31 @@ describe("definePlugin and pluginOptions", () => {
     });
 
     expect(configured?.dev?.proxy?.[0]?.pathRewrite).toEqual({
-      length: "/preserved",
+      length: "/preserved-length",
+      when: "/preserved-when",
     });
+  });
+
+  it("clones opaque plugin presets into the config pipeline snapshot", async () => {
+    const preset = definePluginPreset(
+      () => [{ name: "preset-plugin" }] as const,
+    );
+    const installedPreset = preset();
+
+    const configured = await runConfigureHooks(
+      { plugins: [installedPreset] },
+      {
+        command: "build",
+        cwd: process.cwd(),
+        mode: "production",
+      },
+    );
+
+    expect(configured?.plugins?.[0]).not.toBe(installedPreset);
+    expect(configured?.plugins?.[0]).toEqual({});
+    expect(
+      resolveConfig(configured).plugins.map((plugin) => plugin.name),
+    ).toEqual(["preset-plugin"]);
   });
 
   it("isolates and freezes resolved Application options", () => {
@@ -854,10 +1306,10 @@ describe("definePlugin and pluginOptions", () => {
     });
     const plugin = analytics(authored);
 
-    resolveInstalled(plugin);
+    const state = resolveInstalled(plugin);
     authored.endpoint = "/mutated";
     authored.headers.regions.push("caller");
-    plugin.setup?.({} as never);
+    state.plugin.setup?.({} as never);
 
     expect(observed).toEqual({
       endpoint: "/events",
@@ -1336,7 +1788,7 @@ describe("static plugin settings", () => {
       createdAt: new Date(0),
     });
     const configuredState = resolveInstalled(configured);
-    configured.setup?.({} as never);
+    configuredState.plugin.setup?.({} as never);
     expect(Object.values(configuredState.applicationSettings)).toEqual([
       { enabled: true },
     ]);
@@ -1395,9 +1847,10 @@ describe("plugin setting lifecycle", () => {
     });
     const plugin = analytics.withPageOptIn();
     const state = resolveInstalled(plugin);
+    const resolvedPlugin = state.plugin;
 
-    await plugin.setup?.({} as never);
-    await plugin.emitIR?.({
+    await resolvedPlugin.setup?.({} as never);
+    await resolvedPlugin.emitIR?.({
       framework: {
         pages: [{ id: "home", plugins: { analytics: { enabled: false } } }],
       },
@@ -1410,7 +1863,7 @@ describe("plugin setting lifecycle", () => {
         home: createPageConfig({ analytics: true }),
       },
     });
-    await plugin.emitIR?.({
+    await resolvedPlugin.emitIR?.({
       framework: { pages: Object.values(graph.pages) },
     } as never);
 
@@ -1447,7 +1900,7 @@ describe("plugin setting lifecycle", () => {
     );
 
     const state = resolvePluginSettingsState(config, registry);
-    plugin.setup?.({} as never);
+    config.plugins[0]?.setup?.({} as never);
     expect(state.applicationSettings.analytics).toEqual({ enabled: true });
     expect(setupSettings).toEqual([{ endpoint: "/events" }]);
 
@@ -1527,7 +1980,14 @@ describe("plugin setting lifecycle", () => {
 function resolveInstalled(plugin: Plugin) {
   const config = resolveConfig({ plugins: [plugin] });
   const registry = collectPluginSettingsRegistry(config.plugins);
-  return resolvePluginSettingsState(config, registry);
+  const resolvedPlugin = config.plugins[0];
+  if (!resolvedPlugin) {
+    throw new Error("Expected resolveConfig() to retain the installed plugin.");
+  }
+  return {
+    ...resolvePluginSettingsState(config, registry),
+    plugin: resolvedPlugin,
+  };
 }
 
 function createPageConfig(plugins: unknown = {}): ResolvedPageFileConfig {

--- a/packages/ev/tests/plugin-types.test.ts
+++ b/packages/ev/tests/plugin-types.test.ts
@@ -542,6 +542,227 @@ describe("plugin type output", () => {
     ).resolves.toMatchObject({ stderr: "" });
   });
 
+  it("type-checks recursive presets without leaking conditional or widened keys", async () => {
+    const cwd = await createTempDir();
+    const packageRoot = path.resolve(import.meta.dirname, "..");
+    await writeFixtureFiles(cwd, {
+      "ev.config.ts": `
+        import { defineConfig } from "@evjs/ev";
+        import {
+          definePlugin,
+          definePluginPreset,
+          pluginOptions,
+        } from "@evjs/ev/plugin";
+
+        declare const dynamic: boolean;
+        const analytics = definePlugin({
+          name: "@test/analytics",
+          key: "analytics",
+          page: pluginOptions({ defaults: {} }),
+        });
+        const access = definePlugin({
+          name: "@test/access",
+          key: "access",
+          page: pluginOptions({ defaults: {} }),
+        });
+        const whenEnabled = definePlugin({
+          name: "@test/when-enabled",
+          key: "when-enabled",
+          page: pluginOptions({ defaults: {} }),
+        });
+        const dynamicAnd = definePlugin({
+          name: "@test/dynamic-and",
+          key: "dynamic-and",
+          page: pluginOptions({ defaults: {} }),
+        });
+        const branchA = definePlugin({
+          name: "@test/branch-a",
+          key: "branch-a",
+          page: pluginOptions({ defaults: {} }),
+        });
+        const branchB = definePlugin({
+          name: "@test/branch-b",
+          key: "branch-b",
+          page: pluginOptions({ defaults: {} }),
+        });
+        const widenedEntry = definePlugin({
+          name: "@test/widened-entry",
+          key: "widened-entry",
+          page: pluginOptions({ defaults: {} }),
+        });
+
+        const accessPreset = definePluginPreset(
+          () => [access()] as const,
+        );
+        const applicationPreset = definePluginPreset((channel: string) => {
+          void channel;
+          return [analytics(), accessPreset(), false] as const;
+        });
+        const branchAPreset = definePluginPreset(
+          () => [branchA()] as const,
+        );
+        const branchBPreset = definePluginPreset(
+          () => [branchB()] as const,
+        );
+        const conditionalPreset = definePluginPreset(
+          () => [dynamic ? branchAPreset() : branchBPreset()] as const,
+        );
+        const widenedPreset = definePluginPreset(
+          (): readonly ReturnType<typeof widenedEntry>[] => [widenedEntry()],
+        );
+
+        const assertPresetArguments = () => {
+          // @ts-expect-error The preset keeps its factory parameter types.
+          applicationPreset(123);
+        };
+        void assertPresetArguments;
+
+        export default defineConfig({
+          plugins: [
+            applicationPreset("checkout"),
+            whenEnabled().when(dynamic),
+            dynamic && dynamicAnd(),
+            conditionalPreset(),
+            widenedPreset(),
+          ],
+        });
+      `,
+      "src/page.config.ts": `
+        import { definePageConfig } from "@evjs/ev";
+
+        definePageConfig({
+          plugins: {
+            analytics: true,
+            access: true,
+            "when-enabled": true,
+          },
+        });
+        definePageConfig({
+          plugins: {
+            // @ts-expect-error A conditionally omitted plugin is not guaranteed.
+            "dynamic-and": true,
+          },
+        });
+        definePageConfig({
+          plugins: {
+            // @ts-expect-error Neither conditional preset branch is guaranteed.
+            "branch-a": true,
+          },
+        });
+        definePageConfig({
+          plugins: {
+            // @ts-expect-error Neither conditional preset branch is guaranteed.
+            "branch-b": true,
+          },
+        });
+        definePageConfig({
+          plugins: {
+            // @ts-expect-error A widened preset tuple may be empty.
+            "widened-entry": true,
+          },
+        });
+      `,
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+          ignoreDeprecations: "6.0",
+          module: "ESNext",
+          moduleResolution: "Bundler",
+          noEmit: true,
+          paths: {
+            "@evjs/ev": [path.join(packageRoot, "src/index.ts")],
+            "@evjs/ev/config": [path.join(packageRoot, "src/config/index.ts")],
+            "@evjs/ev/plugin": [path.join(packageRoot, "src/plugin/index.ts")],
+          },
+          skipLibCheck: true,
+          strict: true,
+          target: "ESNext",
+          typeRoots: [path.resolve(packageRoot, "../../node_modules/@types")],
+          types: ["node"],
+        },
+        include: ["ev.config.ts", "src"],
+      }),
+    });
+    await syncPluginTypes({ cwd });
+
+    const tsc = require.resolve("typescript/bin/tsc");
+    await expect(
+      execFileAsync(process.execPath, [tsc, "--project", "tsconfig.json"], {
+        cwd,
+      }),
+    ).resolves.toMatchObject({ stderr: "" });
+  });
+
+  it("emits declarations for exported plugin preset factories", async () => {
+    const cwd = await createTempDir();
+    const packageRoot = path.resolve(import.meta.dirname, "..");
+    await writeFixtureFiles(cwd, {
+      "preset.ts": `
+        import {
+          definePlugin,
+          definePluginPreset,
+          pluginOptions,
+        } from "@evjs/ev/plugin";
+
+        export interface PresetOptions {
+          endpoint: string;
+        }
+
+        const analytics = definePlugin({
+          name: "@test/analytics",
+          key: "analytics",
+          application: pluginOptions<PresetOptions>(),
+        });
+
+        export const observability = definePluginPreset(
+          (options: PresetOptions) => [analytics(options)] as const,
+        );
+      `,
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+          declaration: true,
+          emitDeclarationOnly: true,
+          ignoreDeprecations: "6.0",
+          module: "ESNext",
+          moduleResolution: "Bundler",
+          outDir: "dist",
+          paths: {
+            "@evjs/ev/config": [path.join(packageRoot, "src/config/index.ts")],
+            "@evjs/ev/plugin": [path.join(packageRoot, "src/plugin/index.ts")],
+          },
+          rootDir: path.parse(packageRoot).root,
+          skipLibCheck: true,
+          strict: true,
+          target: "ESNext",
+          typeRoots: [path.resolve(packageRoot, "../../node_modules/@types")],
+          types: ["node"],
+        },
+        include: ["preset.ts"],
+      }),
+    });
+
+    const tsc = require.resolve("typescript/bin/tsc");
+    await expect(
+      execFileAsync(process.execPath, [tsc, "--project", "tsconfig.json"], {
+        cwd,
+      }),
+    ).resolves.toMatchObject({ stderr: "" });
+
+    const realCwd = await fs.realpath(cwd);
+    const declarationPath = path.join(
+      cwd,
+      "dist",
+      path.relative(path.parse(realCwd).root, realCwd),
+      "preset.d.ts",
+    );
+    const declaration = await fs.readFile(declarationPath, "utf-8");
+    expect(declaration).toContain("@evjs/ev/plugin");
+    expect(declaration).not.toContain(packageRoot);
+    expect(declaration).not.toContain("config/plugins");
+    expect(declaration).not.toContain("plugin/defined");
+  });
+
   it("keeps JavaScript configs from widening the Page registry to any", async () => {
     const cwd = await createTempDir();
     await writeFixtureFiles(cwd, {

--- a/packages/plugin-qiankun/src/index.ts
+++ b/packages/plugin-qiankun/src/index.ts
@@ -166,7 +166,6 @@ export const evPluginQiankunMaster = definePlugin({
   name: masterPluginName,
   key: "qiankun-master",
   application: pluginOptions<QiankunMasterPluginOptions>(),
-  enforce: "pre",
   async emitIR(ctx) {
     await emitQiankunMasterIR(ctx, ctx.options);
   },
@@ -179,7 +178,6 @@ export const evPluginQiankunSlave = definePlugin({
   name: slavePluginName,
   key: "qiankun-slave",
   application: pluginOptions<QiankunSlavePluginOptions>({ defaults: {} }),
-  enforce: "pre",
   async emitIR(ctx) {
     await emitQiankunSlaveIR(ctx, ctx.options);
   },


### PR DESCRIPTION
## Summary
- Refine the breaking plugin API introduced by #65 around explicit composition, type-stable activation, deterministic analysis, and narrower lifecycle capabilities.
- Make common application and Page configuration ergonomic while keeping plugin packages publishable and inspectable across the config-loader boundary.

## Changes
- Add typed synchronous `definePluginPreset()` composition with exact tuple/Page-key inference and loader-safe, non-forgeable runtime identity.
- Add `plugin(options).when(active, reason?)` so conditional activation preserves plugin and Page option types; inactive plugins remain declared for analysis but do not run executable hooks.
- Remove global `enforce` ordering. Preserve authored order and apply only explicit required/optional dependency edges, with clear inactive-dependency errors.
- Separate deterministic `configure`/IR analysis from runtime `setup`: public `prepare` and `inspect` no longer acquire or dispose plugin resources.
- Narrow lifecycle contexts to immutable framework, plugin, and bundler metadata views.
- Isolate resolved Application options per config pipeline with an immutable plugin declaration and a one-assignment snapshot shared only by clones in that pipeline.
- Preserve plugin and opaque preset identity through configure-result cloning without carrying snapshots into concurrent or re-entered pipelines; remove the former mutable cache rollback path from dev reloads.
- Add an inspectable plugin plan with activation state, dependency declarations, and declared stages.
- Update qiankun ordering, the plugin-authoring example, changelog, contributor/architecture guidance, and English/Chinese docs.
- Add coverage for presets, conditional activation, Page type extraction, declaration emission, Jiti/ESM loader boundaries, forged brands, ordering, lifecycle activation, inspect output, concurrent direct/preset pipelines, inspect interleaving, and pipeline re-entry.

## Validation
- `npm run check-types` — passed.
- `npm run lint` — passed.
- `npx turbo test --concurrency=1 '--filter=!@evjs/ev'` — passed for all other workspaces.
- Six focused `@evjs/ev` plugin/config/lifecycle/type suites — 177 tests passed.
- Concurrent snapshot regression suite (`plugin-settings.test.ts`) — 53 tests passed.
- Utoopack `create-config` tests — 35 passed.
- Webpack `create-config` tests — 24 passed.
- `git diff --check` — passed.
- `npm test -- --concurrency=1` — the non-watcher suites passed, but the local macOS run could not complete 12 dev watcher tests because `fs.watch` hit `EMFILE: too many open files`; the same tests timed out when isolated after the watcher error.

## Risk / rollout
- This is intentionally breaking and has no compatibility layer.
- Removes the public `enforce` field and changes `prepare`/`inspect` so they do not execute `setup` or `dispose`.
- Introduces process-global, versioned WeakMap registries solely to preserve framework-created plugin/preset declarations and pipeline-local snapshots across Jiti/ESM loader copies without putting forgeable brands on user objects.
- This PR is stacked on #65 and targets `xusd320/refactor-plugin-api-v2`.

## Reviewer notes
- Please focus on preset expansion and declaration portability, loader-boundary identity, inactive dependency semantics, the analysis/setup lifecycle split, and config-pipeline snapshot isolation.
- A later follow-up can add host/plugin version compatibility preflight and a dedicated plugin testing harness; those are outside this PR.
