### PR TITLE
docs(changelog): prepare v0.3.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ---
 
+## [0.3.6] — 2026-08-06
+
+### ✨ Improvements
+
+- **Public SPA Router replacement** — Generated Pages apps defer initial Router
+  construction until runtime base and history projection, then load replacement
+  Routers through TanStack's public APIs for later base, history, or runtime
+  Route-overlay updates. Replacement preserves the shared Query client and
+  commits only after the candidate Router is ready.
+
+### 🐛 Bug Fixes
+
+- **Race-safe Router remounting** — Runtime replacement and rollback now use the
+  latest mount state after asynchronous Router loading, so an intervening
+  `unmount()` stays unmounted and an intervening `render()` moves onto the
+  replacement Router instead of leaving the application blank.
+- **Committed qiankun projection rollback** — Qiankun slave lifecycles roll back
+  runtime projection only after it succeeds, avoiding duplicate rollback and
+  history restoration when projection itself fails.
+
+---
+
 ## [0.3.5] — 2026-08-06
 
 ### ✨ Features


### PR DESCRIPTION
## Summary
- Prepare the EVJS v0.3.6 stable release notes from the current `main` branch.
- Cover the public SPA Router replacement lifecycle and the follow-up mount-state race fix.

## Changes
- Add a dated v0.3.6 changelog section for commits merged after v0.3.5.
- Document candidate Router loading through TanStack public APIs with shared Query client retention.
- Document race-safe remounting and committed qiankun projection rollback.

## Validation
- `npm run lint`
- `npm --workspace evjs-docs run build`
- `git diff --check`
- PR #83 full test suite passed with `WATCHPACK_POLLING=true`.
- PR #84 full test suite passed with `WATCHPACK_POLLING=true`.

## Risk / rollout
- Documentation-only change; package versions and internal workspace dependency ranges remain managed by the release workflow.
- Publishing GitHub Release `v0.3.6` after merge will publish all public `@evjs/*` workspaces with the npm `latest` dist-tag.
- No migration, configuration, dependency, auth, security, or privacy changes.

## Reviewer notes
- Verify that the notes describe only `v0.3.5..main` (PRs #83 and #84).
- The release will target the resulting merge commit on `main`.
