### PR TITLE
feat(ev): add server entry replacement slot

### DIFF
--- a/docs/docs/generated-contributions.md
+++ b/docs/docs/generated-contributions.md
@@ -201,6 +201,7 @@ The supported slots are:
 | Slot | Covers |
 |------|--------|
 | `client.entry` | Entry imports and entry wrapper modules, including replacement wrappers |
+| `server.entry` | Replacement modules for existing Page server entries |
 | `page.wrapper` | Semantic Page component wrapping across client and server projections |
 | `server.request.middleware` | Framework request middleware in the server pipeline |
 | `html.tag` | Structured `meta`, `link`, `script`, and `style` tags |
@@ -209,6 +210,33 @@ The supported slots are:
 
 Use `client.entry` to import a side-effect module or call an explicit
 installer. The IR does not carry an inert runtime-plugin registry.
+
+`server.entry` is replacement-only. It requires `mode: "replace"` and an exact
+Page target, and that Page must already own a `page-server` entry. The
+contribution replaces only that entry's generated facade module; its framework
+name, kind, owner, environment, renderer identity, and output asset binding
+remain unchanged. It cannot create an entry or target another server renderer
+kind.
+
+```ts
+emitIR(ctx) {
+  const entry = ctx.emit.module({
+    id: "page-server-entry",
+    scope: { kind: "page", pageId: "dashboard" },
+    source: "export default function Dashboard() { return null; }",
+  });
+
+  ctx.slot("server.entry").add({
+    id: "page-server-entry-slot",
+    target: { kind: "page", pageId: "dashboard" },
+    module: entry,
+    mode: "replace",
+  });
+}
+```
+
+Unknown Pages, Pages without a concrete `page-server` entry, and multiple
+replacements for the same concrete entry fail during IR materialization.
 
 `client.entry.runtime` accepts only `"client"`. A client entry cannot
 materialize server code, so `"server"` and the misleading `"all"` value are

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/generated-contributions.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/generated-contributions.md
@@ -190,6 +190,7 @@ slots 如下：
 | Slot | 覆盖能力 |
 |------|----------|
 | `client.entry` | Entry imports、entry wrapper modules 和 replacement wrappers |
+| `server.entry` | 替换已有 Page server entry 的模块 |
 | `page.wrapper` | 跨 client/server projection 的语义 Page component 包装 |
 | `server.request.middleware` | Server pipeline 中的 framework request middleware |
 | `html.tag` | 结构化 `meta`、`link`、`script`、`style` tags |
@@ -198,6 +199,32 @@ slots 如下：
 
 需要 import side-effect module 或执行安装逻辑时，使用 `client.entry` 显式调用
 installer。IR 不携带 inert runtime-plugin registry。
+
+`server.entry` 只支持 replacement。它要求显式提供 `mode: "replace"` 和精确的 Page
+target，且该 Page 必须已经拥有 `page-server` entry。Contribution 只替换该 entry 的
+generated facade module；框架持有的 name、kind、owner、environment、renderer identity
+与 output asset binding 均保持不变。它不能新增 entry，也不能命中其他 server renderer
+kind。
+
+```ts
+emitIR(ctx) {
+  const entry = ctx.emit.module({
+    id: "page-server-entry",
+    scope: { kind: "page", pageId: "dashboard" },
+    source: "export default function Dashboard() { return null; }",
+  });
+
+  ctx.slot("server.entry").add({
+    id: "page-server-entry-slot",
+    target: { kind: "page", pageId: "dashboard" },
+    module: entry,
+    mode: "replace",
+  });
+}
+```
+
+未知 Page、没有 concrete `page-server` entry 的 Page，以及同一 concrete entry 的多次
+replacement，都会在 IR materialization 阶段失败。
 
 `client.entry.runtime` 只接受 `"client"`。Client entry 无法物化 server code，
 因此 `"server"` 和具有误导性的 `"all"` 都会被拒绝。需要把 Page component

--- a/packages/ev/src/_internal/build/generated-contributions.ts
+++ b/packages/ev/src/_internal/build/generated-contributions.ts
@@ -24,6 +24,7 @@ import type {
   HtmlTagSlotPlanItem,
   PageWrapperSlotPlanItem,
   ServerAppEntryMetadata,
+  ServerEntrySlotPlanItem,
   ServerMiddlewareNode,
 } from "@evjs/shared/manifest";
 import { assertPluginId } from "@evjs/shared/manifest";
@@ -70,6 +71,7 @@ export const GENERATED_IR_TYPES = "types.d.ts";
 const generatedModuleRefSymbol = Symbol.for("evjs.generated.module.ref");
 const FRAMEWORK_SLOT_NAMES = [
   "client.entry",
+  "server.entry",
   "page.wrapper",
   "server.request.middleware",
   "html.tag",
@@ -90,6 +92,7 @@ const CONTRIBUTION_RUNTIMES = [
 ] as const satisfies readonly ContributionRuntime[];
 const CLIENT_ENTRY_RUNTIMES = ["client"] as const;
 const CLIENT_ENTRY_MODES = ["import", "replace"] as const;
+const SERVER_ENTRY_MODES = ["replace"] as const;
 const HTML_TAG_NAMES = [
   "meta",
   "link",
@@ -145,6 +148,7 @@ interface InternalGeneratedModuleRef {
 
 type TargetedSlotPlanItem =
   | ClientEntrySlotPlanItem
+  | ServerEntrySlotPlanItem
   | PageWrapperSlotPlanItem
   | HtmlTagSlotPlanItem;
 
@@ -318,10 +322,41 @@ class ContributionCollector<TBundlerCfg> {
       }
     }
 
+    const serverEntryReplacements = new Map<string, ServerEntrySlotPlanItem>();
     for (const slot of this.slots) {
       if (!isTargetedSlotPlanItem(slot) || !slot.target) continue;
       const target = slot.target;
       this.validateKnownTarget(slot);
+
+      if (slot.slot === "server.entry") {
+        const pageId = slot.target.pageId;
+        const matches = this.options.plan.entries.filter(
+          (entry) =>
+            entry.environment === "server" &&
+            entry.kind === "page-server" &&
+            targetMatchesEntry(target, entry),
+        );
+        if (matches.length === 0) {
+          throw new Error(
+            `[evjs] Plugin "${slot.pluginId}" server.entry contribution "${slot.id}" targets page "${pageId}", but no server page entry matches that target.`,
+          );
+        }
+        if (matches.length > 1) {
+          throw new Error(
+            `[evjs] Plugin "${slot.pluginId}" server.entry contribution "${slot.id}" targets page "${pageId}", but multiple server page entries match that target: ${matches
+              .map((entry) => `"${entry.name}"`)
+              .join(", ")}.`,
+          );
+        }
+        const entry = matches[0];
+        const previous = serverEntryReplacements.get(entry.name);
+        if (previous) {
+          throw new Error(
+            `[evjs] Server page entry "${entry.name}" has multiple replacement server.entry contributions: ${previous.key}, ${slot.key}.`,
+          );
+        }
+        serverEntryReplacements.set(entry.name, slot);
+      }
 
       if (
         slot.slot === "client.entry" &&
@@ -607,6 +642,24 @@ class ContributionCollector<TBundlerCfg> {
             : {}),
         };
       }
+      case "server.entry": {
+        const item = input as FrameworkSlotInput<"server.entry">;
+        assertGeneratedModuleOrString(pluginId, item.id, item.module);
+        return {
+          ...base,
+          slot: name,
+          module: this.resolveModuleValue(
+            item.module,
+            {
+              from: base.key,
+              kind: "slot-module",
+            },
+            "file",
+          ),
+          target: validateServerEntryTarget(item.target),
+          mode: validateEnum(item.mode, SERVER_ENTRY_MODES, `${base.key}.mode`),
+        };
+      }
       case "page.wrapper": {
         const item = input as FrameworkSlotInput<"page.wrapper">;
         assertGeneratedModuleOrString(pluginId, item.id, item.module);
@@ -848,6 +901,7 @@ function isTargetedSlotPlanItem(
 ): slot is TargetedSlotPlanItem {
   return (
     slot.slot === "client.entry" ||
+    slot.slot === "server.entry" ||
     slot.slot === "page.wrapper" ||
     slot.slot === "html.tag"
   );
@@ -1500,6 +1554,17 @@ function createEntrySource(
     return toGeneratedImportSpecifier(cwd, fromFile, file);
   }
 
+  if (entry.kind === "page-server") {
+    const replacement = getMatchingServerEntryReplacement(plan, entry);
+    if (replacement) {
+      const mod = toGeneratedImportSpecifier(cwd, fromFile, replacement.module);
+      return [
+        `export { default } from ${JSON.stringify(mod)};`,
+        `export * from ${JSON.stringify(mod)};`,
+      ].join("\n");
+    }
+  }
+
   if (entry.metadata?.type === "pages-app") {
     return createClientEntrySource({
       cwd,
@@ -1768,6 +1833,15 @@ function getMatchingClientEntrySlots(
   );
 }
 
+function getMatchingServerEntryReplacement(
+  plan: BuildPlan,
+  entry: BuildEntry,
+): ServerEntrySlotPlanItem | undefined {
+  return getSlotItems<ServerEntrySlotPlanItem>(plan, "server.entry").find(
+    (slot) => targetMatchesEntry(slot.target, entry),
+  );
+}
+
 function getSlotItems<T extends FrameworkSlotPlanItem>(
   plan: BuildPlan,
   slot: FrameworkSlotName,
@@ -1952,6 +2026,22 @@ function validateContributionTarget(
     return { ...target };
   }
   throw new Error('[evjs] target.kind must be "application" or "page".');
+}
+
+function validateServerEntryTarget(target: unknown): {
+  kind: "page";
+  pageId: string;
+} {
+  if (!target || typeof target !== "object" || Array.isArray(target)) {
+    throw new Error("[evjs] server.entry target must be a Page target.");
+  }
+  if (Reflect.get(target, "kind") !== "page") {
+    throw new Error('[evjs] server.entry target.kind must be "page".');
+  }
+  return validateContributionTarget(target as ContributionTarget) as {
+    kind: "page";
+    pageId: string;
+  };
 }
 
 function assertGeneratedModuleOrString(

--- a/packages/ev/src/plugin/index.ts
+++ b/packages/ev/src/plugin/index.ts
@@ -606,17 +606,19 @@ export interface FrameworkSlot<K extends FrameworkSlotName> {
 export type FrameworkSlotInput<K extends FrameworkSlotName> =
   K extends "client.entry"
     ? ClientEntryContribution
-    : K extends "page.wrapper"
-      ? PageWrapperContribution
-      : K extends "server.request.middleware"
-        ? ServerRequestMiddlewareContribution
-        : K extends "html.tag"
-          ? HtmlTagContribution
-          : K extends "resolve.alias"
-            ? ResolveAliasContribution
-            : K extends "resolve.external"
-              ? ResolveExternalContribution
-              : never;
+    : K extends "server.entry"
+      ? ServerEntryContribution
+      : K extends "page.wrapper"
+        ? PageWrapperContribution
+        : K extends "server.request.middleware"
+          ? ServerRequestMiddlewareContribution
+          : K extends "html.tag"
+            ? HtmlTagContribution
+            : K extends "resolve.alias"
+              ? ResolveAliasContribution
+              : K extends "resolve.external"
+                ? ResolveExternalContribution
+                : never;
 
 export interface ClientEntryContribution {
   id: string;
@@ -632,6 +634,14 @@ export interface ClientEntryContribution {
    * such as qiankun slave mode that must own the entry exports.
    */
   mode?: "import" | "replace";
+}
+
+/** Replaces one existing framework-owned Page server entry facade. */
+export interface ServerEntryContribution {
+  id: string;
+  module: GeneratedModuleRef | string;
+  target: { kind: "page"; pageId: string };
+  mode: "replace";
 }
 
 /**

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -2804,6 +2804,300 @@ describe("prepareFrameworkBuild", () => {
     await prepared.dispose();
   });
 
+  it("replaces exact Page server entry facades without changing framework entry identity", async () => {
+    const cwd = await createProject();
+    for (const pageId of ["home", "admin", "profile"]) {
+      await writeFile(
+        path.join(cwd, `src/pages/${pageId}/page.tsx`),
+        `export default function ${pageId}Page() { return null; }`,
+        "utf-8",
+      );
+      await writeFile(
+        path.join(cwd, `src/pages/${pageId}/page.config.ts`),
+        'export default { render: "ssr" };',
+        "utf-8",
+      );
+    }
+
+    let compiledPlan: BuildPlan | undefined;
+    let linkedOutput: BuildOutput | undefined;
+    const plugin: Plugin<Record<string, never>> = {
+      id: "server-entry-replacement",
+      setup() {
+        return {
+          afterBuild(result) {
+            linkedOutput = result.output;
+          },
+        };
+      },
+      emitIR(ctx) {
+        for (const pageId of ["home", "admin"] as const) {
+          const entry = ctx.emit.module({
+            id: `${pageId}-server-entry`,
+            scope: { kind: "page", pageId },
+            source: [
+              `export default function ${pageId}ServerPage() { return null; }`,
+              `export const ${pageId}ServerExport = true;`,
+            ].join("\n"),
+          });
+          ctx.slot("server.entry").add({
+            id: `${pageId}-server-entry-slot`,
+            target: { kind: "page", pageId },
+            module: entry,
+            mode: "replace",
+          });
+        }
+      },
+    };
+
+    await build(
+      {
+        output: { client: "dist/client", server: "dist/server" },
+        routing: { mode: "spa" },
+        plugins: [plugin],
+      },
+      {
+        cwd,
+        bundler: createMockBundler([], {
+          onBuildPlan(plan) {
+            compiledPlan = plan;
+          },
+        }),
+      },
+    );
+
+    const manifest = JSON.parse(
+      await fs.promises.readFile(path.join(cwd, ".ev/manifest.json"), "utf-8"),
+    ) as BuildPlan;
+    const homeName = createPageServerBuildEntryName("home");
+    const adminName = createPageServerBuildEntryName("admin");
+    const profileName = createPageServerBuildEntryName("profile");
+    const homeModule = manifest.generated?.modules.find(
+      (module) => module.id === "home-server-entry",
+    );
+    const adminModule = manifest.generated?.modules.find(
+      (module) => module.id === "admin-server-entry",
+    );
+    const homeFacadeFile = `.ev/entries/${homeName}.ts`;
+    const adminFacadeFile = `.ev/entries/${adminName}.ts`;
+    const profileFacadeFile = `.ev/entries/${profileName}.ts`;
+    const homeFacade = await fs.promises.readFile(
+      path.join(cwd, homeFacadeFile),
+      "utf-8",
+    );
+    const adminFacade = await fs.promises.readFile(
+      path.join(cwd, adminFacadeFile),
+      "utf-8",
+    );
+    const profileFacade = await fs.promises.readFile(
+      path.join(cwd, profileFacadeFile),
+      "utf-8",
+    );
+
+    for (const [name, pageId] of [
+      [homeName, "home"],
+      [adminName, "admin"],
+      [profileName, "profile"],
+    ] as const) {
+      expect(
+        compiledPlan?.entries.find((entry) => entry.name === name),
+      ).toMatchObject({
+        name,
+        import: `./.ev/entries/${name}.ts`,
+        environment: "server",
+        kind: "page-server",
+        owner: { pageId },
+        metadata: { type: "react-server-page" },
+      });
+      expect(
+        compiledPlan?.server.renderers?.find(
+          (renderer) => renderer.name === name,
+        ),
+      ).toMatchObject({
+        name,
+        import: `./.ev/entries/${name}.ts`,
+        kind: "page-server",
+        owner: { pageId },
+        metadata: { type: "react-server-page" },
+      });
+      expect(linkedOutput?.server.renderers?.[name]).toMatchObject({
+        kind: "page-server",
+        owner: { pageId },
+        assets: { js: [`${name}.js`], css: [] },
+      });
+    }
+
+    const homeImport = generatedImport(
+      cwd,
+      homeFacadeFile,
+      homeModule?.file ?? "",
+    );
+    const adminImport = generatedImport(
+      cwd,
+      adminFacadeFile,
+      adminModule?.file ?? "",
+    );
+    expect(homeFacade).toContain(`export { default } from "${homeImport}";`);
+    expect(homeFacade).toContain(`export * from "${homeImport}";`);
+    expect(adminFacade).toContain(`export { default } from "${adminImport}";`);
+    expect(adminFacade).toContain(`export * from "${adminImport}";`);
+    expect(homeFacade).not.toContain("src/pages/home/page");
+    expect(adminFacade).not.toContain("src/pages/admin/page");
+    expect(profileFacade).toContain(
+      'import * as pageModule from "../../src/pages/profile/page";',
+    );
+    expect(profileFacade).toContain(
+      'export { PageProvider } from "@evjs/ev/_internal/client/page-context";',
+    );
+    expect(manifest.generated?.slots).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          slot: "server.entry",
+          id: "home-server-entry-slot",
+          target: { kind: "page", pageId: "home" },
+          module: homeModule?.file,
+          mode: "replace",
+        }),
+        expect.objectContaining({
+          slot: "server.entry",
+          id: "admin-server-entry-slot",
+          target: { kind: "page", pageId: "admin" },
+          module: adminModule?.file,
+          mode: "replace",
+        }),
+      ]),
+    );
+    expect(manifest.generated?.importEdges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: "server-entry-replacement:home-server-entry-slot",
+          to: "server-entry-replacement:home-server-entry",
+          kind: "slot-module",
+          specifier: homeModule?.file,
+        }),
+        expect.objectContaining({
+          from: "server-entry-replacement:admin-server-entry-slot",
+          to: "server-entry-replacement:admin-server-entry",
+          kind: "slot-module",
+          specifier: adminModule?.file,
+        }),
+      ]),
+    );
+  });
+
+  it("rejects multiple replacements for one concrete Page server entry", async () => {
+    const cwd = await createProject();
+    await writeFile(
+      path.join(cwd, "src/pages/home/page.tsx"),
+      "export default function Home() { return null; }",
+      "utf-8",
+    );
+    await writeFile(
+      path.join(cwd, "src/pages/home/page.config.ts"),
+      'export default { render: "ssr" };',
+      "utf-8",
+    );
+    const plugin: Plugin<Record<string, never>> = {
+      id: "duplicate-server-entry",
+      emitIR(ctx) {
+        for (const id of ["first", "second"] as const) {
+          const entry = ctx.emit.module({
+            id: `${id}-entry`,
+            scope: { kind: "page", pageId: "home" },
+            source: "export default function Home() { return null; }",
+          });
+          ctx.slot("server.entry").add({
+            id: `${id}-slot`,
+            target: { kind: "page", pageId: "home" },
+            module: entry,
+            mode: "replace",
+          });
+        }
+      },
+    };
+
+    await expect(
+      prepareFrameworkBuild(
+        { routing: { mode: "spa" }, plugins: [plugin] },
+        { cwd },
+      ),
+    ).rejects.toThrow(
+      `Server page entry "${createPageServerBuildEntryName("home")}" has multiple replacement server.entry contributions: duplicate-server-entry:first-slot, duplicate-server-entry:second-slot.`,
+    );
+  });
+
+  it("rejects unknown Pages and Pages without a server entry", async () => {
+    const createPlugin = (pageId: string): Plugin<Record<string, never>> => ({
+      id: `server-entry-${pageId}`,
+      emitIR(ctx) {
+        const entry = ctx.emit.module({
+          id: "entry",
+          scope: { kind: "application" },
+          source: "export default function Page() { return null; }",
+        });
+        ctx.slot("server.entry").add({
+          id: "entry-slot",
+          target: { kind: "page", pageId },
+          module: entry,
+          mode: "replace",
+        });
+      },
+    });
+
+    const unknownCwd = await createSpaProject();
+    await expect(
+      prepareFrameworkBuild(
+        {
+          routing: { mode: "spa" },
+          plugins: [createPlugin("missing")],
+        },
+        { cwd: unknownCwd },
+      ),
+    ).rejects.toThrow(
+      'server.entry contribution "entry-slot" targets unknown page "missing".',
+    );
+
+    const csrCwd = await createSpaProject();
+    await expect(
+      prepareFrameworkBuild(
+        {
+          routing: { mode: "spa" },
+          plugins: [createPlugin("index")],
+        },
+        { cwd: csrCwd },
+      ),
+    ).rejects.toThrow(
+      'server.entry contribution "entry-slot" targets page "index", but no server page entry matches that target.',
+    );
+  });
+
+  it("rejects non-Page server entry targets", async () => {
+    const cwd = await createSpaProject();
+    const plugin: Plugin<Record<string, never>> = {
+      id: "invalid-server-entry-target",
+      emitIR(ctx) {
+        const entry = ctx.emit.module({
+          id: "entry",
+          scope: { kind: "application" },
+          source: "export default function Page() { return null; }",
+        });
+        ctx.slot("server.entry").add({
+          id: "entry-slot",
+          target: { kind: "application" } as never,
+          module: entry,
+          mode: "replace",
+        });
+      },
+    };
+
+    await expect(
+      prepareFrameworkBuild(
+        { routing: { mode: "spa" }, plugins: [plugin] },
+        { cwd },
+      ),
+    ).rejects.toThrow('server.entry target.kind must be "page".');
+  });
+
   it("adds server.request.middleware contributions to the generated server entry", async () => {
     const cwd = await createProject();
     await writeFile(

--- a/packages/shared/src/manifest/index.ts
+++ b/packages/shared/src/manifest/index.ts
@@ -733,6 +733,7 @@ export type GeneratedScope =
 
 export type FrameworkSlotName =
   | "client.entry"
+  | "server.entry"
   | "page.wrapper"
   | "server.request.middleware"
   | "html.tag"
@@ -806,6 +807,7 @@ export interface GeneratedImportEdgePlan {
 
 export type FrameworkSlotPlanItem =
   | ClientEntrySlotPlanItem
+  | ServerEntrySlotPlanItem
   | PageWrapperSlotPlanItem
   | ServerRequestMiddlewareSlotPlanItem
   | HtmlTagSlotPlanItem
@@ -825,6 +827,13 @@ export interface ClientEntrySlotPlanItem extends FrameworkSlotPlanItemBase {
   runtime: ClientContributionRuntime;
   mode: "import" | "replace";
   target?: ContributionTarget;
+}
+
+export interface ServerEntrySlotPlanItem extends FrameworkSlotPlanItemBase {
+  slot: "server.entry";
+  module: string;
+  mode: "replace";
+  target: { kind: "page"; pageId: string };
 }
 
 export interface PageWrapperSlotPlanItem extends FrameworkSlotPlanItemBase {


### PR DESCRIPTION
## Summary

- add a replacement-only `server.entry` generated contribution slot for exact Page-owned `page-server` entries
- preserve framework entry and renderer identity while forwarding default and named exports from the replacement module
- validate unknown or non-server Page targets and duplicate replacements, with generated manifest/import-edge coverage
- document the API in English and Chinese

## Validation

- `npx turbo run build --filter=@evjs/ev`
- `npx turbo run test --filter=@evjs/ev` (799 tests)
- `npm --workspace @evjs/shared run check-types`
- `npm --workspace @evjs/ev run check-types`
- `npm run lint`
- `npm --workspace evjs-docs run build`
- `git diff --check`

## Known repository gate issue

Root `npm run check-types` and `npm test` are currently blocked in the unchanged `packages/bundler-utoopack/src/adapter/create-config.ts:267` by a `ServerEntry | undefined` versus `string | undefined` type mismatch. The affected package is outside this PR; the focused EVJS build, type checks, and full EVJS test suite pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for replacing existing Page server entry modules through the `server.entry` contribution slot.
  - Replacement contributions target a specific Page and preserve framework metadata, asset bindings, imports, and related entry information.
  - Invalid configurations—such as unknown Pages, missing server entries, duplicate replacements, or non-Page targets—are rejected.

- **Documentation**
  - Added English and Simplified Chinese documentation covering configuration, constraints, examples, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->