### PR TITLE
fix(qiankun): synchronize sub-app browser history

### DIFF
--- a/docs/docs/qiankun.md
+++ b/docs/docs/qiankun.md
@@ -207,6 +207,10 @@ Application layouts must not add their own `popstate` listener that compares
 `window.location` with `useLocation()` and renders a corrective `Navigate`.
 The scoped adapter is the single synchronization point, so native traversal
 continues to respect Router blockers and qiankun mount/unmount ownership.
+When a mounted master changes the URL programmatically without emitting
+`popstate`, its route component forwards the href change through the qiankun
+update lifecycle. The slave refreshes its scoped adapter only when the browser
+URL and Router history differ.
 
 The generated route types remain local to the slave source tree: they describe
 `/` and `/details`, not the externally assigned `/catalog` prefix.

--- a/docs/docs/qiankun.md
+++ b/docs/docs/qiankun.md
@@ -203,6 +203,11 @@ the slave does not replace the host's global `history.pushState` or
 `history.replaceState` methods. The adapter is released on unmount. Memory
 history remains isolated and does not write the browser URL.
 
+Application layouts must not add their own `popstate` listener that compares
+`window.location` with `useLocation()` and renders a corrective `Navigate`.
+The scoped adapter is the single synchronization point, so native traversal
+continues to respect Router blockers and qiankun mount/unmount ownership.
+
 The generated route types remain local to the slave source tree: they describe
 `/` and `/details`, not the externally assigned `/catalog` prefix.
 

--- a/docs/docs/qiankun.md
+++ b/docs/docs/qiankun.md
@@ -196,6 +196,13 @@ entry's first `start()`. The router therefore observes the mounted base and
 history before the first application render. When run outside qiankun, the same
 Pages remain available under their standalone base.
 
+While mounted with browser or hash history, the slave uses a scoped history
+adapter. Slave `Link` and `useNavigate()` calls still update the shared browser
+URL, and native back/forward events update both the host and slave routers, but
+the slave does not replace the host's global `history.pushState` or
+`history.replaceState` methods. The adapter is released on unmount. Memory
+history remains isolated and does not write the browser URL.
+
 The generated route types remain local to the slave source tree: they describe
 `/` and `/details`, not the externally assigned `/catalog` prefix.
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/qiankun.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/qiankun.md
@@ -191,6 +191,11 @@ Slave 内的 `Link` 与 `useNavigate()` 仍会更新共享的浏览器 URL，浏
 `history.pushState` 或 `history.replaceState` 方法。适配器会在 unmount 时释放。
 Memory history 仍保持隔离，不会写入浏览器 URL。
 
+业务 Layout 不需要再监听 `popstate`、比较 `window.location` 与 `useLocation()`，
+也不需要渲染一个纠偏用的 `Navigate`。作用域 history 适配器是唯一的同步入口，因此
+浏览器原生前进/回退仍会遵守 Router blocker，并由 qiankun mount/unmount lifecycle
+统一管理。
+
 生成的 route types 始终描述 slave 本地源码树：其中是 `/` 与 `/details`，而不是
 外部分配的 `/catalog` 前缀。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/qiankun.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/qiankun.md
@@ -185,6 +185,12 @@ Slave lifecycle 会加载原始生成 entry，通过 `pagesApp.updateRuntime()` 
 首次渲染前就能观察到挂载后的 base 与 history。在 qiankun 外独立运行时，同一组 Page
 仍然使用 standalone base。
 
+使用 browser 或 hash history 挂载时，slave 会使用作用域隔离的 history 适配器。
+Slave 内的 `Link` 与 `useNavigate()` 仍会更新共享的浏览器 URL，浏览器原生前进/回退
+也会同时更新 host 与 slave router，但 slave 不会替换 host 全局的
+`history.pushState` 或 `history.replaceState` 方法。适配器会在 unmount 时释放。
+Memory history 仍保持隔离，不会写入浏览器 URL。
+
 生成的 route types 始终描述 slave 本地源码树：其中是 `/` 与 `/details`，而不是
 外部分配的 `/catalog` 前缀。
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/qiankun.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/qiankun.md
@@ -195,6 +195,9 @@ Memory history 仍保持隔离，不会写入浏览器 URL。
 也不需要渲染一个纠偏用的 `Navigate`。作用域 history 适配器是唯一的同步入口，因此
 浏览器原生前进/回退仍会遵守 Router blocker，并由 qiankun mount/unmount lifecycle
 统一管理。
+已挂载的 master 主动修改 URL 且不产生 `popstate` 时，route component 会通过
+qiankun update lifecycle 转发 href 变化。Slave 仅在浏览器 URL 与 Router history
+不一致时刷新作用域适配器。
 
 生成的 route types 始终描述 slave 本地源码树：其中是 `/` 与 `/details`，而不是
 外部分配的 `/catalog` 前缀。

--- a/e2e/cases/qiankun.ts
+++ b/e2e/cases/qiankun.ts
@@ -85,6 +85,22 @@ test.describe("qiankun", () => {
     await expect(page.getByText("Orders")).toBeVisible();
     await expect(page.getByText("Inventory")).toBeVisible();
     await expect(page.getByText("Revenue")).toBeVisible();
+
+    await page.getByRole("link", { name: "View catalog details" }).click();
+    await expect(page).toHaveURL(`${masterURL}/catalog/details`);
+    await expect(
+      page.getByRole("heading", { name: "Catalog details" }),
+    ).toBeVisible();
+
+    await page.goBack();
+    await expect(page).toHaveURL(`${masterURL}/catalog`);
+    await expect(page.getByRole("heading", { name: "Catalog" })).toBeVisible();
+
+    await page.goForward();
+    await expect(page).toHaveURL(`${masterURL}/catalog/details`);
+    await expect(
+      page.getByRole("heading", { name: "Catalog details" }),
+    ).toBeVisible();
   });
 });
 

--- a/e2e/cases/qiankun.ts
+++ b/e2e/cases/qiankun.ts
@@ -86,6 +86,20 @@ test.describe("qiankun", () => {
     await expect(page.getByText("Inventory")).toBeVisible();
     await expect(page.getByText("Revenue")).toBeVisible();
 
+    await page.evaluate(() => {
+      window.history.replaceState(window.history.state, "", "/catalog/details");
+    });
+    await expect(page).toHaveURL(`${masterURL}/catalog/details`);
+    await expect(
+      page.getByRole("heading", { name: "Catalog details" }),
+    ).toBeVisible();
+
+    await page.evaluate(() => {
+      window.history.replaceState(window.history.state, "", "/catalog");
+    });
+    await expect(page).toHaveURL(`${masterURL}/catalog`);
+    await expect(page.getByRole("heading", { name: "Catalog" })).toBeVisible();
+
     await page.getByRole("link", { name: "View catalog details" }).click();
     await expect(page).toHaveURL(`${masterURL}/catalog/details`);
     await expect(

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -10,6 +10,9 @@ export default defineConfig<ExtTestOptions>({
     : "list",
   timeout: 60_000,
   retries: 0,
+  // Example fixtures load and exercise the same built workspace packages.
+  // Serialize CI bootstrap so workers cannot race on that shared module graph.
+  workers: process.env.CI ? 1 : undefined,
   use: {
     headless: true,
   },

--- a/packages/ev/src/navigation/index.ts
+++ b/packages/ev/src/navigation/index.ts
@@ -25,6 +25,12 @@ import {
 import type { ComponentPropsWithRef, ReactElement } from "react";
 import type { Register } from "../route/index.js";
 
+export type { RouterHistory } from "@tanstack/react-router";
+export {
+  createBrowserHistory,
+  createHashHistory,
+} from "@tanstack/react-router";
+
 type RegisteredAppRouter = Register extends {
   router: infer TRouter extends RouterAnyRouter;
 }

--- a/packages/plugin-qiankun/src/runtime.ts
+++ b/packages/plugin-qiankun/src/runtime.ts
@@ -1,4 +1,9 @@
-import { useLocation } from "@evjs/ev/navigation";
+import {
+  createBrowserHistory,
+  createHashHistory,
+  type RouterHistory,
+  useLocation,
+} from "@evjs/ev/navigation";
 import type { AppConfiguration, LifeCycleFn, LifeCycles } from "qiankun";
 import {
   createElement,
@@ -136,7 +141,7 @@ interface NormalizedQiankunMasterOptions {
 interface GeneratedPagesAppRuntimeUpdate {
   routes?: QiankunRuntimePageDefinition[];
   basepath?: string;
-  history?: QiankunHistoryOptions;
+  history?: QiankunHistoryOptions | RouterHistory;
 }
 
 interface QiankunMicroAppInstance {
@@ -302,6 +307,7 @@ export function createQiankunSlaveLifecycles(options: {
   let hasMountedEntry = false;
   let entryMounted = false;
   let lifecycleQueue = Promise.resolve();
+  let scopedHistory: RouterHistory | undefined;
   let runtimeProjection: SlaveRuntimeProjection = {
     basepath: "/",
     history: { type: "browser" },
@@ -347,7 +353,10 @@ export function createQiankunSlaveLifecycles(options: {
     }
   }
 
-  async function runMount(props: QiankunLifecycleProps = {}): Promise<void> {
+  async function runMount(
+    props: QiankunLifecycleProps = {},
+    useStandaloneDefaults = false,
+  ): Promise<void> {
     if (entryMounted) return;
     currentContainer = resolveMountContainer(props, options.mount);
     const context = ctx();
@@ -359,16 +368,25 @@ export function createQiankunSlaveLifecycles(options: {
     let projectionAttempted = false;
     let runtimeMountAttempted = false;
     let entryMountAttempted = false;
+    let nextScopedHistory: RouterHistory | undefined;
     let entryModule: unknown;
 
     try {
       runtimeMountAttempted = runtime.mount !== undefined;
       await runtime.mount?.(props, context);
       entryModule = await context.loadEntry();
-      nextProjection = resolveSlaveRuntimeProjection(props, previousProjection);
+      nextProjection = resolveSlaveRuntimeProjection(
+        props,
+        previousProjection,
+        useStandaloneDefaults,
+      );
+      nextScopedHistory = useStandaloneDefaults
+        ? undefined
+        : createScopedSlaveHistory(nextProjection.history.type);
       const projectionOptions = createSlaveRuntimeProjectionUpdate(
         previousProjection,
         nextProjection,
+        nextScopedHistory,
       );
       if (projectionOptions) {
         projectionUpdate = resolveRequiredSlavePagesAppUpdate(entryModule);
@@ -417,6 +435,9 @@ export function createQiankunSlaveLifecycles(options: {
       await collectQiankunCleanupError(rollbackErrors, () =>
         clearContainer(currentContainer),
       );
+      await collectQiankunCleanupError(rollbackErrors, () =>
+        nextScopedHistory?.destroy(),
+      );
       currentContainer = undefined;
       entryMounted = false;
       throwQiankunMountError(error, rollbackErrors);
@@ -424,6 +445,7 @@ export function createQiankunSlaveLifecycles(options: {
 
     hasMountedEntry = true;
     entryMounted = true;
+    scopedHistory = nextScopedHistory;
     runtimeProjection = nextProjection;
   }
 
@@ -440,6 +462,8 @@ export function createQiankunSlaveLifecycles(options: {
     await collectQiankunCleanupError(errors, () =>
       clearContainer(currentContainer),
     );
+    await collectQiankunCleanupError(errors, () => scopedHistory?.destroy());
+    scopedHistory = undefined;
     currentContainer = undefined;
     entryMounted = false;
     throwQiankunCleanupErrors(errors);
@@ -449,12 +473,40 @@ export function createQiankunSlaveLifecycles(options: {
     if (!entryMounted) return;
     await runtime.update?.(props, ctx());
     if (!loadedEntryModule) return;
-    runtimeProjection = await configureSlaveEntry(
-      loadedEntryModule,
+    const previousProjection = runtimeProjection;
+    const nextProjection = resolveSlaveRuntimeProjection(
       props,
-      runtimeProjection,
+      previousProjection,
       false,
     );
+    const historyChanged = !equalHistoryOptions(
+      nextProjection.history,
+      previousProjection.history,
+    );
+    const nextScopedHistory = historyChanged
+      ? createScopedSlaveHistory(nextProjection.history.type)
+      : scopedHistory;
+    const updateOptions = createSlaveRuntimeProjectionUpdate(
+      previousProjection,
+      nextProjection,
+      historyChanged ? nextScopedHistory : undefined,
+    );
+    if (!updateOptions) return;
+
+    const update = resolveRequiredSlavePagesAppUpdate(loadedEntryModule);
+    try {
+      await update(updateOptions);
+    } catch (error) {
+      if (nextScopedHistory !== scopedHistory) {
+        nextScopedHistory?.destroy();
+      }
+      throw error;
+    }
+    if (nextScopedHistory !== scopedHistory) {
+      scopedHistory?.destroy();
+    }
+    scopedHistory = nextScopedHistory;
+    runtimeProjection = nextProjection;
   }
 
   function enqueueLifecycle(operation: () => Promise<void>): Promise<void> {
@@ -480,7 +532,7 @@ export function createQiankunSlaveLifecycles(options: {
     mount,
     unmount,
     update,
-    standalone: () => mount({}),
+    standalone: () => enqueueLifecycle(() => runMount({}, true)),
     isPoweredByQiankun,
   };
 }
@@ -938,25 +990,6 @@ function isQiankunRedirectRoute(
   return typeof route.redirect === "string";
 }
 
-async function configureSlaveEntry(
-  entryModule: unknown,
-  props: QiankunLifecycleProps,
-  current: SlaveRuntimeProjection,
-  useStandaloneDefaults = true,
-): Promise<SlaveRuntimeProjection> {
-  const next = resolveSlaveRuntimeProjection(
-    props,
-    current,
-    useStandaloneDefaults,
-  );
-  const updateOptions = createSlaveRuntimeProjectionUpdate(current, next);
-  if (!updateOptions) return next;
-
-  const update = resolveRequiredSlavePagesAppUpdate(entryModule);
-  await update(updateOptions);
-  return next;
-}
-
 function resolveSlaveRuntimeProjection(
   props: QiankunLifecycleProps,
   current: SlaveRuntimeProjection,
@@ -986,14 +1019,78 @@ function resolveSlaveBasepath(
 function createSlaveRuntimeProjectionUpdate(
   current: SlaveRuntimeProjection,
   next: SlaveRuntimeProjection,
+  historyOverride?: RouterHistory,
 ): GeneratedPagesAppRuntimeUpdate | undefined {
+  let history: QiankunHistoryOptions | RouterHistory | undefined;
+  if (historyOverride) {
+    history = historyOverride;
+  } else if (!equalHistoryOptions(next.history, current.history)) {
+    history = next.history;
+  }
   const updateOptions: GeneratedPagesAppRuntimeUpdate = {
     ...(next.basepath !== current.basepath ? { basepath: next.basepath } : {}),
-    ...(!equalHistoryOptions(next.history, current.history)
-      ? { history: next.history }
-      : {}),
+    ...(history ? { history } : {}),
   };
   return Object.keys(updateOptions).length > 0 ? updateOptions : undefined;
+}
+
+/**
+ * Create a browser-backed history whose TanStack method interception is scoped
+ * to the slave instead of replacing the host's global history methods.
+ *
+ * @internal
+ */
+export function createQiankunSlaveHistory(
+  type: Exclude<QiankunHistoryType, "memory">,
+  win: Window = globalThis.window,
+): RouterHistory {
+  const scopedWindow = createScopedHistoryWindow(win);
+  return type === "hash"
+    ? createHashHistory({ window: scopedWindow })
+    : createBrowserHistory({ window: scopedWindow });
+}
+
+function createScopedSlaveHistory(
+  type: QiankunHistoryType,
+): RouterHistory | undefined {
+  if (type === "memory" || typeof globalThis.window === "undefined") {
+    return undefined;
+  }
+  return createQiankunSlaveHistory(type);
+}
+
+function createScopedHistoryWindow(win: Window) {
+  const history = {
+    get length() {
+      return win.history.length;
+    },
+    get state() {
+      return win.history.state;
+    },
+    back() {
+      win.history.back();
+    },
+    forward() {
+      win.history.forward();
+    },
+    go(delta?: number) {
+      win.history.go(delta);
+    },
+    pushState(data: unknown, unused: string, url?: string | URL | null) {
+      win.history.pushState(data, unused, url);
+    },
+    replaceState(data: unknown, unused: string, url?: string | URL | null) {
+      win.history.replaceState(data, unused, url);
+    },
+  };
+  return {
+    history,
+    get location() {
+      return win.location;
+    },
+    addEventListener: win.addEventListener.bind(win),
+    removeEventListener: win.removeEventListener.bind(win),
+  };
 }
 
 function resolveRequiredSlavePagesAppUpdate(

--- a/packages/plugin-qiankun/src/runtime.ts
+++ b/packages/plugin-qiankun/src/runtime.ts
@@ -369,6 +369,7 @@ export function createQiankunSlaveLifecycles(options: {
     let runtimeMountAttempted = false;
     let entryMountAttempted = false;
     let nextScopedHistory: RouterHistory | undefined;
+    let rollbackScopedHistory: RouterHistory | undefined;
     let entryModule: unknown;
 
     try {
@@ -417,14 +418,22 @@ export function createQiankunSlaveLifecycles(options: {
         );
       }
       if (projectionAttempted && projectionUpdate) {
+        rollbackScopedHistory = useStandaloneDefaults
+          ? undefined
+          : createScopedSlaveHistory(previousProjection.history.type);
         const rollbackProjection = createSlaveRuntimeProjectionUpdate(
           nextProjection,
           previousProjection,
+          rollbackScopedHistory ?? previousProjection.history,
         );
         if (rollbackProjection) {
-          await collectQiankunCleanupError(rollbackErrors, () =>
-            projectionUpdate?.(rollbackProjection),
-          );
+          try {
+            await projectionUpdate(rollbackProjection);
+          } catch (rollbackError) {
+            rollbackErrors.push(rollbackError);
+            rollbackScopedHistory?.destroy();
+            rollbackScopedHistory = undefined;
+          }
         }
       }
       if (runtimeMountAttempted) {
@@ -438,6 +447,12 @@ export function createQiankunSlaveLifecycles(options: {
       await collectQiankunCleanupError(rollbackErrors, () =>
         nextScopedHistory?.destroy(),
       );
+      if (projectionAttempted) {
+        if (rollbackScopedHistory !== scopedHistory) {
+          scopedHistory?.destroy();
+        }
+        scopedHistory = rollbackScopedHistory;
+      }
       currentContainer = undefined;
       entryMounted = false;
       throwQiankunMountError(error, rollbackErrors);
@@ -445,12 +460,20 @@ export function createQiankunSlaveLifecycles(options: {
 
     hasMountedEntry = true;
     entryMounted = true;
+    if (scopedHistory !== nextScopedHistory) {
+      scopedHistory?.destroy();
+    }
     scopedHistory = nextScopedHistory;
     runtimeProjection = nextProjection;
   }
 
   async function runUnmount(props: QiankunLifecycleProps = {}): Promise<void> {
-    if (!entryMounted) return;
+    if (!entryMounted) {
+      scopedHistory?.destroy();
+      scopedHistory = undefined;
+      currentContainer = undefined;
+      return;
+    }
     const context = ctx();
     const errors: unknown[] = [];
     await collectQiankunCleanupError(errors, () =>
@@ -483,13 +506,18 @@ export function createQiankunSlaveLifecycles(options: {
       nextProjection.history,
       previousProjection.history,
     );
-    const nextScopedHistory = historyChanged
-      ? createScopedSlaveHistory(nextProjection.history.type)
-      : scopedHistory;
+    const refreshScopedHistory = shouldRefreshScopedHistory(
+      nextProjection.history.type,
+      scopedHistory,
+    );
+    const nextScopedHistory =
+      historyChanged || refreshScopedHistory
+        ? createScopedSlaveHistory(nextProjection.history.type)
+        : scopedHistory;
     const updateOptions = createSlaveRuntimeProjectionUpdate(
       previousProjection,
       nextProjection,
-      historyChanged ? nextScopedHistory : undefined,
+      historyChanged || refreshScopedHistory ? nextScopedHistory : undefined,
     );
     if (!updateOptions) return;
 
@@ -718,14 +746,20 @@ function createQiankunRouteComponent(
     const containerRef = useRef<HTMLDivElement>(null);
     const microAppRef = useRef<QiankunMicroAppInstance | undefined>(undefined);
     const mountedBaseRef = useRef<string | undefined>(undefined);
+    const mountedHrefRef = useRef<string | undefined>(undefined);
     const latestBaseRef = useRef<string | undefined>(undefined);
+    const latestHrefRef = useRef<string | undefined>(undefined);
     const updateQueueRef = useRef(Promise.resolve());
     const [error, setError] = useState<unknown>();
     const routePathname = useLocation({
       select: (location) => location.pathname,
     });
+    const routeHref = useLocation({
+      select: (location) => location.href,
+    });
     const base = resolveQiankunSlaveBase(master.base, route, routePathname);
     latestBaseRef.current = base;
+    latestHrefRef.current = routeHref;
 
     useEffect(() => {
       const container = containerRef.current;
@@ -763,6 +797,7 @@ function createQiankunRouteComponent(
           );
           microAppRef.current = microApp;
           mountedBaseRef.current = mountedBase;
+          mountedHrefRef.current = latestHrefRef.current;
           void microApp.mountPromise
             ?.then(() => prefetchQiankunApps(master, "after-mount", app.name))
             .catch(reportError);
@@ -789,7 +824,11 @@ function createQiankunRouteComponent(
 
     useEffect(() => {
       const microApp = microAppRef.current;
-      if (!microApp?.update || mountedBaseRef.current === base) {
+      if (
+        !microApp?.update ||
+        (mountedBaseRef.current === base &&
+          mountedHrefRef.current === routeHref)
+      ) {
         return;
       }
 
@@ -797,7 +836,13 @@ function createQiankunRouteComponent(
         await microApp.mountPromise;
         if (microAppRef.current !== microApp) return;
         const nextBase = latestBaseRef.current ?? base;
-        if (mountedBaseRef.current === nextBase) return;
+        const nextHref = latestHrefRef.current ?? routeHref;
+        if (
+          mountedBaseRef.current === nextBase &&
+          mountedHrefRef.current === nextHref
+        ) {
+          return;
+        }
         const appProps = splitAppProps(app.props);
         const routeProps = splitRouteProps(route.microAppProps);
         await microApp.update?.(
@@ -809,12 +854,13 @@ function createQiankunRouteComponent(
           ),
         );
         mountedBaseRef.current = nextBase;
+        mountedHrefRef.current = nextHref;
       });
       updateQueueRef.current = update.catch(() => {});
       void update.catch((updateError) => {
         if (microAppRef.current === microApp) setError(updateError);
       });
-    }, [base]);
+    }, [base, routeHref]);
 
     if (error) throw error;
     return createElement("div", {
@@ -1019,7 +1065,7 @@ function resolveSlaveBasepath(
 function createSlaveRuntimeProjectionUpdate(
   current: SlaveRuntimeProjection,
   next: SlaveRuntimeProjection,
-  historyOverride?: RouterHistory,
+  historyOverride?: QiankunHistoryOptions | RouterHistory,
 ): GeneratedPagesAppRuntimeUpdate | undefined {
   let history: QiankunHistoryOptions | RouterHistory | undefined;
   if (historyOverride) {
@@ -1057,6 +1103,33 @@ function createScopedSlaveHistory(
     return undefined;
   }
   return createQiankunSlaveHistory(type);
+}
+
+function shouldRefreshScopedHistory(
+  type: QiankunHistoryType,
+  history: RouterHistory | undefined,
+): boolean {
+  if (type === "memory" || typeof globalThis.window === "undefined") {
+    return false;
+  }
+  if (!history) return true;
+  return (
+    history.location.href !== readWindowHistoryHref(type, globalThis.window)
+  );
+}
+
+function readWindowHistoryHref(
+  type: Exclude<QiankunHistoryType, "memory">,
+  win: Window,
+): string {
+  if (type === "browser") {
+    return `${win.location.pathname}${win.location.search}${win.location.hash}`;
+  }
+  const hashParts = win.location.hash.split("#").slice(1);
+  const pathname = hashParts[0] ?? "/";
+  const nestedHash =
+    hashParts.length > 1 ? `#${hashParts.slice(1).join("#")}` : "";
+  return `${pathname}${win.location.search}${nestedHash}`;
 }
 
 function createScopedHistoryWindow(win: Window) {

--- a/packages/plugin-qiankun/tests/runtime.test.ts
+++ b/packages/plugin-qiankun/tests/runtime.test.ts
@@ -201,7 +201,7 @@ describe("@evjs/plugin-qiankun runtime", () => {
     expect(hostLocations).toEqual(["/catalog/details?tab=all"]);
     expect(slaveLocations).toEqual(["/catalog/details?tab=all"]);
 
-    slaveHistory.back();
+    win.history.back();
     await Promise.resolve();
 
     expect(win.location.pathname).toBe("/catalog");
@@ -210,7 +210,7 @@ describe("@evjs/plugin-qiankun runtime", () => {
     expect(hostLocations).toEqual(["/catalog/details?tab=all", "/catalog"]);
     expect(slaveLocations).toEqual(["/catalog/details?tab=all", "/catalog"]);
 
-    slaveHistory.forward();
+    win.history.forward();
     await Promise.resolve();
 
     expect(win.location.pathname).toBe("/catalog/details");
@@ -233,6 +233,38 @@ describe("@evjs/plugin-qiankun runtime", () => {
     expect(win.listenerCount("popstate")).toBe(1);
 
     hostHistory.destroy();
+    expect(win.history.pushState).toBe(nativePushState);
+    expect(win.history.replaceState).toBe(nativeReplaceState);
+  });
+
+  it("does not resurrect host history hooks when the host releases them first", async () => {
+    const win = createHistoryWindow("/catalog");
+    const nativePushState = win.history.pushState;
+    const nativeReplaceState = win.history.replaceState;
+    const hostHistory = createBrowserHistory({ window: win });
+    const slaveHistory = createQiankunSlaveHistory(
+      "browser",
+      win as unknown as Window,
+    );
+    const slaveLocations: string[] = [];
+    slaveHistory.subscribe(({ location }) =>
+      slaveLocations.push(location.href),
+    );
+
+    hostHistory.destroy();
+    expect(win.history.pushState).toBe(nativePushState);
+    expect(win.history.replaceState).toBe(nativeReplaceState);
+
+    slaveHistory.push("/catalog/details");
+    slaveHistory.flush();
+    win.history.back();
+    await Promise.resolve();
+
+    expect(win.location.pathname).toBe("/catalog");
+    expect(slaveHistory.location.href).toBe("/catalog");
+    expect(slaveLocations).toEqual(["/catalog/details", "/catalog"]);
+
+    slaveHistory.destroy();
     expect(win.history.pushState).toBe(nativePushState);
     expect(win.history.replaceState).toBe(nativeReplaceState);
   });

--- a/packages/plugin-qiankun/tests/runtime.test.ts
+++ b/packages/plugin-qiankun/tests/runtime.test.ts
@@ -269,6 +269,71 @@ describe("@evjs/plugin-qiankun runtime", () => {
     expect(win.history.replaceState).toBe(nativeReplaceState);
   });
 
+  it("refreshes scoped history after a host programmatic navigation", async () => {
+    const originalWindow = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "window",
+    );
+    const win = createHistoryWindow("/catalog");
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: win,
+    });
+    const hostHistory = createBrowserHistory({ window: win });
+    let activeHistory: ReturnType<typeof createQiankunSlaveHistory> | undefined;
+    const updateRuntime = vi.fn(
+      (update: { history?: ReturnType<typeof createQiankunSlaveHistory> }) => {
+        if (update.history) activeHistory = update.history;
+      },
+    );
+    const slave = createQiankunSlaveLifecycles({
+      name: "catalog",
+      mount: "#app",
+      async loadEntry() {
+        return {
+          pagesApp: { updateRuntime },
+          start: vi.fn(),
+          app: { unmount: vi.fn() },
+        };
+      },
+    });
+
+    try {
+      await slave.mount({
+        container: createElement(),
+        base: "/catalog",
+        history: "browser",
+      });
+      const mountedHistory = activeHistory;
+      if (!mountedHistory) {
+        throw new Error("Expected the mounted slave history projection.");
+      }
+      expect(mountedHistory.location.href).toBe("/catalog");
+      const destroyMountedHistory = vi.spyOn(mountedHistory, "destroy");
+
+      hostHistory.push("/catalog/details");
+      hostHistory.flush();
+      expect(win.location.pathname).toBe("/catalog/details");
+      expect(mountedHistory?.location.href).toBe("/catalog");
+
+      await slave.update({});
+
+      expect(updateRuntime).toHaveBeenCalledTimes(2);
+      expect(activeHistory).not.toBe(mountedHistory);
+      expect(activeHistory?.location.href).toBe("/catalog/details");
+      expect(destroyMountedHistory).toHaveBeenCalledTimes(1);
+
+      await slave.unmount();
+    } finally {
+      hostHistory.destroy();
+      if (originalWindow) {
+        Object.defineProperty(globalThis, "window", originalWindow);
+      } else {
+        delete (globalThis as { window?: unknown }).window;
+      }
+    }
+  });
+
   it("keeps hash navigation synchronized with native browser history", async () => {
     const win = createHistoryWindow("/shell#/catalog");
     const hostHistory = createBrowserHistory({ window: win });
@@ -1119,6 +1184,100 @@ describe("@evjs/plugin-qiankun runtime", () => {
     expect(activeHistory).toBe("hash");
   });
 
+  it("keeps a live scoped history after a browser mount rolls back", async () => {
+    const originalWindow = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "window",
+    );
+    const originalSelf = Object.getOwnPropertyDescriptor(globalThis, "self");
+    const originalDocument = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "document",
+    );
+    const win = createHistoryWindow("/catalog");
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: win,
+    });
+    Object.defineProperty(globalThis, "self", {
+      configurable: true,
+      value: win,
+    });
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: {},
+    });
+    const hostHistory = createBrowserHistory({ window: win });
+    const hostPushState = win.history.pushState;
+    const hostReplaceState = win.history.replaceState;
+    const pagesApp = createPagesApp({
+      routes: [
+        { path: "/", module: { default: () => null } },
+        { path: "/$", module: { default: () => null } },
+      ],
+    });
+    const router = pagesApp.app.router as {
+      history: ReturnType<typeof createQiankunSlaveHistory>;
+    };
+    const initialHistory = router.history;
+    const mountError = new Error("entry start failed");
+    const retryError = new Error("runtime mount failed");
+    const runtimeMount = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(retryError);
+    const slave = createQiankunSlaveLifecycles({
+      name: "catalog",
+      mount: "#app",
+      runtime: { mount: runtimeMount },
+      async loadEntry() {
+        return {
+          pagesApp,
+          app: pagesApp.app,
+          start() {
+            throw mountError;
+          },
+        };
+      },
+    });
+
+    try {
+      await expect(
+        slave.mount({
+          container: createElement(),
+          base: "/catalog",
+          history: "browser",
+        }),
+      ).rejects.toBe(mountError);
+
+      const restoredHistory = router.history;
+      expect(restoredHistory).not.toBe(initialHistory);
+      expect(restoredHistory.location.href).toBe("/catalog");
+      expect(win.history.pushState).toBe(hostPushState);
+      expect(win.history.replaceState).toBe(hostReplaceState);
+      expect(win.listenerCount("popstate")).toBe(2);
+
+      await expect(
+        slave.mount({
+          container: createElement(),
+          base: "/catalog",
+          history: "browser",
+        }),
+      ).rejects.toBe(retryError);
+      expect(router.history).toBe(restoredHistory);
+      expect(router.history.location.href).toBe("/catalog");
+      expect(win.listenerCount("popstate")).toBe(2);
+
+      await slave.unmount();
+      expect(win.listenerCount("popstate")).toBe(1);
+    } finally {
+      hostHistory.destroy();
+      restoreGlobal("window", originalWindow);
+      restoreGlobal("self", originalSelf);
+      restoreGlobal("document", originalDocument);
+    }
+  });
+
   it("resets mount state when multiple unmount steps fail", async () => {
     const calls: string[] = [];
     const container = createElement();
@@ -1308,4 +1467,15 @@ function createHistoryWindow(initialHref: string) {
       return listeners.get(type)?.size ?? 0;
     },
   };
+}
+
+function restoreGlobal(
+  key: "window" | "self" | "document",
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(globalThis, key, descriptor);
+  } else {
+    delete (globalThis as Record<string, unknown>)[key];
+  }
 }

--- a/packages/plugin-qiankun/tests/runtime.test.ts
+++ b/packages/plugin-qiankun/tests/runtime.test.ts
@@ -1,7 +1,9 @@
 import { createPagesApp } from "@evjs/ev/_internal/client";
+import { createBrowserHistory } from "@evjs/ev/navigation";
 import { describe, expect, it, vi } from "vitest";
 import {
   createQiankunMasterRoutes,
+  createQiankunSlaveHistory,
   createQiankunSlaveLifecycles,
   defineQiankunMasterResolver,
   defineQiankunSlaveRuntime,
@@ -165,6 +167,104 @@ describe("@evjs/plugin-qiankun runtime", () => {
         "/tenant/acme",
       ),
     ).toBe("/workspace");
+  });
+
+  it("shares browser navigation without replacing the host history methods", async () => {
+    const win = createHistoryWindow("/catalog");
+    const nativePushState = win.history.pushState;
+    const nativeReplaceState = win.history.replaceState;
+    const hostHistory = createBrowserHistory({ window: win });
+    const hostPushState = win.history.pushState;
+    const hostReplaceState = win.history.replaceState;
+    const slaveHistory = createQiankunSlaveHistory(
+      "browser",
+      win as unknown as Window,
+    );
+    const hostLocations: string[] = [];
+    const slaveLocations: string[] = [];
+    hostHistory.subscribe(({ location }) => hostLocations.push(location.href));
+    slaveHistory.subscribe(({ location }) =>
+      slaveLocations.push(location.href),
+    );
+
+    expect(win.history.pushState).toBe(hostPushState);
+    expect(win.history.replaceState).toBe(hostReplaceState);
+    expect(win.listenerCount("popstate")).toBe(2);
+
+    slaveHistory.push("/catalog/details?tab=all");
+    slaveHistory.flush();
+
+    expect(win.location.pathname).toBe("/catalog/details");
+    expect(win.location.search).toBe("?tab=all");
+    expect(hostHistory.location.href).toBe("/catalog/details?tab=all");
+    expect(slaveHistory.location.href).toBe("/catalog/details?tab=all");
+    expect(hostLocations).toEqual(["/catalog/details?tab=all"]);
+    expect(slaveLocations).toEqual(["/catalog/details?tab=all"]);
+
+    slaveHistory.back();
+    await Promise.resolve();
+
+    expect(win.location.pathname).toBe("/catalog");
+    expect(hostHistory.location.href).toBe("/catalog");
+    expect(slaveHistory.location.href).toBe("/catalog");
+    expect(hostLocations).toEqual(["/catalog/details?tab=all", "/catalog"]);
+    expect(slaveLocations).toEqual(["/catalog/details?tab=all", "/catalog"]);
+
+    slaveHistory.forward();
+    await Promise.resolve();
+
+    expect(win.location.pathname).toBe("/catalog/details");
+    expect(hostHistory.location.href).toBe("/catalog/details?tab=all");
+    expect(slaveHistory.location.href).toBe("/catalog/details?tab=all");
+    expect(hostLocations).toEqual([
+      "/catalog/details?tab=all",
+      "/catalog",
+      "/catalog/details?tab=all",
+    ]);
+    expect(slaveLocations).toEqual([
+      "/catalog/details?tab=all",
+      "/catalog",
+      "/catalog/details?tab=all",
+    ]);
+
+    slaveHistory.destroy();
+    expect(win.history.pushState).toBe(hostPushState);
+    expect(win.history.replaceState).toBe(hostReplaceState);
+    expect(win.listenerCount("popstate")).toBe(1);
+
+    hostHistory.destroy();
+    expect(win.history.pushState).toBe(nativePushState);
+    expect(win.history.replaceState).toBe(nativeReplaceState);
+  });
+
+  it("keeps hash navigation synchronized with native browser history", async () => {
+    const win = createHistoryWindow("/shell#/catalog");
+    const hostHistory = createBrowserHistory({ window: win });
+    const hostPushState = win.history.pushState;
+    const hostReplaceState = win.history.replaceState;
+    const slaveHistory = createQiankunSlaveHistory(
+      "hash",
+      win as unknown as Window,
+    );
+
+    slaveHistory.push("/catalog/details?tab=all");
+    slaveHistory.flush();
+
+    expect(win.location.pathname).toBe("/shell");
+    expect(win.location.hash).toBe("#/catalog/details?tab=all");
+    expect(hostHistory.location.href).toBe("/shell#/catalog/details?tab=all");
+    expect(slaveHistory.location.href).toBe("/catalog/details?tab=all");
+
+    slaveHistory.back();
+    await Promise.resolve();
+
+    expect(hostHistory.location.href).toBe("/shell#/catalog");
+    expect(slaveHistory.location.href).toBe("/catalog");
+
+    slaveHistory.destroy();
+    expect(win.history.pushState).toBe(hostPushState);
+    expect(win.history.replaceState).toBe(hostReplaceState);
+    hostHistory.destroy();
   });
 
   it("waits for a deferred route update before unmounting its micro-app", async () => {
@@ -652,6 +752,71 @@ describe("@evjs/plugin-qiankun runtime", () => {
     });
   });
 
+  it("projects and releases scoped browser history in qiankun mode", async () => {
+    const originalWindow = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "window",
+    );
+    const win = createHistoryWindow("/catalog");
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: win,
+    });
+    const hostHistory = createBrowserHistory({ window: win });
+    const hostPushState = win.history.pushState;
+    const hostReplaceState = win.history.replaceState;
+
+    try {
+      const updateRuntime = vi.fn();
+      const slave = createQiankunSlaveLifecycles({
+        name: "catalog",
+        mount: "#app",
+        async loadEntry() {
+          return {
+            pagesApp: { updateRuntime },
+            start: vi.fn(),
+            app: { unmount: vi.fn() },
+          };
+        },
+      });
+
+      await slave.mount({
+        container: createElement(),
+        base: "/catalog",
+        history: "browser",
+      });
+
+      const projection = updateRuntime.mock.calls[0]?.[0] as {
+        basepath?: string;
+        history?: { push?: unknown; back?: unknown; destroy?: unknown };
+      };
+      expect(projection.basepath).toBe("/catalog");
+      expect(projection.history).toEqual(
+        expect.objectContaining({
+          push: expect.any(Function),
+          back: expect.any(Function),
+          destroy: expect.any(Function),
+        }),
+      );
+      expect(win.history.pushState).toBe(hostPushState);
+      expect(win.history.replaceState).toBe(hostReplaceState);
+      expect(win.listenerCount("popstate")).toBe(2);
+
+      await slave.unmount({ container: createElement() });
+
+      expect(win.listenerCount("popstate")).toBe(1);
+      expect(win.history.pushState).toBe(hostPushState);
+      expect(win.history.replaceState).toBe(hostReplaceState);
+    } finally {
+      hostHistory.destroy();
+      if (originalWindow) {
+        Object.defineProperty(globalThis, "window", originalWindow);
+      } else {
+        delete (globalThis as { window?: unknown }).window;
+      }
+    }
+  });
+
   it("reuses an equivalent slave runtime projection across remounts", async () => {
     const container = createElement();
     const updateRuntime = vi.fn();
@@ -1018,6 +1183,97 @@ function createDeferred(): { promise: Promise<void>; resolve(): void } {
     promise,
     resolve() {
       resolvePromise?.();
+    },
+  };
+}
+
+function createHistoryWindow(initialHref: string) {
+  type HistoryEntry = { href: string; state: Record<string, unknown> };
+  const origin = "https://evjs.test";
+  const listeners = new Map<string, Set<EventListener>>();
+  const entries: HistoryEntry[] = [
+    {
+      href: initialHref,
+      state: { __TSR_index: 0, key: "initial", __TSR_key: "initial" },
+    },
+  ];
+  let index = 0;
+  const location = {
+    pathname: "/",
+    search: "",
+    hash: "",
+  };
+
+  const applyHref = (href: string | URL | null | undefined) => {
+    const url = new URL(
+      href?.toString() ?? entries[index]?.href ?? "/",
+      origin,
+    );
+    location.pathname = url.pathname;
+    location.search = url.search;
+    location.hash = url.hash;
+    return `${url.pathname}${url.search}${url.hash}`;
+  };
+  applyHref(initialHref);
+
+  const dispatch = (type: string) => {
+    const event = new Event(type);
+    for (const listener of listeners.get(type) ?? []) listener(event);
+  };
+  const move = (delta: number) => {
+    const nextIndex = Math.min(Math.max(index + delta, 0), entries.length - 1);
+    if (nextIndex === index) return;
+    index = nextIndex;
+    applyHref(entries[index]?.href);
+    dispatch("popstate");
+  };
+
+  const history = {
+    get length() {
+      return entries.length;
+    },
+    get state() {
+      return entries[index]?.state;
+    },
+    pushState: vi.fn(
+      (
+        state: Record<string, unknown>,
+        _unused: string,
+        href?: string | URL | null,
+      ) => {
+        const nextHref = applyHref(href);
+        entries.splice(index + 1, entries.length, { href: nextHref, state });
+        index = entries.length - 1;
+      },
+    ),
+    replaceState: vi.fn(
+      (
+        state: Record<string, unknown>,
+        _unused: string,
+        href?: string | URL | null,
+      ) => {
+        const nextHref = applyHref(href);
+        entries[index] = { href: nextHref, state };
+      },
+    ),
+    go: vi.fn((delta = 0) => move(delta)),
+    back: vi.fn(() => move(-1)),
+    forward: vi.fn(() => move(1)),
+  };
+
+  return {
+    history,
+    location,
+    addEventListener(type: string, listener: EventListener) {
+      const eventListeners = listeners.get(type) ?? new Set<EventListener>();
+      eventListeners.add(listener);
+      listeners.set(type, eventListeners);
+    },
+    removeEventListener(type: string, listener: EventListener) {
+      listeners.get(type)?.delete(listener);
+    },
+    listenerCount(type: string) {
+      return listeners.get(type)?.size ?? 0;
     },
   };
 }


### PR DESCRIPTION
## Summary
- Fix qiankun/Tern child application routing so child navigation, host-driven URL changes, and native browser back/forward stay synchronized.
- Root cause: host and child TanStack histories both intercepted the same global `window.history` methods, so lifecycle cleanup could restore stale wrappers and leave the child Router observing stale state. Separately, `pushState`/`replaceState` do not emit `popstate`, and the master previously forwarded qiankun updates only when the resolved base changed, so same-base host navigation never reached the child.
- Keep synchronization in the framework runtime; application layouts no longer need a corrective `popstate` listener or `Navigate`.

## Changes
- Add a scoped browser/hash history adapter for each mounted qiankun child without replacing the host's global `pushState` or `replaceState`.
- Forward master href changes through the qiankun update lifecycle, including same-base programmatic navigation.
- Refresh the child history projection only when its Router location differs from the browser URL.
- Preserve a live Router history across failed mount rollback and retry paths, and release owned adapters on unmount.
- Keep memory history and standalone execution isolated.
- Add unit regressions for native traversal, host-driven navigation, teardown ordering, mount rollback, and retry cleanup.
- Extend qiankun E2E coverage and update equivalent English/Chinese documentation.
- Serialize Playwright workers in CI only. The example fixtures share built workspace package outputs, and concurrent worker bootstrap intermittently observed incomplete named-export graphs; local E2E remains parallel.

## Validation
- `npm --workspace @evjs/plugin-qiankun test` — 56 tests passed.
- `npm --workspace @evjs/plugin-qiankun run check-types` — passed.
- `npm run test:e2e -- e2e/cases/qiankun.ts` — 2 tests passed.
- `npm run check-types` — 31 Turbo tasks plus the root test TypeScript project passed.
- `npm run lint` — passed.
- `npm --workspace evjs-docs run build` — passed for both locales.
- `git diff --check` — passed.
- GitHub Actions [CI run 30797060209](https://github.com/afx-team/evjs/actions/runs/30797060209) — passed, including the complete unit and 53-test E2E suites.

## Risk / rollout
- Low-to-moderate routing lifecycle risk, limited to qiankun slave mounts using browser or hash history.
- No migration, application workaround, configuration change, or global history patching is required.
- Memory history and standalone behavior remain unchanged.
- CI E2E is intentionally serialized, trading a small runtime increase for deterministic workspace fixture startup; local runs retain normal parallelism.

## Reviewer notes
- Please focus on same-base host navigation forwarding, Router history ownership during mount rollback, and listener cleanup when host and child histories are released in either order.
- For the CI-only change, review whether serializing shared workspace fixtures is the preferred stability/performance tradeoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved qiankun micro-app routing with synchronized browser and hash history.
  * Added support for host-driven navigation and native browser back/forward actions.
  * Preserved isolated memory history behavior.
  * Exposed browser and hash history utilities for navigation integrations.

* **Bug Fixes**
  * Improved history cleanup during unmount and recovery after failed mounting.

* **Documentation**
  * Documented routing synchronization behavior and simplified integration guidance.

* **Tests**
  * Expanded coverage for navigation, synchronization, cleanup, and lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->