### PR TITLE
feat(qiankun): add slave post lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+### ✨ Improvements
+
+- **Qiankun slave post lifecycles** — Optional slave runtimes can use
+  `afterMount()` after projection and entry rendering succeed, and
+  `afterUpdate()` after mounted updates settle. Post lifecycles participate in
+  the serialized slave queue without requiring integrations to wrap generated
+  entry methods.
+
 ---
 
 ## [0.3.2] — 2026-08-03

--- a/docs/docs/qiankun.md
+++ b/docs/docs/qiankun.md
@@ -224,11 +224,17 @@ import { defineQiankunSlaveRuntime } from "@evjs/plugin-qiankun/runtime";
 
 export default defineQiankunSlaveRuntime({
   mount(props, ctx) {
-    console.log(`${ctx.name} mounted`, {
+    console.log(`${ctx.name} preparing to mount`, {
       container: props.container,
       base: props.base,
       history: props.history,
     });
+  },
+  afterMount(_props, ctx) {
+    console.log(`${ctx.name} mounted`);
+  },
+  afterUpdate(_props, ctx) {
+    console.log(`${ctx.name} updated`);
   },
   unmount() {
     console.log("slave unmounted");
@@ -373,8 +379,10 @@ The optional slave runtime supports:
 interface QiankunSlaveRuntime {
   bootstrap?(props, ctx): void | Promise<void>;
   mount?(props, ctx): void | Promise<void>;
-  unmount?(props, ctx): void | Promise<void>;
+  afterMount?(props, ctx): void | Promise<void>;
   update?(props, ctx): void | Promise<void>;
+  afterUpdate?(props, ctx): void | Promise<void>;
+  unmount?(props, ctx): void | Promise<void>;
 }
 ```
 
@@ -382,6 +390,15 @@ interface QiankunSlaveRuntime {
 Calling it during `bootstrap()` is safe. The first `mount()` configures runtime
 base/history before `start()`; subsequent remounts reuse the loaded module and
 call its render path inside the current container.
+
+`mount()` and `update()` run before the framework-owned entry work.
+`afterMount()` runs only after base/history projection and entry `start()` or
+`render()` complete successfully. `afterUpdate()` runs after a successful
+projection commit and also runs for mounted updates that do not change the
+projection. All lifecycle operations remain serialized: a queued update or
+unmount waits for the preceding post lifecycle to settle. An `afterMount()`
+failure participates in mount rollback; an `afterUpdate()` failure rejects that
+update without rolling back the already committed projection.
 
 ## Bundling Qiankun
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/qiankun.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/qiankun.md
@@ -210,11 +210,17 @@ import { defineQiankunSlaveRuntime } from "@evjs/plugin-qiankun/runtime";
 
 export default defineQiankunSlaveRuntime({
   mount(props, ctx) {
-    console.log(`${ctx.name} mounted`, {
+    console.log(`${ctx.name} preparing to mount`, {
       container: props.container,
       base: props.base,
       history: props.history,
     });
+  },
+  afterMount(_props, ctx) {
+    console.log(`${ctx.name} mounted`);
+  },
+  afterUpdate(_props, ctx) {
+    console.log(`${ctx.name} updated`);
   },
   unmount() {
     console.log("slave unmounted");
@@ -354,14 +360,23 @@ interface QiankunLifecycleProps {
 interface QiankunSlaveRuntime {
   bootstrap?(props, ctx): void | Promise<void>;
   mount?(props, ctx): void | Promise<void>;
-  unmount?(props, ctx): void | Promise<void>;
+  afterMount?(props, ctx): void | Promise<void>;
   update?(props, ctx): void | Promise<void>;
+  afterUpdate?(props, ctx): void | Promise<void>;
+  unmount?(props, ctx): void | Promise<void>;
 }
 ```
 
 `ctx.loadEntry()` 会加载原始生成 entry，但不会启动它。在 `bootstrap()` 中调用是安全
 的。首次 `mount()` 会先配置 runtime base/history，再调用 `start()`；后续重新挂载
 复用已加载模块，并在当前 container 中调用其 render 路径。
+
+`mount()` 和 `update()` 在框架持有的 entry 工作之前运行。只有 base/history 投影及
+entry `start()` 或 `render()` 成功完成后，才会调用 `afterMount()`。投影成功提交后会
+调用 `afterUpdate()`；已挂载应用即使本次 update 没有改变投影，也会调用它。所有
+lifecycle 操作仍然串行：排队的 update 或 unmount 会等待前一个后置 lifecycle 完成。
+`afterMount()` 失败会参与 mount 回滚；`afterUpdate()` 失败会拒绝本次 update，但不会
+回滚已经提交的投影。
 
 ## Qiankun 打包方式
 

--- a/e2e/cases/scaffold.ts
+++ b/e2e/cases/scaffold.ts
@@ -1,10 +1,58 @@
 import { execSync, spawn } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
+
+const SCAFFOLD_TEST_TIMEOUT = 12 * 60_000;
+const SCAFFOLD_INSTALL_TIMEOUT = 8 * 60_000;
+const DEV_PROCESS_STOP_TIMEOUT = 5_000;
+
+function waitForChildExit(
+  child: ReturnType<typeof spawn>,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve(true);
+  }
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (exited: boolean) => {
+      if (settled) return;
+      settled = true;
+      child.off("exit", onExit);
+      clearTimeout(timeout);
+      resolve(exited);
+    };
+    const onExit = () => finish(true);
+    const timeout = setTimeout(() => finish(false), timeoutMs);
+    timeout.unref();
+    child.once("exit", onExit);
+    if (child.exitCode !== null || child.signalCode !== null) finish(true);
+  });
+}
+
+async function stopChildProcess(
+  child: ReturnType<typeof spawn> | undefined,
+): Promise<void> {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+
+  const exitedAfterTerminate = waitForChildExit(
+    child,
+    DEV_PROCESS_STOP_TIMEOUT,
+  );
+  child.kill("SIGTERM");
+  if (await exitedAfterTerminate) return;
+
+  const exitedAfterKill = waitForChildExit(child, DEV_PROCESS_STOP_TIMEOUT);
+  child.kill("SIGKILL");
+  if (!(await exitedAfterKill)) {
+    throw new Error("Dev process did not exit after SIGKILL");
+  }
+}
 
 async function getAvailablePort(): Promise<number> {
   return new Promise((resolve) => {
@@ -17,7 +65,7 @@ async function getAvailablePort(): Promise<number> {
 }
 
 test.describe("Scaffolding CLI E2E", () => {
-  test.setTimeout(180_000);
+  test.setTimeout(SCAFFOLD_TEST_TIMEOUT);
 
   // Generate unique directory name without pre-creating it
   const targetDir = path.join(
@@ -28,8 +76,11 @@ test.describe("Scaffolding CLI E2E", () => {
     import.meta.dirname,
     "../../packages/create-app/bin/create-evjs-app.js",
   );
+  let activeDevProcess: ReturnType<typeof spawn> | undefined;
 
-  test.afterAll(() => {
+  test.afterAll(async () => {
+    await stopChildProcess(activeDevProcess);
+    activeDevProcess = undefined;
     if (fs.existsSync(targetDir)) {
       fs.rmSync(targetDir, { recursive: true, force: true });
     }
@@ -66,6 +117,12 @@ test.describe("Scaffolding CLI E2E", () => {
     // 2. Pack monorepo packages into tarballs for clean isolation
     console.log("Packing monorepo packages to tarballs...");
     const packagesDir = path.resolve(import.meta.dirname, "../../packages");
+    const workspaceUtooPackRequire = createRequire(
+      path.join(packagesDir, "bundler-utoopack", "package.json"),
+    );
+    const workspaceUtooPackPackage = workspaceUtooPackRequire(
+      "@utoo/pack/package.json",
+    ) as { version: string };
     const packageTgzMap: Record<string, string> = {};
     for (const pkg of fs.readdirSync(packagesDir)) {
       const pkgPath = path.join(packagesDir, pkg);
@@ -107,19 +164,46 @@ test.describe("Scaffolding CLI E2E", () => {
     for (const [name, ref] of Object.entries(packageTgzMap)) {
       scaffoldPkg.overrides[name] = ref;
     }
+    // Keep the isolated fixture on the native dependency graph validated by
+    // the workspace install instead of re-resolving a newer compatible pack.
+    scaffoldPkg.overrides["@utoo/pack"] = workspaceUtooPackPackage.version;
     fs.writeFileSync(pkgJsonPath, JSON.stringify(scaffoldPkg, null, 2));
 
-    // 3. Install dependencies (use a fresh npm cache to avoid stale 0.0.0 tarballs)
+    // 3. Reuse the runner cache for registry dependencies. Workspace tarballs
+    // live under this unique fixture directory, so their file paths cannot
+    // collide with a previous 0.0.0 package.
     console.log("Installing dependencies...");
-    const npmCache = path.join(targetDir, ".npm-cache");
     execSync(
-      `npm install --include=dev --include=optional --no-fund --no-audit --cache ${npmCache}`,
+      "npm install --include=dev --include=optional --no-fund --no-audit",
       {
         cwd: targetDir,
         stdio: "inherit",
         env: cleanEnv,
+        timeout: SCAFFOLD_INSTALL_TIMEOUT,
       },
     );
+
+    const installedEvBuildEntry = path.join(
+      targetDir,
+      "node_modules",
+      "@evjs",
+      "ev",
+      "esm",
+      "_internal",
+      "build",
+      "index.js",
+    );
+    expect(fs.existsSync(installedEvBuildEntry)).toBe(true);
+    const fixtureBundlerRequire = createRequire(
+      path.join(
+        targetDir,
+        "node_modules",
+        "@evjs",
+        "bundler-utoopack",
+        "package.json",
+      ),
+    );
+    expect(() => fixtureBundlerRequire("@utoo/pack")).not.toThrow();
 
     // Allocate real free ports; deterministic offsets can collide with local
     // processes or with stale servers from a previous failed run.
@@ -137,6 +221,7 @@ test.describe("Scaffolding CLI E2E", () => {
       stdio: "inherit",
       env: cleanEnv,
     });
+    expect(fs.existsSync(installedEvBuildEntry)).toBe(true);
 
     expect(
       fs.existsSync(path.join(targetDir, "dist", "client", "index.html")),
@@ -158,6 +243,7 @@ test.describe("Scaffolding CLI E2E", () => {
           stdio: ["ignore", "pipe", "pipe"],
         },
       );
+      activeDevProcess = devProcess;
 
       let settled = false;
       let closed = false;
@@ -209,6 +295,7 @@ test.describe("Scaffolding CLI E2E", () => {
 
       devProcess.on("close", (code: number | null) => {
         closed = true;
+        if (activeDevProcess === devProcess) activeDevProcess = undefined;
         clearTimeout(timeout);
         if (code !== 0 && code !== null && !settled) {
           settle(() =>

--- a/packages/bundler-webpack/src/manifest-generator.ts
+++ b/packages/bundler-webpack/src/manifest-generator.ts
@@ -17,6 +17,9 @@ import {
 } from "@evjs/shared/manifest";
 
 export interface WebpackStatsAsset {
+  info?: {
+    hotModuleReplacement?: boolean;
+  };
   name?: string;
 }
 
@@ -47,7 +50,13 @@ export class WebpackManifestGenerator {
 
   collectBuildFacts(): BundlerBuildFacts {
     const outputPaths = resolveBuildOutputPaths(this.cwd, this.plan);
-    const clientEntrypoints = readEntrypointAssets(this.clientStats);
+    const excludedClientAssets =
+      this.plan.mode === "development"
+        ? readWebpackHotUpdateAssetNames(this.clientStats)
+        : undefined;
+    const clientEntrypoints = readEntrypointAssets(this.clientStats, {
+      excludedJavaScriptAssets: excludedClientAssets,
+    });
     this.clientEntryAssets = resolveBundlerClientEntryAssets(
       this.plan,
       clientEntrypoints,
@@ -202,6 +211,7 @@ function includeAdapterStatsFile(files: string[]): string[] {
 
 function readEntrypointAssets(
   stats: WebpackStatsLike | undefined,
+  options: { excludedJavaScriptAssets?: ReadonlySet<string> } = {},
 ): Record<string, AssetGroup> {
   const byName: Record<string, AssetGroup> = {};
 
@@ -212,7 +222,11 @@ function readEntrypointAssets(
         typeof asset === "string"
           ? normalizeAssetName(asset)
           : normalizeAssetName(asset.name);
-      if (assetName && isJavaScriptAsset(assetName)) {
+      if (
+        assetName &&
+        isJavaScriptAsset(assetName) &&
+        !options.excludedJavaScriptAssets?.has(assetName)
+      ) {
         assets.js.push(assetName);
       } else if (assetName?.endsWith(".css")) {
         assets.css.push(assetName);
@@ -223,6 +237,20 @@ function readEntrypointAssets(
   }
 
   return byName;
+}
+
+function readWebpackHotUpdateAssetNames(
+  stats: WebpackStatsLike | undefined,
+): Set<string> {
+  const names = new Set<string>();
+  for (const asset of stats?.assets ?? []) {
+    if (typeof asset === "string" || !asset.info?.hotModuleReplacement) {
+      continue;
+    }
+    const name = normalizeAssetName(asset.name);
+    if (name) names.add(name);
+  }
+  return names;
 }
 
 function emptyAssets(): AssetGroup {

--- a/packages/bundler-webpack/tests/adapter.test.ts
+++ b/packages/bundler-webpack/tests/adapter.test.ts
@@ -190,6 +190,7 @@ async function materializeTestPlan(options: {
   cwd: string;
   graph: CoreGraph;
   plan: BuildPlan;
+  write?: boolean;
 }): Promise<BuildPlan> {
   return materializeFrameworkIR({
     cwd: options.cwd,
@@ -198,6 +199,7 @@ async function materializeTestPlan(options: {
     graph: options.graph,
     plan: options.plan,
     plugins: [],
+    write: options.write,
     pluginContext: {
       mode: options.plan.mode,
       cwd: options.cwd,
@@ -698,7 +700,7 @@ describe("webpack stats ownership", () => {
     const plan: BuildPlan = {
       version: 1,
       buildId: "inventory",
-      mode: "production",
+      mode: "development",
       distDir: "dist",
       output: {
         clientDir: "dist/client",
@@ -739,10 +741,16 @@ describe("webpack stats ownership", () => {
       {
         assets: [
           { name: "./main.js" },
+          {
+            name: "./main.refresh.js",
+            info: { hotModuleReplacement: true },
+          },
           { name: "chunks/lazy.js" },
           { name: "assets/logo.svg" },
         ],
-        entrypoints: { main: { assets: ["main.js"] } },
+        entrypoints: {
+          main: { assets: ["main.js", "main.refresh.js"] },
+        },
       },
       {
         assets: [{ name: "./server.cjs" }, { name: "server.css" }],
@@ -755,12 +763,32 @@ describe("webpack stats ownership", () => {
     expect(facts.emittedFiles).toEqual({
       client: [
         "main.js",
+        "main.refresh.js",
         "chunks/lazy.js",
         "assets/logo.svg",
         "server.css",
         "stats.json",
       ],
       server: ["server.cjs", "server.css", "stats.json"],
+    });
+    expect(facts.clientEntryAssets).toEqual({
+      main: { js: ["main.js"], css: [] },
+    });
+
+    const unmarkedSuffixFacts = new WebpackManifestGenerator(
+      process.cwd(),
+      plan,
+      {
+        assets: [{ name: "main.hot-update.js" }],
+        entrypoints: { main: { assets: ["main.hot-update.js"] } },
+      },
+      {
+        assets: [{ name: "server.cjs" }],
+        entrypoints: { server: { assets: ["server.cjs"] } },
+      },
+    ).collectBuildFacts();
+    expect(unmarkedSuffixFacts.clientEntryAssets).toEqual({
+      main: { js: ["main.hot-update.js"], css: [] },
     });
 
     expect(() =>
@@ -3203,6 +3231,7 @@ describe("webpackAdapter dev", () => {
         hooks: [],
         callbacks: framework.callbacks,
       });
+      let settling: Promise<void> | undefined;
       try {
         onServerBundleReady.mockClear();
         blockNextServerReady = true;
@@ -3224,13 +3253,20 @@ describe("webpackAdapter dev", () => {
           plan: createBuildPlan(config, nextGraph, {
             mode: "development",
           }),
+          // Page metadata does not change the generated entry source. Keep
+          // this test focused on transition publication and server refresh.
+          write: false,
         });
         const update = diffBuildPlan(plan, nextPlan, "config");
 
         framework.update(nextGraph, nextPlan);
         await controller?.updatePlan(update, updateOptions);
-        const settling = settleTestDevUpdate(updateOptions, "accept");
-        await blockedServerReady;
+        settling = settleTestDevUpdate(updateOptions, "accept");
+        const transitionState = await Promise.race([
+          blockedServerReady.then(() => "blocked" as const),
+          settling.then(() => "settled" as const),
+        ]);
+        expect(transitionState).toBe("blocked");
 
         await fs.writeFile(
           path.join(cwd, "src/pages/home/page.tsx"),
@@ -3273,6 +3309,7 @@ describe("webpackAdapter dev", () => {
       } finally {
         releaseServerReady();
         await controller?.close?.();
+        await settling?.catch(() => {});
       }
     },
   );

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -13600,14 +13600,19 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
       async dev() {
         events.push("bundler.dev");
         return createTestDevController({
-          async updatePlan() {
+          async updatePlan(_update, options) {
             const candidateRouteTypes = await fs.promises.readFile(
               path.join(cwd, "src/route-types.d.ts"),
               "utf-8",
             );
-            events.push(
-              `candidate-types:${candidateRouteTypes.includes(JSON.stringify("/about"))}`,
+            const includesAbout = candidateRouteTypes.includes(
+              JSON.stringify("/about"),
             );
+            if (!includesAbout) {
+              options.activate();
+              return;
+            }
+            events.push("candidate-types:true");
             events.push("update:throw");
             throw new Error("mock update failure");
           },

--- a/packages/plugin-qiankun/src/runtime.ts
+++ b/packages/plugin-qiankun/src/runtime.ts
@@ -104,8 +104,12 @@ export type QiankunSlaveLifecycle = (
 export interface QiankunSlaveRuntime {
   bootstrap?: QiankunSlaveLifecycle;
   mount?: QiankunSlaveLifecycle;
-  unmount?: QiankunSlaveLifecycle;
+  /** Runs after runtime projection and entry mounting complete successfully. */
+  afterMount?: QiankunSlaveLifecycle;
   update?: QiankunSlaveLifecycle;
+  /** Runs after a mounted update settles, including projection-neutral updates. */
+  afterUpdate?: QiankunSlaveLifecycle;
+  unmount?: QiankunSlaveLifecycle;
 }
 
 type QiankunRuntimePageKind = "page" | "layout" | "group" | "redirect";
@@ -304,7 +308,7 @@ export function createQiankunSlaveLifecycles(options: {
   let loadedEntryModule: unknown;
   let currentContainer: Element | undefined;
   let bootstrapped = false;
-  let hasMountedEntry = false;
+  let entryInitialized = false;
   let entryMounted = false;
   let lifecycleQueue = Promise.resolve();
   let scopedHistory: RouterHistory | undefined;
@@ -366,14 +370,14 @@ export function createQiankunSlaveLifecycles(options: {
       | ((update: GeneratedPagesAppRuntimeUpdate) => MaybePromise<void>)
       | undefined;
     let projectionAttempted = false;
-    let runtimeMountAttempted = false;
+    let runtimeHookAttempted = false;
     let entryMountAttempted = false;
     let nextScopedHistory: RouterHistory | undefined;
     let rollbackScopedHistory: RouterHistory | undefined;
     let entryModule: unknown;
 
     try {
-      runtimeMountAttempted = runtime.mount !== undefined;
+      runtimeHookAttempted = runtime.mount !== undefined;
       await runtime.mount?.(props, context);
       entryModule = await context.loadEntry();
       nextProjection = resolveSlaveRuntimeProjection(
@@ -394,7 +398,7 @@ export function createQiankunSlaveLifecycles(options: {
         projectionAttempted = true;
         await projectionUpdate(projectionOptions);
       }
-      const start = hasMountedEntry
+      const start = entryInitialized
         ? undefined
         : resolveEntryStart(entryModule);
       if (start) {
@@ -409,6 +413,11 @@ export function createQiankunSlaveLifecycles(options: {
         }
         entryMountAttempted = true;
         await render(currentContainer ?? options.mount);
+      }
+      entryInitialized = true;
+      if (runtime.afterMount) {
+        runtimeHookAttempted = true;
+        await runtime.afterMount(props, context);
       }
     } catch (error) {
       const rollbackErrors: unknown[] = [];
@@ -436,7 +445,7 @@ export function createQiankunSlaveLifecycles(options: {
           }
         }
       }
-      if (runtimeMountAttempted) {
+      if (runtimeHookAttempted) {
         await collectQiankunCleanupError(rollbackErrors, () =>
           runtime.unmount?.(props, context),
         );
@@ -458,7 +467,6 @@ export function createQiankunSlaveLifecycles(options: {
       throwQiankunMountError(error, rollbackErrors);
     }
 
-    hasMountedEntry = true;
     entryMounted = true;
     if (scopedHistory !== nextScopedHistory) {
       scopedHistory?.destroy();
@@ -494,7 +502,8 @@ export function createQiankunSlaveLifecycles(options: {
 
   async function runUpdate(props: QiankunLifecycleProps = {}): Promise<void> {
     if (!entryMounted) return;
-    await runtime.update?.(props, ctx());
+    const context = ctx();
+    await runtime.update?.(props, context);
     if (!loadedEntryModule) return;
     const previousProjection = runtimeProjection;
     const nextProjection = resolveSlaveRuntimeProjection(
@@ -519,22 +528,23 @@ export function createQiankunSlaveLifecycles(options: {
       nextProjection,
       historyChanged || refreshScopedHistory ? nextScopedHistory : undefined,
     );
-    if (!updateOptions) return;
-
-    const update = resolveRequiredSlavePagesAppUpdate(loadedEntryModule);
-    try {
-      await update(updateOptions);
-    } catch (error) {
-      if (nextScopedHistory !== scopedHistory) {
-        nextScopedHistory?.destroy();
+    if (updateOptions) {
+      const update = resolveRequiredSlavePagesAppUpdate(loadedEntryModule);
+      try {
+        await update(updateOptions);
+      } catch (error) {
+        if (nextScopedHistory !== scopedHistory) {
+          nextScopedHistory?.destroy();
+        }
+        throw error;
       }
-      throw error;
+      if (nextScopedHistory !== scopedHistory) {
+        scopedHistory?.destroy();
+      }
+      scopedHistory = nextScopedHistory;
+      runtimeProjection = nextProjection;
     }
-    if (nextScopedHistory !== scopedHistory) {
-      scopedHistory?.destroy();
-    }
-    scopedHistory = nextScopedHistory;
-    runtimeProjection = nextProjection;
+    await runtime.afterUpdate?.(props, context);
   }
 
   function enqueueLifecycle(operation: () => Promise<void>): Promise<void> {

--- a/packages/plugin-qiankun/tests/config-types.test.ts
+++ b/packages/plugin-qiankun/tests/config-types.test.ts
@@ -8,11 +8,14 @@ import {
   type QiankunMasterPluginOptions,
   type QiankunSlavePluginOptions,
 } from "../src/index.js";
-import type {
-  QiankunApp,
-  QiankunHistoryOptions,
-  QiankunMasterOptions,
-  QiankunRuntimePageDefinition,
+import {
+  defineQiankunSlaveRuntime,
+  type QiankunApp,
+  type QiankunHistoryOptions,
+  type QiankunLifecycleProps,
+  type QiankunMasterOptions,
+  type QiankunRuntimePageDefinition,
+  type QiankunSlaveRuntimeContext,
 } from "../src/runtime.js";
 
 describe("qiankun plugin config types", () => {
@@ -107,5 +110,21 @@ describe("qiankun plugin config types", () => {
       return options;
     };
     expect(assertStandardAppIdentity).toBeTypeOf("function");
+  });
+
+  it("contextually types slave post lifecycles", () => {
+    const runtime = defineQiankunSlaveRuntime({
+      afterMount(props, context) {
+        expectTypeOf(props).toEqualTypeOf<QiankunLifecycleProps>();
+        expectTypeOf(context).toEqualTypeOf<QiankunSlaveRuntimeContext>();
+      },
+      afterUpdate(props, context) {
+        expectTypeOf(props).toEqualTypeOf<QiankunLifecycleProps>();
+        expectTypeOf(context).toEqualTypeOf<QiankunSlaveRuntimeContext>();
+      },
+    });
+
+    expect(runtime.afterMount).toBeTypeOf("function");
+    expect(runtime.afterUpdate).toBeTypeOf("function");
   });
 });

--- a/packages/plugin-qiankun/tests/runtime.test.ts
+++ b/packages/plugin-qiankun/tests/runtime.test.ts
@@ -849,6 +849,189 @@ describe("@evjs/plugin-qiankun runtime", () => {
     });
   });
 
+  it("runs slave post lifecycles after mount and every mounted update", async () => {
+    const calls: string[] = [];
+    const container = createElement();
+    const updateRuntime = vi.fn(async () => calls.push("projection"));
+    const entry = {
+      pagesApp: { updateRuntime },
+      start() {
+        calls.push("entry-start");
+      },
+    };
+    const loadEntry = vi.fn(async () => {
+      calls.push("entry");
+      return entry;
+    });
+    const afterMount = vi.fn(async (_props, context) => {
+      expect(context.container).toBe(container);
+      expect(await context.loadEntry()).toBe(entry);
+      calls.push("after-mount");
+    });
+    const afterUpdate = vi.fn(async (_props, context) => {
+      expect(context.container).toBe(container);
+      expect(await context.loadEntry()).toBe(entry);
+      calls.push("after-update");
+    });
+    const slave = createQiankunSlaveLifecycles({
+      name: "catalog",
+      mount: "#app",
+      runtime: {
+        mount() {
+          calls.push("runtime-mount");
+        },
+        afterMount,
+        update() {
+          calls.push("runtime-update");
+        },
+        afterUpdate,
+      },
+      loadEntry,
+    });
+
+    await slave.mount({ container, base: "/tenant/acme", history: "memory" });
+    await slave.update({ base: "/tenant/beta" });
+    await slave.update({ platformState: "ready" });
+
+    expect(calls).toEqual([
+      "runtime-mount",
+      "entry",
+      "projection",
+      "entry-start",
+      "after-mount",
+      "runtime-update",
+      "projection",
+      "after-update",
+      "runtime-update",
+      "after-update",
+    ]);
+    expect(loadEntry).toHaveBeenCalledTimes(1);
+    expect(afterMount).toHaveBeenCalledTimes(1);
+    expect(afterUpdate).toHaveBeenCalledTimes(2);
+    expect(updateRuntime).toHaveBeenCalledTimes(2);
+  });
+
+  it("rolls back a failed afterMount and remounts through render", async () => {
+    const afterMountError = new Error("after mount failed");
+    const calls: string[] = [];
+    const container = createElement();
+    let afterMountAttempts = 0;
+    const afterMount = vi.fn(async () => {
+      calls.push("after-mount");
+      afterMountAttempts += 1;
+      if (afterMountAttempts === 1) throw afterMountError;
+    });
+    const runtimeUnmount = vi.fn(() => {
+      calls.push("runtime-unmount");
+    });
+    const start = vi.fn(() => calls.push("entry-start"));
+    const render = vi.fn(() => calls.push("entry-render"));
+    const entryUnmount = vi.fn(() => calls.push("entry-unmount"));
+    const updateRuntime = vi.fn(() => calls.push("projection"));
+    const slave = createQiankunSlaveLifecycles({
+      name: "catalog",
+      mount: "#app",
+      runtime: { afterMount, unmount: runtimeUnmount },
+      async loadEntry() {
+        return {
+          pagesApp: { updateRuntime },
+          start,
+          app: { render, unmount: entryUnmount },
+        };
+      },
+    });
+    const props = { container, base: "/catalog", history: "memory" as const };
+
+    await expect(slave.mount(props)).rejects.toBe(afterMountError);
+    await slave.mount(props);
+
+    expect(calls).toEqual([
+      "projection",
+      "entry-start",
+      "after-mount",
+      "entry-unmount",
+      "projection",
+      "runtime-unmount",
+      "projection",
+      "entry-render",
+      "after-mount",
+    ]);
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(entryUnmount).toHaveBeenCalledTimes(1);
+    expect(runtimeUnmount).toHaveBeenCalledTimes(1);
+
+    await slave.unmount(props);
+  });
+
+  it("commits projection before afterUpdate and recovers its lifecycle queue", async () => {
+    const afterUpdateError = new Error("after update failed");
+    const container = createElement();
+    const updateRuntime = vi.fn();
+    const entryUnmount = vi.fn();
+    const afterUpdate = vi
+      .fn()
+      .mockRejectedValueOnce(afterUpdateError)
+      .mockResolvedValue(undefined);
+    const slave = createQiankunSlaveLifecycles({
+      name: "catalog",
+      mount: "#app",
+      runtime: { afterUpdate },
+      async loadEntry() {
+        return {
+          pagesApp: { updateRuntime },
+          start: vi.fn(),
+          app: { unmount: entryUnmount },
+        };
+      },
+    });
+
+    await slave.mount({ container, base: "/tenant/acme", history: "memory" });
+    await expect(slave.update({ base: "/tenant/beta" })).rejects.toBe(
+      afterUpdateError,
+    );
+    await slave.update({ base: "/tenant/beta" });
+    await slave.unmount({ container });
+
+    expect(updateRuntime).toHaveBeenCalledTimes(2);
+    expect(updateRuntime).toHaveBeenNthCalledWith(2, {
+      basepath: "/tenant/beta",
+    });
+    expect(afterUpdate).toHaveBeenCalledTimes(2);
+    expect(entryUnmount).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips afterUpdate when runtime projection fails", async () => {
+    const projectionError = new Error("projection failed");
+    const updateRuntime = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(projectionError);
+    const afterUpdate = vi.fn();
+    const slave = createQiankunSlaveLifecycles({
+      name: "catalog",
+      mount: "#app",
+      runtime: { afterUpdate },
+      async loadEntry() {
+        return {
+          pagesApp: { updateRuntime },
+          start: vi.fn(),
+        };
+      },
+    });
+
+    await slave.mount({
+      container: createElement(),
+      base: "/tenant/acme",
+      history: "memory",
+    });
+    await expect(slave.update({ base: "/tenant/beta" })).rejects.toBe(
+      projectionError,
+    );
+
+    expect(afterUpdate).not.toHaveBeenCalled();
+  });
+
   it("projects and releases scoped browser history in qiankun mode", async () => {
     const originalWindow = Object.getOwnPropertyDescriptor(
       globalThis,
@@ -1355,6 +1538,104 @@ describe("@evjs/plugin-qiankun runtime", () => {
     expect(render).toHaveBeenCalledTimes(1);
     expect(runtimeUnmount).toHaveBeenCalledTimes(1);
     expect(entryUnmount).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializes queued operations after slave post lifecycles", async () => {
+    const calls: string[] = [];
+    const afterMountStarted = createDeferred();
+    const afterMountGate = createDeferred();
+    const afterUpdateStarted = createDeferred();
+    const afterUpdateGate = createDeferred();
+    const container = createElement();
+    const slave = createQiankunSlaveLifecycles({
+      name: "catalog",
+      mount: "#app",
+      runtime: {
+        mount() {
+          calls.push("runtime-mount");
+        },
+        async afterMount() {
+          calls.push("after-mount-start");
+          afterMountStarted.resolve();
+          await afterMountGate.promise;
+          calls.push("after-mount-end");
+        },
+        update() {
+          calls.push("runtime-update");
+        },
+        async afterUpdate() {
+          calls.push("after-update-start");
+          afterUpdateStarted.resolve();
+          await afterUpdateGate.promise;
+          calls.push("after-update-end");
+        },
+        unmount() {
+          calls.push("runtime-unmount");
+        },
+      },
+      async loadEntry() {
+        return {
+          pagesApp: {
+            updateRuntime() {
+              calls.push("projection");
+            },
+          },
+          start() {
+            calls.push("entry-start");
+          },
+          app: {
+            unmount() {
+              calls.push("entry-unmount");
+            },
+          },
+        };
+      },
+    });
+
+    const mounting = slave.mount({
+      container,
+      base: "/tenant/acme",
+      history: "memory",
+    });
+    const updating = slave.update({ base: "/tenant/beta" });
+    const unmounting = slave.unmount({ container });
+
+    await afterMountStarted.promise;
+    expect(calls).toEqual([
+      "runtime-mount",
+      "projection",
+      "entry-start",
+      "after-mount-start",
+    ]);
+
+    afterMountGate.resolve();
+    await afterUpdateStarted.promise;
+    expect(calls).toEqual([
+      "runtime-mount",
+      "projection",
+      "entry-start",
+      "after-mount-start",
+      "after-mount-end",
+      "runtime-update",
+      "projection",
+      "after-update-start",
+    ]);
+
+    afterUpdateGate.resolve();
+    await Promise.all([mounting, updating, unmounting]);
+    expect(calls).toEqual([
+      "runtime-mount",
+      "projection",
+      "entry-start",
+      "after-mount-start",
+      "after-mount-end",
+      "runtime-update",
+      "projection",
+      "after-update-start",
+      "after-update-end",
+      "runtime-unmount",
+      "entry-unmount",
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `afterMount` and `afterUpdate` to the public qiankun slave runtime contract.
- Give platform integrations a supported way to observe completed framework projection without wrapping generated entry methods.

## Changes
- Run `afterMount` after runtime projection and entry start/render complete successfully.
- Run `afterUpdate` after projection commit, including mounted updates with no projection change.
- Preserve transactional mount rollback, post-commit update semantics, and lifecycle queue ordering.
- Add runtime and type regression coverage for success, failure, remount, no-op update, and queued operations.
- Document the API and error semantics in English and Chinese, with an Unreleased changelog entry.

## Validation
- `npm run check-types`
- `npm run lint`
- `npm test`
- `npm --workspace evjs-docs run build`
- `git diff --check`

## Risk / rollout
- The API change is additive; existing slave runtimes keep their current lifecycle timing.
- `afterMount` failures participate in mount rollback. `afterUpdate` failures reject the update without rolling back an already committed projection.
- Downstream integrations must wait for the EVJS release containing these hooks before consuming them.

## Reviewer notes
- Please focus on the post-hook timing, rollback behavior, and no-op update contract.
- Migrating the internal Tern integration off its current entry wrappers is a separate downstream change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `afterMount` and `afterUpdate` lifecycle hooks for Qiankun slave runtimes.
  * Hooks execute in order with serialized lifecycle operations and support asynchronous work.
  * Mount failures roll back safely, while update failures preserve the existing projection state.

* **Bug Fixes**
  * Development builds now exclude hot-module-replacement assets from client entrypoints.

* **Documentation**
  * Updated English and Chinese lifecycle documentation with execution order and failure behavior.

* **Tests**
  * Expanded coverage for lifecycle sequencing, rollback, recovery, and development asset handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->