### PR TITLE
docs(changelog): prepare v0.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.2] — 2026-08-03
+
 ### ⚠️ Breaking Changes
 
 - **Single plugin configuration model** — Applications install typed plugin


### PR DESCRIPTION
## Summary
- Finalize the current unreleased notes as the v0.3.2 release.
- Keep source package manifests at their release-workflow placeholder versions.

## Changes
- Add the `0.3.2` heading and release date to `CHANGELOG.md`.

## Validation
- `npm run check-types`
- `npm run lint`
- `git diff --check`
- `npm test` attempted locally; 85/86 `@evjs/bundler-webpack` tests passed, with one watch-transition timeout after macOS reported `EMFILE: too many open files`.
- GitHub `Build & Test` passed on the exact `main` base commit.

## Risk / rollout
- Low code risk: this PR changes only release metadata.
- Publishing the GitHub release will trigger the existing npm release workflow for all public workspaces.

## Reviewer notes
- Confirm the current Unreleased section is the intended v0.3.2 scope.