### PR TITLE
fix(client): preserve latest mount state during router swaps

### DIFF
--- a/packages/client/src/framework/page/page-route.ts
+++ b/packages/client/src/framework/page/page-route.ts
@@ -265,7 +265,6 @@ export function createPagesApp(options: CreatePagesAppOptions): PagesApp {
 
     const previousRuntime = activeRuntime;
     const previousState = runtimeState;
-    const previousMount = mountedApp;
     const retainedHistory = historyChanged
       ? undefined
       : previousRuntime.history;
@@ -294,8 +293,8 @@ export function createPagesApp(options: CreatePagesAppOptions): PagesApp {
       }
       activeRuntime = candidate;
       runtimeState = nextState;
-      if (previousMount) {
-        await candidate.app.render(previousMount.container, { hydrate: false });
+      if (mountedApp) {
+        await candidate.app.render(mountedApp.container, { hydrate: false });
       }
       if (
         historyChanged &&
@@ -324,8 +323,8 @@ export function createPagesApp(options: CreatePagesAppOptions): PagesApp {
           activeRuntime = previousRuntime;
         }
         runtimeState = previousState;
-        if (previousMount && previousUnmounted) {
-          await activeRuntime.app.render(previousMount.container, {
+        if (mountedApp && previousUnmounted) {
+          await activeRuntime.app.render(mountedApp.container, {
             hydrate: false,
           });
         }

--- a/packages/client/tests/page-bootstrap.test.ts
+++ b/packages/client/tests/page-bootstrap.test.ts
@@ -87,6 +87,46 @@ describe("SPA page bootstrap", () => {
     ]);
   });
 
+  it("stays unmounted when unmount runs while a replacement Router loads", async () => {
+    const loadStarted = createDeferred<void>();
+    const releaseLoad = createDeferred<void>();
+    const pagesApp = createRuntimeRacePagesApp(loadStarted, releaseLoad);
+    const mount = {} as HTMLElement;
+
+    pagesApp.app.render(mount);
+    const update = pagesApp.updateRuntime({ routes: [] });
+    await loadStarted.promise;
+
+    pagesApp.app.unmount();
+    releaseLoad.resolve();
+    await update;
+
+    expect(reactRootCalls).toEqual(["createRoot", "render", "unmount"]);
+  });
+
+  it("keeps a render started while a replacement Router loads mounted", async () => {
+    const loadStarted = createDeferred<void>();
+    const releaseLoad = createDeferred<void>();
+    const pagesApp = createRuntimeRacePagesApp(loadStarted, releaseLoad);
+    const mount = {} as HTMLElement;
+
+    void pagesApp.app.router;
+    const update = pagesApp.updateRuntime({ routes: [] });
+    await loadStarted.promise;
+
+    pagesApp.app.render(mount);
+    releaseLoad.resolve();
+    await update;
+
+    expect(reactRootCalls).toEqual([
+      "createRoot",
+      "render",
+      "unmount",
+      "createRoot",
+      "render",
+    ]);
+  });
+
   it("validates render options before mounting", () => {
     const { app } = createTestPagesApp();
     const mount = {} as HTMLElement;
@@ -148,6 +188,30 @@ function createTestPagesApp() {
   }
   return createPagesApp({
     routes: [{ path: "/", module: { default: Home } }],
+  });
+}
+
+function createRuntimeRacePagesApp(
+  loadStarted: ReturnType<typeof createDeferred<void>>,
+  releaseLoad: ReturnType<typeof createDeferred<void>>,
+) {
+  function Home() {
+    return null;
+  }
+  return createPagesApp({
+    routes: [
+      {
+        path: "/",
+        module: {
+          default: Home,
+          async loader() {
+            loadStarted.resolve();
+            await releaseLoad.promise;
+          },
+        },
+      },
+    ],
+    history: { type: "memory", initialEntries: ["/"] },
   });
 }
 


### PR DESCRIPTION
## Summary
- Prevent PagesApp runtime replacement from applying a stale mount snapshot after the candidate Router finishes loading.
- Address the post-merge mount lifecycle race reported on PR #83.

## Changes
- Read the current `mountedApp` state when committing a replacement Router and when restoring the previous runtime after rollback.
- Keep an intervening `unmount()` unmounted instead of recreating its React Root.
- Move an intervening `render()` onto the committed replacement Router.
- Add regression coverage for both concurrent lifecycle orders.

## Validation
- `./node_modules/.bin/turbo run build --filter=@evjs/client`
- `npm --workspace @evjs/client test -- --configLoader runner tests/page-bootstrap.test.ts` (11 tests passed)
- `npm run check-types`
- `npm run lint`
- `WATCHPACK_POLLING=true npm test -- --env-mode=loose`
- `git diff --check`

The default native-watcher test run hit the environment's file-descriptor limit (`EMFILE`) in a Webpack transition test. The full suite passed with Watchpack polling enabled, matching PR #83's validation setup.

## Risk / rollout
- Low, localized to mounted PagesApp Router replacement and rollback.
- No public API, dependency, configuration, or generated contract changes.
- Concurrent `render()` and `unmount()` calls now follow the latest mount state observed after asynchronous Router loading.

## Reviewer notes
- Please focus on the live `mountedApp` checks in the replacement commit and rollback paths.
- Regression tests correspond to the unresolved review thread: https://github.com/afx-team/evjs/pull/83#discussion_r3726209240
