### PR TITLE
docs(changelog): add v0.3.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ---
 
+## [0.3.3] — 2026-08-03
+
+### 🐛 Bug Fixes
+
+- **Qiankun sub-app browser history synchronization** — Qiankun masters now
+  forward same-base host location changes to mounted slaves, and slave Routers
+  reconcile native browser back/forward navigation without requiring an
+  application-level `popstate` workaround. Browser and hash history adapters
+  are scoped per app and retain the active wrapper during rollback, preventing
+  stale shared `window.history` restoration.
+
+---
+
 ## [0.3.2] — 2026-08-03
 
 ### ⚠️ Breaking Changes


### PR DESCRIPTION
## Summary
- Add the missing `v0.3.3` entry to `CHANGELOG.md` after the GitHub Release published without a corresponding repository update.
- Document the user-facing qiankun sub-app browser history fix from PR #71.

## Changes
- Add the `0.3.3` release section dated 2026-08-03.
- Describe same-base host navigation forwarding, native back/forward reconciliation, scoped history adapters, and rollback-safe history restoration.
- Keep the existing `v0.3.3` tag and npm artifacts unchanged.

## Validation
- `npm run lint`
- `npm run build --workspace evjs-docs`
- `git diff --check`

## Risk / rollout
- Low risk: documentation-only change with no runtime, package, configuration, or published artifact changes.

## Reviewer notes
- Please verify that the changelog wording accurately captures the user-visible behavior fixed in PR #71.
- The release workflow currently publishes from the GitHub Release tag but does not update `CHANGELOG.md`; automating that workflow is outside this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the 0.3.3 changelog entry.
  * Documented improved browser-history synchronization for sub-apps, including navigation updates, back/forward handling, and safer history restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->