### PR TITLE
fix(ci): set npm dist-tag for prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,18 @@ jobs:
           }
           const registry = "https://registry.npmjs.org";
 
+          const prereleaseId = version.match(
+            /^[^-]+-([0-9A-Za-z-]+)(?:[.+]|$)/,
+          )?.[1];
+          let npmTag = "latest";
+          if (prereleaseId === "alpha" || prereleaseId === "rc") {
+            npmTag = prereleaseId;
+          } else if (prereleaseId) {
+            npmTag = "next";
+          }
+
+          console.log(`Publishing ${version} with npm dist-tag ${npmTag}.`);
+
           const wait = (ms) =>
             new Promise((resolve) => {
               setTimeout(resolve, ms);
@@ -195,6 +207,8 @@ jobs:
                 workspacePackage.dir,
                 "--access",
                 "public",
+                "--tag",
+                npmTag,
                 "--registry",
                 registry,
               ],


### PR DESCRIPTION
## Summary

- infer the npm dist-tag from the release version before publishing
- publish `alpha` and `rc` prereleases under matching tags
- route other prereleases to `next` and stable releases to `latest`
- pass the resolved tag explicitly to every workspace `npm publish`

## Root cause

The release workflow pins npm 11.6.2, which rejects prerelease versions unless `npm publish` receives an explicit `--tag`. The v0.3.4-alpha.0 release therefore stopped at the first workspace before authentication or upload.

Failed run: https://github.com/afx-team/evjs/actions/runs/30799090797/job/91639274626
