### PR TITLE
refactor(spa): decouple router runtime from TanStack internals

### DIFF
--- a/docs/docs/qiankun.md
+++ b/docs/docs/qiankun.md
@@ -192,9 +192,18 @@ local `/details` is rendered at `/catalog/details`.
 
 The slave lifecycle loads the original generated entry, projects the received
 `base` and `history` through `pagesApp.updateRuntime()`, and only then calls the
-entry's first `start()`. The router therefore observes the mounted base and
-history before the first application render. When run outside qiankun, the same
-Pages remain available under their standalone base.
+entry's first `start()`. The generated Pages app defers router construction
+until that runtime projection is available, so the first router is created
+with the mounted base and history instead of being patched after creation.
+When run outside qiankun, the same Pages remain available under their
+standalone base.
+
+If a mounted slave later receives a different base, history, or runtime route
+overlay, the Pages app creates and loads a candidate router with the existing
+Query client. It switches the rendered provider only after that candidate is
+ready; a failed candidate leaves the active router in place. This replacement
+boundary uses TanStack Router's public construction and loading APIs rather
+than depending on its internal match stores.
 
 While mounted with browser or hash history, the slave uses a scoped history
 adapter. Slave `Link` and `useNavigate()` calls still update the shared browser

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/qiankun.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/qiankun.md
@@ -181,9 +181,15 @@ src/
 `/` 会渲染在 `/catalog`，本地 `/details` 会渲染在 `/catalog/details`。
 
 Slave lifecycle 会加载原始生成 entry，通过 `pagesApp.updateRuntime()` 投影收到的
-`base` 与 `history`，然后才调用 entry 的首次 `start()`。因此 router 在 Application
-首次渲染前就能观察到挂载后的 base 与 history。在 qiankun 外独立运行时，同一组 Page
-仍然使用 standalone base。
+`base` 与 `history`，然后才调用 entry 的首次 `start()`。生成的 Pages app 会把 router
+创建延迟到 runtime 投影就绪之后，因此首个 router 会直接使用挂载后的 base 与
+history，而不是创建后再修改。在 qiankun 外独立运行时，同一组 Page 仍然使用
+standalone base。
+
+已挂载的 slave 后续收到不同的 base、history 或 runtime route overlay 时，Pages app
+会复用现有 Query client 创建并加载候选 router。只有候选 router 就绪后才切换已渲染的
+provider；候选加载失败时，当前 router 会继续生效。这个替换边界只使用 TanStack
+Router 的公开创建与加载 API，不依赖其内部 match store。
 
 使用 browser 或 hash history 挂载时，slave 会使用作用域隔离的 history 适配器。
 Slave 内的 `Link` 与 `useNavigate()` 仍会更新共享的浏览器 URL，浏览器原生前进/回退

--- a/packages/client/src/framework/page/page-route.ts
+++ b/packages/client/src/framework/page/page-route.ts
@@ -11,7 +11,7 @@ import {
   clonePageMetadata,
   type PageMetadata,
 } from "@evjs/shared/manifest";
-import type { QueryClient } from "@tanstack/react-query";
+import { QueryClient } from "@tanstack/react-query";
 import type {
   AnyRoute,
   AnyRouter,
@@ -147,26 +147,64 @@ export function createPagesApp(options: CreatePagesAppOptions): PagesApp {
   assertCreatePagesAppOptions(options);
   const canonicalRoutes = clonePageDefinitions(options.routes);
   const rootModule = options.rootModule;
-  const initialHistory =
-    options.history === undefined
-      ? undefined
-      : resolvePagesAppHistory(options.history);
-  const routeTree = createGeneratedRouteTree({
-    routes: canonicalRoutes,
-    ...(rootModule ? { rootModule } : {}),
-  });
-  const app = createApp({
-    routeTree,
+  const queryClient = new QueryClient();
+  let runtimeState: PagesAppRuntimeState = {
+    routes: [],
     ...(options.basepath !== undefined ? { basepath: options.basepath } : {}),
-    ...(initialHistory ? { history: initialHistory.history } : {}),
-  });
-  let runtimeRoutes: PageDefinition[] = [];
-  let currentBasepath = options.basepath;
-  let currentHistory = captureInitialPagesAppHistory(
-    app.router,
-    initialHistory,
-  );
+    ...(options.history !== undefined
+      ? { history: clonePagesAppHistoryInput(options.history) }
+      : {}),
+  };
+  let activeRuntime: ActivePagesAppRuntime | undefined;
+  let mountedApp: MountedPagesApp | undefined;
   let runtimeUpdateQueue = Promise.resolve();
+
+  const app: App<AnyRouter> = {
+    get router() {
+      return getActiveRuntime().app.router;
+    },
+    queryClient,
+    render(container, renderOptions = {}) {
+      const runtime = getActiveRuntime();
+      mountedApp = {
+        container,
+      };
+      return runtime.app.render(container, renderOptions);
+    },
+    unmount() {
+      mountedApp = undefined;
+      activeRuntime?.app.unmount();
+    },
+  };
+
+  function getActiveRuntime(): ActivePagesAppRuntime {
+    activeRuntime ??= createPagesAppRuntime(runtimeState);
+    return activeRuntime;
+  }
+
+  function createPagesAppRuntime(
+    state: PagesAppRuntimeState,
+    retainedHistory?: ManagedPagesAppHistory,
+  ): ActivePagesAppRuntime {
+    let history = retainedHistory;
+    if (!history && state.history !== undefined) {
+      history = resolvePagesAppHistory(state.history);
+    }
+    const routeTree = createGeneratedRouteTree({
+      routes: composePageDefinitions(canonicalRoutes, state.routes),
+      ...(rootModule ? { rootModule } : {}),
+    });
+    const runtimeApp = createApp({
+      routeTree,
+      queryClient,
+      ...(state.basepath !== undefined ? { basepath: state.basepath } : {}),
+      ...(history ? { history: history.history } : {}),
+    });
+    return {
+      app: runtimeApp,
+      history: captureInitialPagesAppHistory(runtimeApp.router, history),
+    };
+  }
 
   function updateRuntime(
     runtimeOptions: PagesAppRuntimeOptions,
@@ -183,91 +221,114 @@ export function createPagesApp(options: CreatePagesAppOptions): PagesApp {
   ): Promise<void> {
     assertPagesAppRuntimeOptions(runtimeOptions);
     const hasRouteUpdate = runtimeOptions.routes !== undefined;
-    const runtimeRouteOverlay = runtimeOptions.routes ?? [];
     const nextRuntimeRoutes = hasRouteUpdate
-      ? clonePageDefinitions(runtimeRouteOverlay)
-      : runtimeRoutes;
-    const nextRoutes = hasRouteUpdate
-      ? composePageDefinitions(canonicalRoutes, nextRuntimeRoutes)
-      : undefined;
-    if (nextRoutes) {
+      ? clonePageDefinitions(runtimeOptions.routes ?? [])
+      : runtimeState.routes;
+    if (hasRouteUpdate) {
       assertCreatePagesAppOptions({
-        routes: nextRoutes,
+        routes: composePageDefinitions(canonicalRoutes, nextRuntimeRoutes),
         ...(rootModule ? { rootModule } : {}),
       });
     }
-    const nextBasepath = runtimeOptions.basepath ?? currentBasepath;
-    const nextRouteTree = hasRouteUpdate
-      ? createGeneratedRouteTree({
-          routes: nextRoutes ?? canonicalRoutes,
-          ...(rootModule ? { rootModule } : {}),
-        })
-      : app.router.routeTree;
-    const previousRouterOptions = app.router.options;
-    const previousRouteTree = app.router.routeTree;
-    const previousBasepath = app.router.basepath;
-    const previousHistory = app.router.history;
-    const previousMatches = snapshotRouterMatches(app.router);
+    const nextBasepath = runtimeOptions.basepath ?? runtimeState.basepath;
     const historyChanged =
       runtimeOptions.history !== undefined &&
       !pagesAppHistoryInputMatchesCurrent(
         runtimeOptions.history,
-        currentHistory,
+        activeRuntime?.history,
+        runtimeState.history,
       );
-    let nextHistory = currentHistory;
-    let destroyedCurrentHistoryBeforeReplace = false;
+    const nextHistory =
+      runtimeOptions.history !== undefined
+        ? clonePagesAppHistoryInput(runtimeOptions.history)
+        : runtimeState.history;
+    const nextState: PagesAppRuntimeState = {
+      routes: nextRuntimeRoutes,
+      ...(nextBasepath !== undefined ? { basepath: nextBasepath } : {}),
+      ...(nextHistory !== undefined ? { history: nextHistory } : {}),
+    };
+
+    // Generated qiankun entries project base/history before their first render.
+    // Commit that descriptor without constructing a throwaway Router.
+    if (!activeRuntime) {
+      runtimeState = nextState;
+      return;
+    }
+
+    if (
+      !hasRouteUpdate &&
+      runtimeOptions.basepath === undefined &&
+      !historyChanged
+    ) {
+      return;
+    }
+
+    const previousRuntime = activeRuntime;
+    const previousState = runtimeState;
+    const previousMount = mountedApp;
+    const retainedHistory = historyChanged
+      ? undefined
+      : previousRuntime.history;
+    const releaseBeforeCandidate =
+      historyChanged &&
+      shouldReleaseHistoryBeforeReplacement(
+        previousRuntime.history,
+        nextState.history,
+      );
+    let previousReleased = false;
+    let previousUnmounted = false;
+    let candidate: ActivePagesAppRuntime | undefined;
 
     try {
-      if (historyChanged && runtimeOptions.history !== undefined) {
-        if (
-          !isRouterHistory(runtimeOptions.history) &&
-          currentHistory?.owned &&
-          currentHistory.descriptor &&
-          currentHistory.descriptor.type !== "memory"
-        ) {
-          // TanStack patches browser/hash globals, so release the current
-          // framework-owned instance before constructing its replacement.
-          currentHistory.history.destroy();
-          destroyedCurrentHistoryBeforeReplace = true;
-        }
-        nextHistory = resolvePagesAppHistory(runtimeOptions.history);
+      if (releaseBeforeCandidate) {
+        previousRuntime.app.unmount();
+        previousUnmounted = true;
+        previousReleased = true;
+        previousRuntime.history?.history.destroy();
       }
-      app.router.update({
-        ...app.router.options,
-        routeTree: nextRouteTree,
-        ...(nextBasepath !== undefined ? { basepath: nextBasepath } : {}),
-        ...(nextHistory ? { history: nextHistory.history } : {}),
-      });
-      if (hasRouteUpdate) pruneRouterMatches(app.router);
-      await loadUpdatedRouter(app.router);
+      candidate = createPagesAppRuntime(nextState, retainedHistory);
+      await candidate.app.router.load();
+      if (!previousUnmounted) {
+        previousRuntime.app.unmount();
+        previousUnmounted = true;
+      }
+      activeRuntime = candidate;
+      runtimeState = nextState;
+      if (previousMount) {
+        await candidate.app.render(previousMount.container, { hydrate: false });
+      }
+      if (
+        historyChanged &&
+        !previousReleased &&
+        previousRuntime.history?.owned &&
+        previousRuntime.history.history !== candidate.history?.history
+      ) {
+        previousReleased = true;
+        previousRuntime.history.history.destroy();
+      }
     } catch (error) {
       let rollbackError: unknown;
       try {
+        candidate?.app.unmount();
         if (
-          nextHistory?.owned &&
-          nextHistory !== currentHistory &&
-          nextHistory.history !== previousHistory
+          candidate?.history?.owned &&
+          candidate.history.history !== previousRuntime.history?.history
         ) {
-          nextHistory.history.destroy();
+          candidate.history.history.destroy();
         }
-        let rollbackHistory = previousHistory;
-        if (
-          destroyedCurrentHistoryBeforeReplace &&
-          currentHistory?.descriptor
-        ) {
-          const restoredHistory = resolvePagesAppHistory(
-            currentHistory.descriptor,
-          );
-          currentHistory = restoredHistory;
-          rollbackHistory = restoredHistory.history;
+        if (previousReleased) {
+          const restoredRuntime = createPagesAppRuntime(previousState);
+          await restoredRuntime.app.router.load();
+          activeRuntime = restoredRuntime;
+        } else {
+          activeRuntime = previousRuntime;
         }
-        app.router.update({
-          ...previousRouterOptions,
-          routeTree: previousRouteTree,
-          basepath: previousBasepath,
-          ...(rollbackHistory ? { history: rollbackHistory } : {}),
-        });
-        restoreRouterMatches(app.router, previousMatches);
+        runtimeState = previousState;
+        if (previousMount && previousUnmounted) {
+          await activeRuntime.app.render(previousMount.container, {
+            hydrate: false,
+          });
+        }
       } catch (caught) {
         rollbackError = caught;
       }
@@ -279,85 +340,30 @@ export function createPagesApp(options: CreatePagesAppOptions): PagesApp {
       }
       throw error;
     }
-
-    runtimeRoutes = nextRuntimeRoutes;
-    currentBasepath = nextBasepath;
-    if (
-      historyChanged &&
-      !destroyedCurrentHistoryBeforeReplace &&
-      currentHistory?.owned &&
-      nextHistory !== currentHistory
-    ) {
-      // Retain the previous instance until the update commits so rollback can
-      // continue using it. Browser/hash replacements created from descriptors
-      // are the exception above because TanStack patches their shared globals.
-      currentHistory.history.destroy();
-    }
-    currentHistory = nextHistory;
   }
 
   return { app, updateRuntime };
+}
+
+interface PagesAppRuntimeState {
+  routes: PageDefinition[];
+  basepath?: string;
+  history?: PagesAppHistoryInput;
+}
+
+interface ActivePagesAppRuntime {
+  app: App<AnyRouter>;
+  history?: ManagedPagesAppHistory;
+}
+
+interface MountedPagesApp {
+  container: string | HTMLElement;
 }
 
 interface ManagedPagesAppHistory {
   history: RouterHistory;
   owned: boolean;
   descriptor?: PagesAppHistoryDescriptor;
-}
-
-type PagesRouterMatches = ReturnType<AnyRouter["stores"]["matches"]["get"]>;
-
-interface PagesRouterMatchSnapshot {
-  matches: PagesRouterMatches;
-  pending: PagesRouterMatches;
-  cached: PagesRouterMatches;
-}
-
-async function loadUpdatedRouter(router: AnyRouter): Promise<void> {
-  if (!router.history || !router.stores) return;
-  await router.load();
-}
-
-function snapshotRouterMatches(
-  router: AnyRouter,
-): PagesRouterMatchSnapshot | undefined {
-  if (!router.stores) return undefined;
-  return {
-    matches: [...router.stores.matches.get()],
-    pending: [...router.stores.pendingMatches.get()],
-    cached: [...router.stores.cachedMatches.get()],
-  };
-}
-
-function pruneRouterMatches(router: AnyRouter): void {
-  if (!router.stores) return;
-  // TanStack Router caches exiting matches during load. Remove matches for
-  // deleted overlay Routes first so cache cleanup never resolves a stale ID.
-  const keepKnownRoute = (match: PagesRouterMatches[number]) =>
-    Object.hasOwn(router.routesById, match.routeId);
-  router.batch(() => {
-    router.stores.setMatches(
-      router.stores.matches.get().filter(keepKnownRoute),
-    );
-    router.stores.setPending(
-      router.stores.pendingMatches.get().filter(keepKnownRoute),
-    );
-    router.stores.setCached(
-      router.stores.cachedMatches.get().filter(keepKnownRoute),
-    );
-  });
-}
-
-function restoreRouterMatches(
-  router: AnyRouter,
-  snapshot: PagesRouterMatchSnapshot | undefined,
-): void {
-  if (!router.stores || !snapshot) return;
-  router.batch(() => {
-    router.stores.setMatches(snapshot.matches);
-    router.stores.setPending(snapshot.pending);
-    router.stores.setCached(snapshot.cached);
-  });
 }
 
 function captureInitialPagesAppHistory(
@@ -405,12 +411,39 @@ function resolvePagesAppHistory(
 function pagesAppHistoryInputMatchesCurrent(
   input: PagesAppHistoryInput,
   current: ManagedPagesAppHistory | undefined,
+  configured: PagesAppHistoryInput | undefined,
 ): boolean {
-  if (!current) return false;
+  if (!current) {
+    if (configured === undefined) return false;
+    if (isRouterHistory(input) || isRouterHistory(configured)) {
+      return input === configured;
+    }
+    return equalPagesAppHistoryDescriptors(configured, input);
+  }
   if (isRouterHistory(input)) return current.history === input;
   return (
     current.descriptor !== undefined &&
     equalPagesAppHistoryDescriptors(current.descriptor, input)
+  );
+}
+
+function clonePagesAppHistoryInput(
+  input: PagesAppHistoryInput,
+): PagesAppHistoryInput {
+  return isRouterHistory(input) ? input : clonePagesAppHistoryDescriptor(input);
+}
+
+function shouldReleaseHistoryBeforeReplacement(
+  current: ManagedPagesAppHistory | undefined,
+  next: PagesAppHistoryInput | undefined,
+): boolean {
+  return (
+    current?.owned === true &&
+    current.descriptor !== undefined &&
+    current.descriptor.type !== "memory" &&
+    next !== undefined &&
+    !isRouterHistory(next) &&
+    next.type !== "memory"
   );
 }
 

--- a/packages/client/tests/page-bootstrap.test.ts
+++ b/packages/client/tests/page-bootstrap.test.ts
@@ -64,6 +64,29 @@ describe("SPA page bootstrap", () => {
     expect(reactRootCalls).toEqual([]);
   });
 
+  it("remounts a loaded replacement Router after runtime configuration changes", async () => {
+    function Home() {
+      return null;
+    }
+    const pagesApp = createPagesApp({
+      routes: [{ path: "/", module: { default: Home } }],
+      history: { type: "memory", initialEntries: ["/catalog"] },
+    });
+    const firstRouter = pagesApp.app.router;
+
+    pagesApp.app.render({} as HTMLElement);
+    await pagesApp.updateRuntime({ basepath: "/catalog" });
+
+    expect(pagesApp.app.router).not.toBe(firstRouter);
+    expect(reactRootCalls).toEqual([
+      "createRoot",
+      "render",
+      "unmount",
+      "createRoot",
+      "render",
+    ]);
+  });
+
   it("validates render options before mounting", () => {
     const { app } = createTestPagesApp();
     const mount = {} as HTMLElement;

--- a/packages/client/tests/page-route.test.ts
+++ b/packages/client/tests/page-route.test.ts
@@ -123,19 +123,30 @@ describe("createPagesApp", () => {
     await pagesApp.updateRuntime({
       routes: [{ id: "micro-catalog", path: "/catalog", kind: "group" }],
     });
-    expect(generatedRoutePaths(router.routeTree)).toEqual(
+    const catalogRouter = pagesApp.app.router as {
+      routeTree: InspectableGeneratedRoute;
+    };
+    expect(catalogRouter).not.toBe(router);
+    expect(generatedRoutePaths(catalogRouter.routeTree)).toEqual(
       expect.arrayContaining(["/", "/catalog"]),
     );
 
     await pagesApp.updateRuntime({
       routes: [{ id: "micro-orders", path: "/orders", kind: "group" }],
     });
-    const replacedPaths = generatedRoutePaths(router.routeTree);
+    const ordersRouter = pagesApp.app.router as {
+      routeTree: InspectableGeneratedRoute;
+    };
+    expect(ordersRouter).not.toBe(catalogRouter);
+    const replacedPaths = generatedRoutePaths(ordersRouter.routeTree);
     expect(replacedPaths).toEqual(expect.arrayContaining(["/", "/orders"]));
     expect(replacedPaths).not.toContain("/catalog");
 
     await pagesApp.updateRuntime({ routes: [] });
-    const clearedPaths = generatedRoutePaths(router.routeTree);
+    const clearedPaths = generatedRoutePaths(
+      (pagesApp.app.router as { routeTree: InspectableGeneratedRoute })
+        .routeTree,
+    );
     expect(clearedPaths).toContain("/");
     expect(clearedPaths).not.toContain("/orders");
   });
@@ -152,10 +163,6 @@ describe("createPagesApp", () => {
       ],
       history: { type: "memory", initialEntries: ["/catalog"] },
     });
-    const router = pagesApp.app.router as {
-      routeTree: InspectableGeneratedRoute;
-    };
-
     await pagesApp.updateRuntime({
       routes: [
         {
@@ -167,6 +174,9 @@ describe("createPagesApp", () => {
       ],
     });
 
+    const router = pagesApp.app.router as {
+      routeTree: InspectableGeneratedRoute;
+    };
     const runtimeRoot = flattenGeneratedRoutes(router.routeTree).find(
       (route) => route.options.beforeLoad,
     );
@@ -195,10 +205,6 @@ describe("createPagesApp", () => {
       ],
       history: { type: "memory", initialEntries: ["/catalog"] },
     });
-    const router = pagesApp.app.router as {
-      routeTree: InspectableGeneratedRoute;
-    };
-
     await pagesApp.updateRuntime({
       routes: [
         {
@@ -209,26 +215,30 @@ describe("createPagesApp", () => {
       ],
     });
 
-    expect(generatedRoutePaths(router.routeTree)).toEqual([
-      "/",
-      "/",
-      "/about",
-      "/catalog/$",
-    ]);
+    expect(
+      generatedRoutePaths(
+        (pagesApp.app.router as { routeTree: InspectableGeneratedRoute })
+          .routeTree,
+      ),
+    ).toEqual(["/", "/", "/about", "/catalog/$"]);
 
     await pagesApp.updateRuntime({
       routes: [{ id: "runtime-root", path: "/$", kind: "group" }],
     });
-    expect(generatedRoutePaths(router.routeTree)).toEqual(["/", "/$"]);
+    expect(
+      generatedRoutePaths(
+        (pagesApp.app.router as { routeTree: InspectableGeneratedRoute })
+          .routeTree,
+      ),
+    ).toEqual(["/", "/$"]);
 
     await pagesApp.updateRuntime({ routes: [] });
-    expect(generatedRoutePaths(router.routeTree)).toEqual([
-      "/",
-      "/",
-      "/catalog",
-      "/catalog/orders",
-      "/about",
-    ]);
+    expect(
+      generatedRoutePaths(
+        (pagesApp.app.router as { routeTree: InspectableGeneratedRoute })
+          .routeTree,
+      ),
+    ).toEqual(["/", "/", "/catalog", "/catalog/orders", "/about"]);
   });
 
   it("updates basepath and serializable history before the first render", async () => {
@@ -243,14 +253,13 @@ describe("createPagesApp", () => {
         initialEntries: ["/catalog"],
       },
     });
+    await pagesApp.updateRuntime({ basepath: "/catalog" });
+
     const router = pagesApp.app.router as {
       history: { location: { href: string } };
       latestLocation: { pathname: string };
       matchRoutes(pathname: string): unknown[];
     };
-
-    await pagesApp.updateRuntime({ basepath: "/catalog" });
-
     expect(router.history.location.href).toBe("/catalog");
     expect(router.latestLocation.pathname).toBe("/");
     expect(router.matchRoutes("/").length).toBeGreaterThan(1);
@@ -290,7 +299,7 @@ describe("createPagesApp", () => {
     expect(router.history).toBe(initialHistory);
   });
 
-  it("releases owned browser history only after an external history update commits", async () => {
+  it("releases owned browser history after a replacement Router commits", async () => {
     const nativePushState = vi.fn();
     const nativeReplaceState = vi.fn();
     const browserHistory = {
@@ -322,31 +331,22 @@ describe("createPagesApp", () => {
     });
     const router = pagesApp.app.router as {
       history: ReturnType<typeof client.createMemoryHistory>;
-      update(options: unknown): void;
     };
     const ownedHistory = router.history;
     const destroy = vi.spyOn(ownedHistory, "destroy");
     const externalHistory = client.createMemoryHistory();
-    const originalUpdate = router.update.bind(router);
-    vi.spyOn(router, "update").mockImplementationOnce((options) => {
-      originalUpdate(options);
-      throw new Error("mock external history update failure");
-    });
-
-    await expect(
-      pagesApp.updateRuntime({ history: externalHistory }),
-    ).rejects.toThrow("mock external history update failure");
-    expect(destroy).not.toHaveBeenCalled();
-    expect(router.history).toBe(ownedHistory);
 
     await pagesApp.updateRuntime({ history: externalHistory });
     expect(destroy).toHaveBeenCalledTimes(1);
-    expect(router.history).toBe(externalHistory);
+    expect(pagesApp.app.router).not.toBe(router);
+    expect((pagesApp.app.router as { history: unknown }).history).toBe(
+      externalHistory,
+    );
     expect(browserHistory.pushState).toBe(nativePushState);
     expect(browserHistory.replaceState).toBe(nativeReplaceState);
   });
 
-  it("atomically restores the previous Route overlay when router update fails", async () => {
+  it("replaces the Router without mutating the previous Route state", async () => {
     function Home() {
       return null;
     }
@@ -367,19 +367,12 @@ describe("createPagesApp", () => {
     const previousRouteTree = router.routeTree;
     const previousHistory = router.history;
     const previousBasepath = router.basepath;
-    const originalUpdate = router.update.bind(router);
-    vi.spyOn(router, "update").mockImplementationOnce((options) => {
-      originalUpdate(options);
-      throw new Error("mock router update failure");
+    const queryClient = pagesApp.app.queryClient;
+    await pagesApp.updateRuntime({
+      routes: [{ id: "micro-orders", path: "/orders", kind: "group" }],
+      basepath: "/workspace",
+      history: { type: "memory", initialEntries: ["/workspace/orders"] },
     });
-
-    await expect(
-      pagesApp.updateRuntime({
-        routes: [{ id: "micro-orders", path: "/orders", kind: "group" }],
-        basepath: "/workspace",
-        history: { type: "memory", initialEntries: ["/workspace/orders"] },
-      }),
-    ).rejects.toThrow("mock router update failure");
 
     expect(router.routeTree).toBe(previousRouteTree);
     expect(router.history).toBe(previousHistory);
@@ -388,6 +381,16 @@ describe("createPagesApp", () => {
       expect.arrayContaining(["/", "/catalog"]),
     );
     expect(generatedRoutePaths(router.routeTree)).not.toContain("/orders");
+    const replacement = pagesApp.app.router as {
+      basepath: string;
+      routeTree: InspectableGeneratedRoute;
+    };
+    expect(replacement).not.toBe(router);
+    expect(replacement.basepath).toBe("/workspace");
+    expect(generatedRoutePaths(replacement.routeTree)).toEqual(
+      expect.arrayContaining(["/", "/orders"]),
+    );
+    expect(pagesApp.app.queryClient).toBe(queryClient);
   });
 
   it("rejects invalid runtime inputs before changing the active Route tree", async () => {

--- a/packages/plugin-qiankun/src/runtime.ts
+++ b/packages/plugin-qiankun/src/runtime.ts
@@ -369,7 +369,7 @@ export function createQiankunSlaveLifecycles(options: {
     let projectionUpdate:
       | ((update: GeneratedPagesAppRuntimeUpdate) => MaybePromise<void>)
       | undefined;
-    let projectionAttempted = false;
+    let projectionApplied = false;
     let runtimeHookAttempted = false;
     let entryMountAttempted = false;
     let nextScopedHistory: RouterHistory | undefined;
@@ -395,8 +395,8 @@ export function createQiankunSlaveLifecycles(options: {
       );
       if (projectionOptions) {
         projectionUpdate = resolveRequiredSlavePagesAppUpdate(entryModule);
-        projectionAttempted = true;
         await projectionUpdate(projectionOptions);
+        projectionApplied = true;
       }
       const start = entryInitialized
         ? undefined
@@ -426,7 +426,7 @@ export function createQiankunSlaveLifecycles(options: {
           unmountLoadedEntry(entryModule),
         );
       }
-      if (projectionAttempted && projectionUpdate) {
+      if (projectionApplied && projectionUpdate) {
         rollbackScopedHistory = useStandaloneDefaults
           ? undefined
           : createScopedSlaveHistory(previousProjection.history.type);
@@ -456,7 +456,7 @@ export function createQiankunSlaveLifecycles(options: {
       await collectQiankunCleanupError(rollbackErrors, () =>
         nextScopedHistory?.destroy(),
       );
-      if (projectionAttempted) {
+      if (projectionApplied) {
         if (rollbackScopedHistory !== scopedHistory) {
           scopedHistory?.destroy();
         }

--- a/packages/plugin-qiankun/tests/runtime.test.ts
+++ b/packages/plugin-qiankun/tests/runtime.test.ts
@@ -849,6 +849,35 @@ describe("@evjs/plugin-qiankun runtime", () => {
     });
   });
 
+  it("does not roll back a slave projection that never committed", async () => {
+    const projectionError = new Error("projection failed");
+    const updateRuntime = vi.fn(async () => {
+      throw projectionError;
+    });
+    const start = vi.fn();
+    const slave = createQiankunSlaveLifecycles({
+      name: "catalog",
+      mount: "#app",
+      async loadEntry() {
+        return {
+          pagesApp: { updateRuntime },
+          start,
+        };
+      },
+    });
+
+    await expect(
+      slave.mount({
+        container: createElement(),
+        base: "/catalog",
+        history: "hash",
+      }),
+    ).rejects.toBe(projectionError);
+
+    expect(updateRuntime).toHaveBeenCalledTimes(1);
+    expect(start).not.toHaveBeenCalled();
+  });
+
   it("runs slave post lifecycles after mount and every mounted update", async () => {
     const calls: string[] = [];
     const container = createElement();
@@ -1399,10 +1428,10 @@ describe("@evjs/plugin-qiankun runtime", () => {
         { path: "/$", module: { default: () => null } },
       ],
     });
-    const router = pagesApp.app.router as {
+    const initialRouter = pagesApp.app.router as {
       history: ReturnType<typeof createQiankunSlaveHistory>;
     };
-    const initialHistory = router.history;
+    const initialHistory = initialRouter.history;
     const mountError = new Error("entry start failed");
     const retryError = new Error("runtime mount failed");
     const runtimeMount = vi
@@ -1433,7 +1462,11 @@ describe("@evjs/plugin-qiankun runtime", () => {
         }),
       ).rejects.toBe(mountError);
 
-      const restoredHistory = router.history;
+      const restoredRouter = pagesApp.app.router as {
+        history: ReturnType<typeof createQiankunSlaveHistory>;
+      };
+      const restoredHistory = restoredRouter.history;
+      expect(restoredRouter).not.toBe(initialRouter);
       expect(restoredHistory).not.toBe(initialHistory);
       expect(restoredHistory.location.href).toBe("/catalog");
       expect(win.history.pushState).toBe(hostPushState);
@@ -1447,8 +1480,9 @@ describe("@evjs/plugin-qiankun runtime", () => {
           history: "browser",
         }),
       ).rejects.toBe(retryError);
-      expect(router.history).toBe(restoredHistory);
-      expect(router.history.location.href).toBe("/catalog");
+      expect(pagesApp.app.router).toBe(restoredRouter);
+      expect(restoredRouter.history).toBe(restoredHistory);
+      expect(restoredRouter.history.location.href).toBe("/catalog");
       expect(win.listenerCount("popstate")).toBe(2);
 
       await slave.unmount();


### PR DESCRIPTION
## Summary
- Refactor the generated SPA runtime to replace Router instances through TanStack Router's public construction and loading APIs.
- Stabilize SPA routing both standalone and as a qiankun slave while reducing upgrade risk from TanStack internals.

## Changes
- Defer initial Router construction until qiankun runtime projection has supplied the effective base and history.
- Build and load a candidate Router for later base, history, or route-overlay changes, reuse the QueryClient, and switch only after the candidate is ready.
- Remove dependencies on private Router match stores, batching, and route lookup state.
- Treat qiankun projection as committed only after the runtime update succeeds, preventing duplicate rollback after projection failure.
- Add replacement, remount, projection-failure, and scoped-history regression coverage.
- Document the lifecycle in both English and Chinese.

## Validation
- `npm run check-types`
- `npm run lint`
- `WATCHPACK_POLLING=true npx turbo run test --env-mode=loose`
- `npm --workspace evjs-docs run build`
- Focused client and qiankun build/tests against `@tanstack/react-router@1.170.19` with `@tanstack/router-core@1.171.16`
- `git diff --check`

The normal Watchpack watcher mode hit the environment's file-descriptor limit (`EMFILE`); the full test suite passed with polling enabled.

## Risk / rollout
- No dependency ranges or lockfile entries changed; `@tanstack/react-router` remains on the existing compatible range.
- Runtime base, history, or route-overlay updates now replace the internal Router instance behind the stable Pages app facade.
- Risk is concentrated around history ownership and mounted-app replacement; focused regression tests cover these paths.

## Reviewer notes
- Please focus on candidate Router commit/rollback behavior in `page-route.ts` and scoped-history cleanup in the qiankun runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Runtime changes to routes, base paths, and browser history now load a replacement router before switching, reducing disruption during updates.
  * Existing application state and query data are preserved when the runtime is rebuilt.
  * Initial embedded-app startup now applies mounting configuration before loading the router.
* **Bug Fixes**
  * Failed route or configuration updates now retain the last working router.
  * Improved rollback behavior prevents failed embedded-app mounts from incorrectly altering history or startup state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->