### PR TITLE
docs(changelog): prepare v0.3.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.5] — 2026-08-04
+
 ### ✨ Improvements
 
 - **Qiankun slave post lifecycles** — Optional slave runtimes can use
@@ -13,6 +17,13 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
   `afterUpdate()` after mounted updates settle. Post lifecycles participate in
   the serialized slave queue without requiring integrations to wrap generated
   entry methods.
+
+### 🐛 Bug Fixes
+
+- **Stable Webpack development entry assets** — HMR assets are identified from
+  Webpack stats metadata and excluded from canonical client entry assets while
+  remaining in the emitted-file inventory, preventing replacement compilations
+  from failing single-entry validation.
 
 ---
 


### PR DESCRIPTION
## Summary

- Prepare the stable EVJS v0.3.5 release notes from the current `main` branch.
- Keep v0.3.4 reserved from stable promotion because its existing alpha line contains unmerged multi-server work.

## Changes

- Move the qiankun slave post-lifecycle entry from `Unreleased` to v0.3.5.
- Document the Webpack development HMR entry-asset fix included in PR #75.

## Validation

- `npm run lint`
- `npm run check-types`
- `npm --workspace evjs-docs run build`
- `git diff --check`

## Risk / rollout

- Documentation-only change; package source versions remain `0.0.0` and workspace dependencies remain `*`.
- Publishing the GitHub release after this PR merges will trigger the npm release workflow for v0.3.5.

## Reviewer notes

- Please verify that the release notes describe only behavior already merged to `main`.
- The existing `0.3.4-alpha.*` packages remain on the `alpha` dist-tag and are not promoted by this release.
