### PR TITLE
docs(changelog): prepare v0.3.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ---
 
+## [0.3.5] — 2026-08-06
+
+### ✨ Features
+
+- **Page server entry replacement** — Plugins can replace an exact Page-owned
+  `page-server` entry through the replacement-only `server.entry` contribution
+  slot while preserving framework entry, renderer, manifest, and import-edge
+  identity. Invalid Page targets and duplicate replacements are rejected.
+
+### 🐛 Bug Fixes
+
+- **Stable Utoopack HMR transitions** — Utoopack now watches generated `.ev`
+  inputs independently while EVJS relinks topology-preserving updates from the
+  last published build facts, removing timestamp invalidation and the
+  `stats.json` transition barrier that made HMR unreliable.
+- **Resilient development watching** — EVJS canonicalizes dependency ordering,
+  recovers from atomic symlink replacement races, and falls back to polling
+  with per-target backoff when native watchers exhaust resources or close.
+
+---
+
 ## [0.3.4] — 2026-08-04
 
 ### ✨ Improvements


### PR DESCRIPTION
## Summary
- Prepare the EVJS v0.3.5 stable release notes from the current `main` branch.
- Include the Page server-entry replacement capability and the merged Utoopack HMR/dev-watcher stabilization.

## Changes
- Move the two changes shipped after v0.3.4 into a dated v0.3.5 changelog section.
- Document that Utoopack owns generated `.ev` watching and that `stats.json` is no longer an EVJS transition barrier.
- Document native-watcher recovery and polling fallback behavior.

## Validation
- `npm run lint`
- `npm --workspace evjs-docs run build`
- `git diff --check`
- `main` Build & Test for `701f3521` passed

## Risk / rollout
- Documentation-only change; package versions and internal workspace ranges remain release-workflow managed.
- Publishing GitHub Release `v0.3.5` after merge triggers the npm release workflow with the `latest` dist-tag.
- `v0.3.5-alpha.0` was published from the separate, unmerged multi-server experiment. This stable release follows `main` and does not promote that experimental multi-server implementation.

## Reviewer notes
- Verify that the notes describe only commits in `v0.3.4..main`.