### PR TITLE
docs(changelog): prepare v0.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.4] — 2026-08-04
+
 ### ✨ Improvements
 
 - **Qiankun slave post lifecycles** — Optional slave runtimes can use
@@ -13,6 +17,13 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
   `afterUpdate()` after mounted updates settle. Post lifecycles participate in
   the serialized slave queue without requiring integrations to wrap generated
   entry methods.
+
+### 🐛 Bug Fixes
+
+- **Stable Webpack development entry assets** — HMR assets are identified from
+  Webpack stats metadata and excluded from canonical client entry assets while
+  remaining in the emitted-file inventory, preventing replacement compilations
+  from failing single-entry validation.
 
 ---
 


### PR DESCRIPTION
## Summary

- Prepare the stable EVJS v0.3.4 release notes from the current `main` branch.
- Publish only behavior merged to `main`; the existing alpha-only multi-server work remains excluded.

## Changes

- Move the qiankun slave post-lifecycle entry from `Unreleased` to v0.3.4.
- Document the Webpack development HMR entry-asset fix included in PR #75.

## Validation

- `npm run lint`
- `npm run check-types`
- `npm --workspace evjs-docs run build`
- `git diff --check`

## Risk / rollout

- Documentation-only change; package source versions remain `0.0.0` and workspace dependencies remain `*`.
- Publishing the GitHub release after this PR merges will trigger the npm release workflow for v0.3.4.

## Reviewer notes

- Please verify that the release notes describe only behavior already merged to `main`.
- The existing `0.3.4-alpha.*` packages contain additional unmerged work; this stable release intentionally follows current `main` instead of promoting those alpha artifacts.
