### PR TITLE
feat(ev): 支持插件驱动的开发 CLI 快捷键

### DIFF
--- a/docs/docs/dev.md
+++ b/docs/docs/dev.md
@@ -282,7 +282,7 @@ const shortcutsPlugin = {
 export default defineConfig({ plugins: [shortcutsPlugin] });
 ```
 
-The `configureShortcuts` hook returns a `CLIShortcut[]`, and the first plugin to
+The `configureShortcuts` hook returns a `PluginCliShortcut[]`, and the first plugin to
 register a key owns it (later duplicates are dropped). Each `action` receives the
 live `PluginDevSession`:
 

--- a/docs/docs/dev.md
+++ b/docs/docs/dev.md
@@ -141,7 +141,8 @@ paths, so app-specific API proxies can keep their own routing behavior.
 default is on; set `dev.cliShortcuts: false` to disable it. The engine mirrors
 Vite's `bindCLIShortcuts` (readline line events, one key + `Enter`) but ships
 no built-in shortcuts of its own — every key is contributed by a plugin via the
-`configureShortcuts` setup hook (see [Plugin CLI Shortcuts](#plugin-cli-shortcuts)).
+descriptor-level `cliShortcuts()` contribution (see
+[Plugin CLI Shortcuts](#plugin-cli-shortcuts)).
 It is always a no-op in CI and non-TTY contexts, regardless of this option.
 
 ```ts
@@ -238,7 +239,7 @@ interactive keyboard shortcuts. Core ships **no built-in shortcuts** — every k
 `bindCLIShortcuts` mechanics (one key + `Enter`, with concurrent presses
 dropped) but leaves the action set to the ecosystem.
 
-Register shortcuts from a plugin's `setup()` hook:
+Declare shortcuts directly on the plugin descriptor:
 
 ```ts
 // ev.config.ts
@@ -247,36 +248,37 @@ import { definePlugin } from "@evjs/ev/plugin";
 
 const shortcutsPlugin = definePlugin({
   id: "my-shortcuts",
-  setup() {
-    return {
-      configureShortcuts() {
-        return [
-          {
-            key: "u",
-            description: "show server url",
-            action(session) {
-              console.log(session.origin);
-            },
-          },
-          {
-            key: "q",
-            description: "quit",
-            action(session) {
-              session.close();
-            },
-          },
-        ];
+  cliShortcuts() {
+    return [
+      {
+        key: "u",
+        description: "show server url",
+        action(session) {
+          console.log(session.origin);
+        },
       },
-    };
+      {
+        key: "q",
+        description: "quit",
+        action(session) {
+          session.close();
+        },
+      },
+    ];
   },
 });
 
 export default defineConfig({ plugins: [shortcutsPlugin()] });
 ```
 
-The `configureShortcuts` hook returns a `PluginCliShortcut[]`, and the first plugin to
-register a key owns it (later duplicates are dropped). Each `action` receives the
-live `PluginDevSession`:
+`cliShortcuts()` returns a `PluginCliShortcut[]`. evjs collects it once for each
+resolved plugin snapshot; it is a declaration, not a `setup()` lifecycle event.
+Because it does not depend on the hooks object's identity, ordinary setup hooks
+may be reused where otherwise safe. Shortcut actions should not depend on private
+resources created inside `setup()`.
+
+The first plugin to register a key owns it (later duplicates are dropped). Each
+`action` receives the live `PluginDevSession`:
 
 - `origin: string` — the client dev server URL
   (`http(s)://localhost:<port>`).

--- a/docs/docs/dev.md
+++ b/docs/docs/dev.md
@@ -137,6 +137,26 @@ forwarding them to the target.
 Custom proxy rules are applied before the built-in proxy for server runtime
 paths, so app-specific API proxies can keep their own routing behavior.
 
+`dev.cliShortcuts` controls the interactive CLI keyboard shortcuts engine. The
+default is on; set `dev.cliShortcuts: false` to disable it. The engine mirrors
+Vite's `bindCLIShortcuts` (readline line events, one key + `Enter`) but ships
+no built-in shortcuts of its own — every key is contributed by a plugin via the
+`configureShortcuts` setup hook (see [Plugin CLI Shortcuts](#plugin-cli-shortcuts)).
+It is always a no-op in CI / non-TTY contexts, and on the wasm/web (Fetch
+runtime) dev surface, regardless of this option.
+
+```ts
+// ev.config.ts
+export default defineConfig({
+  dev: {
+    cliShortcuts: false, // or { print: false } to hide the help hint
+  },
+});
+```
+
+`ev dev --no-shortcuts` disables the engine for a single run without editing
+config.
+
 ## Request Flow
 
 1. The client dev server serves browser code and HMR.
@@ -205,6 +225,87 @@ loads the discovered config, while `reloadInitialConfig: true` explicitly asks
 the provided or default `loadConfig` function to replace a supplied startup
 config. A custom `loadConfig` can still be retained for later watched reloads
 with `reloadInitialConfig: false`.
+
+The `cliShortcuts` programmatic option overrides `dev.cliShortcuts`: pass
+`false` to disable the interactive shortcuts engine regardless of
+`ev.config.ts` (mirrors `ev dev --no-shortcuts`). When omitted, the config-file
+value (default on) is authoritative.
+
+## Plugin CLI Shortcuts
+
+While `ev dev` runs in a TTY (and not under `CI`), plugins can register
+interactive keyboard shortcuts. Core ships **no built-in shortcuts** — every key
+(including `h` for help) is contributed by a plugin. This mirrors Vite's
+`bindCLIShortcuts` mechanics (one key + `Enter`, with concurrent presses
+dropped) but leaves the action set to the ecosystem.
+
+Register shortcuts from a plugin's `setup()` hook:
+
+```ts
+// my-evjs-plugin.ts
+import { spawn } from "node:child_process";
+import { defineConfig } from "@evjs/ev";
+
+const shortcutsPlugin = {
+  id: "my-shortcuts",
+  setup() {
+    return {
+      configureShortcuts() {
+        return [
+          {
+            key: "o",
+            description: "open the dev server in the browser",
+            action(session) {
+              spawn("open", [session.origin]);
+            },
+          },
+          {
+            key: "u",
+            description: "show server url",
+            action(session) {
+              console.log(session.origin);
+            },
+          },
+          {
+            key: "r",
+            description: "restart the server runtime",
+            action(session) {
+              session.restartServerRuntime();
+            },
+          },
+          {
+            key: "q",
+            description: "quit",
+            action(session) {
+              session.close();
+            },
+          },
+        ];
+      },
+    };
+  },
+};
+
+export default defineConfig({ plugins: [shortcutsPlugin] });
+```
+
+The `configureShortcuts` hook returns a `CLIShortcut[]`, and the first plugin to
+register a key owns it (later duplicates are dropped). Each `action` receives the
+live `DevSession`:
+
+- `origin: string` — the client dev server URL
+  (`http(s)://localhost:<port>`).
+- `restartServerRuntime()` — restart the Hono API server child through the
+  same serialized restart path used when a server bundle becomes ready.
+  No-ops when there is no server-runtime entry.
+- `close()` — trigger dev shutdown (equivalent to `Ctrl-C`).
+
+When bound with a help key, pressing `h` + `Enter` lists every registered
+shortcut; `ev dev` prints a `press h + enter to show help` hint at startup.
+
+Scope: this targets the standard Node dev server (the utoopack dev worker plus
+the Hono API child). The wasm/web (Fetch runtime) dev surface has no Node child
+process and no interactive TTY loop, so the engine stays a no-op there.
 
 ## Transport
 

--- a/docs/docs/dev.md
+++ b/docs/docs/dev.md
@@ -149,7 +149,7 @@ runtime) dev surface, regardless of this option.
 // ev.config.ts
 export default defineConfig({
   dev: {
-    cliShortcuts: false, // or { print: false } to hide the help hint
+    cliShortcuts: false,
   },
 });
 ```
@@ -267,13 +267,6 @@ const shortcutsPlugin = {
             },
           },
           {
-            key: "r",
-            description: "restart the server runtime",
-            action(session) {
-              session.restartServerRuntime();
-            },
-          },
-          {
             key: "q",
             description: "quit",
             action(session) {
@@ -291,17 +284,16 @@ export default defineConfig({ plugins: [shortcutsPlugin] });
 
 The `configureShortcuts` hook returns a `CLIShortcut[]`, and the first plugin to
 register a key owns it (later duplicates are dropped). Each `action` receives the
-live `DevSession`:
+live `PluginDevSession`:
 
 - `origin: string` — the client dev server URL
   (`http(s)://localhost:<port>`).
-- `restartServerRuntime()` — restart the Hono API server child through the
-  same serialized restart path used when a server bundle becomes ready.
-  No-ops when there is no server-runtime entry.
 - `close()` — trigger dev shutdown (equivalent to `Ctrl-C`).
 
-When bound with a help key, pressing `h` + `Enter` lists every registered
-shortcut; `ev dev` prints a `press h + enter to show help` hint at startup.
+Core deliberately exposes only `origin` and `close()`; richer actions (restart,
+reload, profiling, …) are implemented by plugins from these primitives plus their
+own utilities, not by core. A plugin that wants a help listing registers `h`
+itself and reads the shortcut descriptions it knows about.
 
 Scope: this targets the standard Node dev server (the utoopack dev worker plus
 the Hono API child). The wasm/web (Fetch runtime) dev surface has no Node child

--- a/docs/docs/dev.md
+++ b/docs/docs/dev.md
@@ -142,8 +142,7 @@ default is on; set `dev.cliShortcuts: false` to disable it. The engine mirrors
 Vite's `bindCLIShortcuts` (readline line events, one key + `Enter`) but ships
 no built-in shortcuts of its own — every key is contributed by a plugin via the
 `configureShortcuts` setup hook (see [Plugin CLI Shortcuts](#plugin-cli-shortcuts)).
-It is always a no-op in CI / non-TTY contexts, and on the wasm/web (Fetch
-runtime) dev surface, regardless of this option.
+It is always a no-op in CI and non-TTY contexts, regardless of this option.
 
 ```ts
 // ev.config.ts
@@ -242,23 +241,16 @@ dropped) but leaves the action set to the ecosystem.
 Register shortcuts from a plugin's `setup()` hook:
 
 ```ts
-// my-evjs-plugin.ts
-import { spawn } from "node:child_process";
+// ev.config.ts
 import { defineConfig } from "@evjs/ev";
+import { definePlugin } from "@evjs/ev/plugin";
 
-const shortcutsPlugin = {
+const shortcutsPlugin = definePlugin({
   id: "my-shortcuts",
   setup() {
     return {
       configureShortcuts() {
         return [
-          {
-            key: "o",
-            description: "open the dev server in the browser",
-            action(session) {
-              spawn("open", [session.origin]);
-            },
-          },
           {
             key: "u",
             description: "show server url",
@@ -277,9 +269,9 @@ const shortcutsPlugin = {
       },
     };
   },
-};
+});
 
-export default defineConfig({ plugins: [shortcutsPlugin] });
+export default defineConfig({ plugins: [shortcutsPlugin()] });
 ```
 
 The `configureShortcuts` hook returns a `PluginCliShortcut[]`, and the first plugin to
@@ -295,9 +287,9 @@ reload, profiling, …) are implemented by plugins from these primitives plus th
 own utilities, not by core. A plugin that wants a help listing registers `h`
 itself and reads the shortcut descriptions it knows about.
 
-Scope: this targets the standard Node dev server (the utoopack dev worker plus
-the Hono API child). The wasm/web (Fetch runtime) dev surface has no Node child
-process and no interactive TTY loop, so the engine stays a no-op there.
+The engine is bundler-agnostic: it binds after the selected Node CLI dev adapter
+reports its client origin. Both built-in adapters support that callback, and a
+server/API child is not required.
 
 ## Transport
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/dev.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/dev.md
@@ -119,6 +119,24 @@ HTTP(S) URL `target`。Context pattern 必须以 `/` 开头，不能包含空白
 
 自定义代理规则会先于服务端运行时路径的内置代理应用，因此应用自己的 API proxy 可以保留独立的路由行为。
 
+`dev.cliShortcuts` 控制交互式 CLI 键盘快捷键引擎。默认开启;设为
+`dev.cliShortcuts: false` 可关闭。该引擎复刻 Vite `bindCLIShortcuts`
+的机制(readline line 事件,单键 + `Enter`),但内置不提供任何快捷键 ——
+每个键都由插件通过 `configureShortcuts` setup hook 贡献(见
+[插件 CLI 快捷键](#插件-cli-快捷键))。无论该选项如何,在 CI / 非 TTY / 以及
+wasm/web(Fetch runtime)dev 场景下引擎始终为 no-op。
+
+```ts
+// ev.config.ts
+export default defineConfig({
+  dev: {
+    cliShortcuts: false, // 或 { print: false } 隐藏帮助提示
+  },
+});
+```
+
+`ev dev --no-shortcuts` 可在不修改配置的情况下,单次运行关闭该引擎。
+
 ## 请求流
 
 1. 客户端开发服务器提供浏览器代码和 HMR。
@@ -177,6 +195,81 @@ framework preflight 会对照 active BuildPlan 检查这些 capability。
 `dev(undefined, options)` 会加载发现到的配置；`reloadInitialConfig: true` 则会明确要求传入的
 或默认的 `loadConfig` 替换启动 config。若只希望自定义 `loadConfig` 用于后续监听重载，可以
 同时设置 `reloadInitialConfig: false`。
+
+programmatic 选项 `cliShortcuts` 可覆盖 `dev.cliShortcuts`:传 `false`
+即可无视 `ev.config.ts` 关闭交互式快捷键引擎(等价于 `ev dev --no-shortcuts`)。
+省略时以配置文件为准(默认开启)。
+
+## 插件 CLI 快捷键
+
+当 `ev dev` 运行于 TTY(且不在 `CI` 下)时,插件可注册交互式键盘快捷键。Core
+**不内置任何快捷键** —— 每个键(包括 `h` 帮助)均由插件贡献。该机制复刻 Vite
+`bindCLIShortcuts`(单键 + `Enter`,并发的按键会被丢弃),但把 action 集合留给生态。
+
+在插件 `setup()` hook 中注册快捷键:
+
+```ts
+// my-evjs-plugin.ts
+import { spawn } from "node:child_process";
+import { defineConfig } from "@evjs/ev";
+
+const shortcutsPlugin = {
+  id: "my-shortcuts",
+  setup() {
+    return {
+      configureShortcuts() {
+        return [
+          {
+            key: "o",
+            description: "在浏览器打开 dev server",
+            action(session) {
+              spawn("open", [session.origin]);
+            },
+          },
+          {
+            key: "u",
+            description: "显示 server url",
+            action(session) {
+              console.log(session.origin);
+            },
+          },
+          {
+            key: "r",
+            description: "重启 server runtime",
+            action(session) {
+              session.restartServerRuntime();
+            },
+          },
+          {
+            key: "q",
+            description: "退出",
+            action(session) {
+              session.close();
+            },
+          },
+        ];
+      },
+    };
+  },
+};
+
+export default defineConfig({ plugins: [shortcutsPlugin] });
+```
+
+`configureShortcuts` hook 返回 `CLIShortcut[]`,首个为某个 key 注册快捷键的插件
+拥有该 key(后续重复会被丢弃)。每个 `action` 会收到实时的 `DevSession`:
+
+- `origin: string` —— 客户端 dev server URL(`http(s)://localhost:<port>`)。
+- `restartServerRuntime()` —— 通过服务端 bundle ready 时所用的同一条串行化重启
+  路径,重启 Hono API server 子进程;无 server-runtime entry 时为 no-op。
+- `close()` —— 触发 dev 关闭(等价于 `Ctrl-C`)。
+
+以帮助键绑定时,按 `h` + `Enter` 可列出所有已注册快捷键;`ev dev` 启动时会打印
+`press h + enter to show help` 提示。
+
+适用范围:该能力面向标准 Node dev server(utoopack dev worker + Hono API
+子进程)。wasm/web(Fetch runtime)dev 场景没有 Node 子进程也没有交互式 TTY
+循环,因此引擎在该路径下保持为 no-op。
 
 ## 传输层
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/dev.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/dev.md
@@ -249,7 +249,7 @@ const shortcutsPlugin = {
 export default defineConfig({ plugins: [shortcutsPlugin] });
 ```
 
-`configureShortcuts` hook 返回 `CLIShortcut[]`,首个为某个 key 注册快捷键的插件
+`configureShortcuts` hook 返回 `PluginCliShortcut[]`,首个为某个 key 注册快捷键的插件
 拥有该 key(后续重复会被丢弃)。每个 `action` 会收到实时的 `PluginDevSession`:
 
 - `origin: string` —— 客户端 dev server URL(`http(s)://localhost:<port>`)。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/dev.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/dev.md
@@ -130,7 +130,7 @@ wasm/web(Fetch runtime)dev 场景下引擎始终为 no-op。
 // ev.config.ts
 export default defineConfig({
   dev: {
-    cliShortcuts: false, // 或 { print: false } 隐藏帮助提示
+    cliShortcuts: false,
   },
 });
 ```
@@ -234,13 +234,6 @@ const shortcutsPlugin = {
             },
           },
           {
-            key: "r",
-            description: "重启 server runtime",
-            action(session) {
-              session.restartServerRuntime();
-            },
-          },
-          {
             key: "q",
             description: "退出",
             action(session) {
@@ -257,15 +250,14 @@ export default defineConfig({ plugins: [shortcutsPlugin] });
 ```
 
 `configureShortcuts` hook 返回 `CLIShortcut[]`,首个为某个 key 注册快捷键的插件
-拥有该 key(后续重复会被丢弃)。每个 `action` 会收到实时的 `DevSession`:
+拥有该 key(后续重复会被丢弃)。每个 `action` 会收到实时的 `PluginDevSession`:
 
 - `origin: string` —— 客户端 dev server URL(`http(s)://localhost:<port>`)。
-- `restartServerRuntime()` —— 通过服务端 bundle ready 时所用的同一条串行化重启
-  路径,重启 Hono API server 子进程;无 server-runtime entry 时为 no-op。
 - `close()` —— 触发 dev 关闭(等价于 `Ctrl-C`)。
 
-以帮助键绑定时,按 `h` + `Enter` 可列出所有已注册快捷键;`ev dev` 启动时会打印
-`press h + enter to show help` 提示。
+Core 刻意只暴露 `origin` 与 `close()`;更丰富的 action(重启、reload、profiling
+等)由插件基于这些原语加自身工具实现,而非由 core 提供。需要帮助列表的插件可
+自行注册 `h`,读取它已知的快捷键描述。
 
 适用范围:该能力面向标准 Node dev server(utoopack dev worker + Hono API
 子进程)。wasm/web(Fetch runtime)dev 场景没有 Node 子进程也没有交互式 TTY

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/dev.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/dev.md
@@ -122,7 +122,7 @@ HTTP(S) URL `target`。Context pattern 必须以 `/` 开头，不能包含空白
 `dev.cliShortcuts` 控制交互式 CLI 键盘快捷键引擎。默认开启;设为
 `dev.cliShortcuts: false` 可关闭。该引擎复刻 Vite `bindCLIShortcuts`
 的机制(readline line 事件,单键 + `Enter`),但内置不提供任何快捷键 ——
-每个键都由插件通过 `configureShortcuts` setup hook 贡献(见
+每个键都由插件 descriptor 顶层的 `cliShortcuts()` 贡献(见
 [插件 CLI 快捷键](#插件-cli-快捷键))。无论该选项如何,在 CI / 非 TTY 场景下
 引擎始终为 no-op。
 
@@ -206,7 +206,7 @@ programmatic 选项 `cliShortcuts` 可覆盖 `dev.cliShortcuts`:传 `false`
 **不内置任何快捷键** —— 每个键(包括 `h` 帮助)均由插件贡献。该机制复刻 Vite
 `bindCLIShortcuts`(单键 + `Enter`,并发的按键会被丢弃),但把 action 集合留给生态。
 
-在插件 `setup()` hook 中注册快捷键:
+在插件 descriptor 顶层声明快捷键:
 
 ```ts
 // ev.config.ts
@@ -215,35 +215,36 @@ import { definePlugin } from "@evjs/ev/plugin";
 
 const shortcutsPlugin = definePlugin({
   id: "my-shortcuts",
-  setup() {
-    return {
-      configureShortcuts() {
-        return [
-          {
-            key: "u",
-            description: "显示 server url",
-            action(session) {
-              console.log(session.origin);
-            },
-          },
-          {
-            key: "q",
-            description: "退出",
-            action(session) {
-              session.close();
-            },
-          },
-        ];
+  cliShortcuts() {
+    return [
+      {
+        key: "u",
+        description: "显示 server url",
+        action(session) {
+          console.log(session.origin);
+        },
       },
-    };
+      {
+        key: "q",
+        description: "退出",
+        action(session) {
+          session.close();
+        },
+      },
+    ];
   },
 });
 
 export default defineConfig({ plugins: [shortcutsPlugin()] });
 ```
 
-`configureShortcuts` hook 返回 `PluginCliShortcut[]`,首个为某个 key 注册快捷键的插件
-拥有该 key(后续重复会被丢弃)。每个 `action` 会收到实时的 `PluginDevSession`:
+`cliShortcuts()` 返回 `PluginCliShortcut[]`。evjs 会为每个 resolved plugin snapshot
+收集一次；它是声明式 contribution，不是 `setup()` lifecycle event。由于它不依赖 hooks
+对象 identity，普通 setup hooks 在其他条件允许时可以复用。Shortcut action 不应依赖
+`setup()` 内创建的私有资源。
+
+首个为某个 key 注册快捷键的插件拥有该 key(后续重复会被丢弃)。每个 `action` 会收到实时的
+`PluginDevSession`:
 
 - `origin: string` —— 客户端 dev server URL(`http(s)://localhost:<port>`)。
 - `close()` —— 触发 dev 关闭(等价于 `Ctrl-C`)。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/dev.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/dev.md
@@ -123,8 +123,8 @@ HTTP(S) URL `target`。Context pattern 必须以 `/` 开头，不能包含空白
 `dev.cliShortcuts: false` 可关闭。该引擎复刻 Vite `bindCLIShortcuts`
 的机制(readline line 事件,单键 + `Enter`),但内置不提供任何快捷键 ——
 每个键都由插件通过 `configureShortcuts` setup hook 贡献(见
-[插件 CLI 快捷键](#插件-cli-快捷键))。无论该选项如何,在 CI / 非 TTY / 以及
-wasm/web(Fetch runtime)dev 场景下引擎始终为 no-op。
+[插件 CLI 快捷键](#插件-cli-快捷键))。无论该选项如何,在 CI / 非 TTY 场景下
+引擎始终为 no-op。
 
 ```ts
 // ev.config.ts
@@ -209,23 +209,16 @@ programmatic 选项 `cliShortcuts` 可覆盖 `dev.cliShortcuts`:传 `false`
 在插件 `setup()` hook 中注册快捷键:
 
 ```ts
-// my-evjs-plugin.ts
-import { spawn } from "node:child_process";
+// ev.config.ts
 import { defineConfig } from "@evjs/ev";
+import { definePlugin } from "@evjs/ev/plugin";
 
-const shortcutsPlugin = {
+const shortcutsPlugin = definePlugin({
   id: "my-shortcuts",
   setup() {
     return {
       configureShortcuts() {
         return [
-          {
-            key: "o",
-            description: "在浏览器打开 dev server",
-            action(session) {
-              spawn("open", [session.origin]);
-            },
-          },
           {
             key: "u",
             description: "显示 server url",
@@ -244,9 +237,9 @@ const shortcutsPlugin = {
       },
     };
   },
-};
+});
 
-export default defineConfig({ plugins: [shortcutsPlugin] });
+export default defineConfig({ plugins: [shortcutsPlugin()] });
 ```
 
 `configureShortcuts` hook 返回 `PluginCliShortcut[]`,首个为某个 key 注册快捷键的插件
@@ -259,9 +252,8 @@ Core 刻意只暴露 `origin` 与 `close()`;更丰富的 action(重启、reload�
 等)由插件基于这些原语加自身工具实现,而非由 core 提供。需要帮助列表的插件可
 自行注册 `h`,读取它已知的快捷键描述。
 
-适用范围:该能力面向标准 Node dev server(utoopack dev worker + Hono API
-子进程)。wasm/web(Fetch runtime)dev 场景没有 Node 子进程也没有交互式 TTY
-循环,因此引擎在该路径下保持为 no-op。
+该引擎与 bundler 解耦：所选 Node CLI dev adapter 报告 client origin 后即可绑定。
+两个内置 adapter 都支持该 callback，且不要求存在 server/API 子进程。
 
 ## 传输层
 

--- a/packages/bundler-utoopack/tests/create-config.test.ts
+++ b/packages/bundler-utoopack/tests/create-config.test.ts
@@ -45,6 +45,7 @@ describe("createUtoopackConfig", () => {
         port: 41234,
         https: true,
         proxy: [],
+        cliShortcuts: true,
       },
       server: {
         basePath: "/__evjs",
@@ -120,6 +121,7 @@ describe("createUtoopackConfig", () => {
         port: 41234,
         https: { key: "./certs/dev.key", cert: "./certs/dev.crt" },
         proxy: [],
+        cliShortcuts: true,
       },
     });
     const plan = await createPlan(config);
@@ -137,6 +139,7 @@ describe("createUtoopackConfig", () => {
         port: 41234,
         https: { key: "./certs/dev.key", cert: "./certs/dev.crt" },
         proxy: [],
+        cliShortcuts: true,
       },
     });
     const plan = await createPlan(config, { mode: "production" });

--- a/packages/bundler-webpack/tests/create-config.test.ts
+++ b/packages/bundler-webpack/tests/create-config.test.ts
@@ -1117,6 +1117,7 @@ function createResolvedConfig(): ResolvedConfig<WebpackConfigs> {
       port: 3000,
       https: false,
       proxy: [],
+      cliShortcuts: true,
     },
     output: {
       client: "dist/client",

--- a/packages/cli/src/cli-program.ts
+++ b/packages/cli/src/cli-program.ts
@@ -25,6 +25,11 @@ type DevFrameworkCommand = (
     cwd: string;
     flags: CliFlags;
     loadConfig: ConfigLoader;
+    /**
+     * `false` when the user passed `--no-shortcuts`. `undefined` otherwise, so
+     * the user's `ev.config.ts` → `dev.cliShortcuts` is authoritative.
+     */
+    cliShortcuts?: boolean;
   },
 ) => Promise<void>;
 
@@ -74,16 +79,26 @@ export async function runCliProgram(
   program
     .command("dev")
     .description("Start development server")
+    .option("--no-shortcuts", "Disable interactive CLI keyboard shortcuts")
     .allowUnknownOption(true)
-    .action(async (_options: unknown, command: Command) => {
+    .action(async (options: { shortcuts?: boolean }, command: Command) => {
       await runCommand("Failed to start dev server", async () => {
         const cwd = dependencies.cwd();
         const flags = parseCliFlags(command.args);
-        await dependencies.dev(undefined, {
+        // Only inject cliShortcuts when the user passed --no-shortcuts; leave it
+        // absent otherwise so the user's ev.config.ts → dev.cliShortcuts wins.
+        const devOptions: {
+          cwd: string;
+          flags: CliFlags;
+          loadConfig: ConfigLoader;
+          cliShortcuts?: boolean;
+        } = {
           cwd,
           flags,
           loadConfig: dependencies.loadConfig,
-        });
+        };
+        if (options.shortcuts === false) devOptions.cliShortcuts = false;
+        await dependencies.dev(undefined, devOptions);
       });
     });
 

--- a/packages/cli/src/cli-program.ts
+++ b/packages/cli/src/cli-program.ts
@@ -29,7 +29,7 @@ type DevFrameworkCommand = (
      * `false` when the user passed `--no-shortcuts`. `undefined` otherwise, so
      * the user's `ev.config.ts` → `dev.cliShortcuts` is authoritative.
      */
-    cliShortcuts?: boolean;
+    cliShortcuts?: false;
   },
 ) => Promise<void>;
 
@@ -91,7 +91,7 @@ export async function runCliProgram(
           cwd: string;
           flags: CliFlags;
           loadConfig: ConfigLoader;
-          cliShortcuts?: boolean;
+          cliShortcuts?: false;
         } = {
           cwd,
           flags,

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -49,6 +49,30 @@ describe("CLI execution", () => {
     });
   });
 
+  it("forwards --no-shortcuts as cliShortcuts:false to the dev command", async () => {
+    const dev = vi.fn(async () => {});
+    const { dependencies } = createDependencies({ dev });
+
+    await expect(
+      runCliProgram(["node", "ev", "dev", "--no-shortcuts"], dependencies),
+    ).resolves.toBe(0);
+
+    expect(dev).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ cliShortcuts: false }),
+    );
+  });
+
+  it("does not inject cliShortcuts when --no-shortcuts is absent", async () => {
+    const dev = vi.fn(async () => {});
+    const { dependencies } = createDependencies({ dev });
+
+    await runCliProgram(["node", "ev", "dev"], dependencies);
+
+    const [, options] = dev.mock.calls[0];
+    expect(options).not.toHaveProperty("cliShortcuts");
+  });
+
   it("awaits an asynchronous command before resolving", async () => {
     let finishBuild: (() => void) | undefined;
     let markBuildStarted: (() => void) | undefined;

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -69,7 +69,9 @@ describe("CLI execution", () => {
 
     await runCliProgram(["node", "ev", "dev"], dependencies);
 
-    const [, options] = dev.mock.calls[0];
+    const options = (dev.mock.calls[0] as unknown[] | undefined)?.[1] as
+      | Record<string, unknown>
+      | undefined;
     expect(options).not.toHaveProperty("cliShortcuts");
   });
 

--- a/packages/cli/tests/dev-options.test.ts
+++ b/packages/cli/tests/dev-options.test.ts
@@ -84,4 +84,20 @@ describe("programmatic dev config loading", () => {
       }),
     );
   });
+
+  it("forwards cliShortcuts:false to the framework dev entrypoint", async () => {
+    await dev(userConfig, { cliShortcuts: false });
+
+    expect(devMocks.frameworkDev).toHaveBeenCalledWith(
+      userConfig,
+      expect.objectContaining({ cliShortcuts: false }),
+    );
+  });
+
+  it("omits cliShortcuts when no override is supplied", async () => {
+    await dev(userConfig);
+
+    const [, options] = devMocks.frameworkDev.mock.calls[0];
+    expect(options).not.toHaveProperty("cliShortcuts");
+  });
 });

--- a/packages/cli/tests/dev-options.test.ts
+++ b/packages/cli/tests/dev-options.test.ts
@@ -97,7 +97,9 @@ describe("programmatic dev config loading", () => {
   it("omits cliShortcuts when no override is supplied", async () => {
     await dev(userConfig);
 
-    const [, options] = devMocks.frameworkDev.mock.calls[0];
+    const options = (
+      devMocks.frameworkDev.mock.calls[0] as unknown[] | undefined
+    )?.[1] as Record<string, unknown> | undefined;
     expect(options).not.toHaveProperty("cliShortcuts");
   });
 });

--- a/packages/ev/src/_internal/build/cli-shortcuts.ts
+++ b/packages/ev/src/_internal/build/cli-shortcuts.ts
@@ -8,10 +8,8 @@
  * `actionRunning` guard that drops concurrent presses, and a TTY + non-CI
  * no-op default) but is bundler-agnostic and owns no default keys.
  *
- * Scope: this engine targets the standard Node dev server. The wasm/web
- * (Fetch runtime) dev surface has no Node child process and no interactive TTY
- * loop, so the engine stays a no-op there. Pass an explicit `enabled` to
- * force-enable in non-TTY tests.
+ * The engine is bundler-agnostic and binds only when a dev adapter reports a
+ * ready origin. Pass an explicit `enabled` to force-enable in non-TTY tests.
  *
  * @see package "vite" `packages/vite/src/node/shortcuts.ts` (mechanical reference)
  */
@@ -25,6 +23,22 @@ import type {
 
 const logger = getLogger(["evjs", "cli-shortcuts"]);
 
+function normalizeInputKey(input: string): string | undefined {
+  const key = input.trim().toLowerCase();
+  return [...key].length === 1 ? key : undefined;
+}
+
+/** Normalize and validate one plugin-contributed shortcut key. */
+export function normalizeShortcutKey(key: string): string {
+  const normalized = normalizeInputKey(key);
+  if (normalized === undefined) {
+    throw new Error(
+      "[evjs] CLI shortcut key must be a single non-whitespace character.",
+    );
+  }
+  return normalized;
+}
+
 /**
  * Resolve a pressed input line to its registered shortcut, if any.
  *
@@ -35,9 +49,11 @@ export function resolveShortcut(
   input: string,
   shortcuts: readonly PluginCliShortcut[],
 ): PluginCliShortcut | undefined {
-  const key = input.trim().toLowerCase();
-  if (key === "") return undefined;
-  return shortcuts.find((shortcut) => shortcut.key === key);
+  const key = normalizeInputKey(input);
+  if (key === undefined) return undefined;
+  return shortcuts.find(
+    (shortcut) => normalizeShortcutKey(shortcut.key) === key,
+  );
 }
 
 /**
@@ -51,9 +67,10 @@ export function dedupeShortcuts(
   const seen = new Set<string>();
   const deduped: PluginCliShortcut[] = [];
   for (const shortcut of shortcuts) {
-    if (seen.has(shortcut.key)) continue;
-    seen.add(shortcut.key);
-    deduped.push(shortcut);
+    const key = normalizeShortcutKey(shortcut.key);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(Object.freeze({ ...shortcut, key }));
   }
   return deduped;
 }
@@ -65,6 +82,10 @@ export interface ShortcutDispatcher {
    * loop survives a failing shortcut.
    */
   dispatch(input: string): Promise<void>;
+  /** Whether no shortcut action is currently running. */
+  isIdle(): boolean;
+  /** Wait for the currently running action, if any. */
+  waitForIdle(): Promise<void>;
 }
 
 /**
@@ -78,22 +99,61 @@ export function createShortcutDispatcher(
   shortcuts: readonly PluginCliShortcut[],
 ): ShortcutDispatcher {
   let actionRunning = false;
+  let runningAction: Promise<void> | undefined;
   return {
     async dispatch(input) {
       if (actionRunning) return;
       const shortcut = resolveShortcut(input, shortcuts);
       if (!shortcut || shortcut.action == null) return;
       actionRunning = true;
+      const action = (async () => {
+        try {
+          await shortcut.action?.(session);
+        } catch (error) {
+          logger.error`Shortcut "${shortcut.key}" failed: ${error}`;
+        }
+      })();
+      runningAction = action;
       try {
-        await shortcut.action(session);
-      } catch (error) {
-        logger.error`Shortcut "${shortcut.key}" failed: ${error}`;
+        await action;
       } finally {
-        actionRunning = false;
+        if (runningAction === action) {
+          runningAction = undefined;
+          actionRunning = false;
+        }
       }
+    },
+    isIdle() {
+      return runningAction === undefined;
+    },
+    waitForIdle() {
+      return runningAction ?? Promise.resolve();
     },
   };
 }
+
+export interface UnbindCLIShortcutsOptions {
+  /**
+   * Maximum time to wait for the active action after input has been detached.
+   * Omit to wait without a deadline; use `0` for shutdown paths that must not
+   * be held open by plugin work.
+   */
+  actionDrainTimeoutMs?: number;
+}
+
+/**
+ * Detach shortcut input and report whether the active action drained before
+ * the requested deadline.
+ */
+export interface UnbindCLIShortcutsResult {
+  readonly drained: boolean;
+  /** Settles when the action that was active during unbind finishes. */
+  readonly idle: Promise<void>;
+}
+
+export type UnbindCLIShortcuts = (
+  options?: UnbindCLIShortcutsOptions,
+) => Promise<UnbindCLIShortcutsResult>;
 
 export interface BindCLIShortcutsOptions {
   /** Shortcuts contributed by plugins, in registration order. */
@@ -119,14 +179,16 @@ export function bindCLIShortcuts(
   session: PluginDevSession,
   opts: BindCLIShortcutsOptions = {},
   enabled: boolean = process.stdin.isTTY && !process.env.CI,
-): () => void {
-  if (!enabled) return () => {};
+): UnbindCLIShortcuts {
+  if (!enabled) {
+    return async () => ({ drained: true, idle: Promise.resolve() });
+  }
 
   const shortcuts = dedupeShortcuts(opts.customShortcuts ?? []);
   if (shortcuts.length === 0) {
     // No plugin contributed a shortcut. Don't attach a readline interface (and
     // thus never disturb process.stdin) when there is nothing to dispatch.
-    return () => {};
+    return async () => ({ drained: true, idle: Promise.resolve() });
   }
   const dispatcher = createShortcutDispatcher(session, shortcuts);
 
@@ -136,9 +198,41 @@ export function bindCLIShortcuts(
 
   const rl = readline.createInterface({ input: process.stdin });
   rl.on("line", onLine);
+  let closed = false;
 
-  return () => {
-    rl.off("line", onLine);
-    rl.close();
+  return async (options = {}) => {
+    let closeError: unknown;
+    if (!closed) {
+      closed = true;
+      try {
+        rl.off("line", onLine);
+        rl.close();
+      } catch (error) {
+        closeError = error;
+      }
+    }
+    const idle = dispatcher.waitForIdle();
+    const timeoutMs = options.actionDrainTimeoutMs;
+    let drained = true;
+    if (timeoutMs === undefined) {
+      await idle;
+    } else if (timeoutMs === 0) {
+      drained = dispatcher.isIdle();
+    } else {
+      drained = await new Promise<boolean>((resolve) => {
+        let settled = false;
+        const finish = (value: boolean) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          resolve(value);
+        };
+        const timeout = setTimeout(() => finish(false), timeoutMs);
+        timeout.unref?.();
+        void idle.then(() => finish(true));
+      });
+    }
+    if (closeError !== undefined) throw closeError;
+    return { drained, idle };
   };
 }

--- a/packages/ev/src/_internal/build/cli-shortcuts.ts
+++ b/packages/ev/src/_internal/build/cli-shortcuts.ts
@@ -1,18 +1,17 @@
 /**
  * CLI shortcuts engine for `ev dev`.
  *
- * This is the core registration + execution surface only. It deliberately ships
- * no built-in shortcuts (no `r`/`u`/`o`/`c`/`q`): plugins contribute every
- * shortcut via the `configureShortcuts` setup hook. The engine mirrors the
+ * This is the core registration + execution surface only. Core ships no
+ * built-in shortcuts — not even `h` (help) — every key is contributed by a
+ * plugin via the `configureShortcuts` setup hook. The engine mirrors the
  * mechanics of Vite's `bindCLIShortcuts` (readline `'line'` events, an
  * `actionRunning` guard that drops concurrent presses, and a TTY + non-CI
  * no-op default) but is bundler-agnostic and owns no default keys.
  *
- * Scope: this engine targets the standard Node dev server — the utoopack dev
- * worker (the stdin/TTY owner) plus the Hono API server child owned by
- * `restartApiServer`. The wasm/web (Fetch runtime) dev surface has no Node
- * child process and no interactive TTY loop, so the engine stays a no-op
- * there. Pass an explicit `enabled` to force-enable in non-TTY tests.
+ * Scope: this engine targets the standard Node dev server. The wasm/web
+ * (Fetch runtime) dev surface has no Node child process and no interactive TTY
+ * loop, so the engine stays a no-op there. Pass an explicit `enabled` to
+ * force-enable in non-TTY tests.
  *
  * @see package "vite" `packages/vite/src/node/shortcuts.ts` (mechanical reference)
  */
@@ -27,44 +26,92 @@ import type {
 const logger = getLogger(["evjs", "cli-shortcuts"]);
 
 /**
- * Capability handle passed to plugin-registered shortcut actions.
+ * Resolve a pressed input line to its registered shortcut, if any.
  *
- * Canonical alias of {@link PluginDevSession}; defined on the build side so
- * `_internal/build` callers can name it without depending on the plugin
- * surface. `origin` is the client dev server URL reported by
- * `BundlerDevContext.callbacks.onDevServerReady({ origin })`.
+ * Trims whitespace and is case-insensitive. Returns the shortcut even if its
+ * `action` is `undefined`; the dispatcher decides whether to run.
  */
-export type DevSession = PluginDevSession;
+export function resolveShortcut(
+  input: string,
+  shortcuts: readonly PluginCliShortcut[],
+): PluginCliShortcut | undefined {
+  const key = input.trim().toLowerCase();
+  if (key === "") return undefined;
+  return shortcuts.find((shortcut) => shortcut.key === key);
+}
 
-/** A single keyboard shortcut contributed by a plugin. */
-export type CLIShortcut = PluginCliShortcut;
+/**
+ * De-duplicate contributed shortcuts by key, first-writer-wins. A developer's
+ * mental model is that the first plugin to claim a key owns it; later
+ * duplicates are dropped so the dispatch and any help list stay stable.
+ */
+export function dedupeShortcuts(
+  shortcuts: readonly PluginCliShortcut[],
+): PluginCliShortcut[] {
+  const seen = new Set<string>();
+  const deduped: PluginCliShortcut[] = [];
+  for (const shortcut of shortcuts) {
+    if (seen.has(shortcut.key)) continue;
+    seen.add(shortcut.key);
+    deduped.push(shortcut);
+  }
+  return deduped;
+}
+
+export interface ShortcutDispatcher {
+  /**
+   * Dispatch one pressed input line. Returns the matching shortcut when its
+   * `action` ran (or would have run), or `undefined` when nothing matched.
+   * Concurrent presses while an action is already running are dropped.
+   */
+  dispatch(input: string): Promise<PluginCliShortcut | undefined>;
+}
+
+/**
+ * Build a reusable shortcut dispatcher from contributed shortcuts + the live
+ * session. Exposed so the dispatch path (key matching, `actionRunning` guard,
+ * action error handling) is unit-testable without binding a readline interface.
+ * `bindCLIShortcuts` uses this internally.
+ */
+export function createShortcutDispatcher(
+  session: PluginDevSession,
+  shortcuts: readonly PluginCliShortcut[],
+): ShortcutDispatcher {
+  const deduped = dedupeShortcuts(shortcuts);
+  let actionRunning = false;
+  return {
+    async dispatch(input) {
+      if (actionRunning) return undefined;
+      const shortcut = resolveShortcut(input, deduped);
+      if (!shortcut || shortcut.action == null) return undefined;
+      actionRunning = true;
+      try {
+        await shortcut.action(session);
+        return shortcut;
+      } catch (error) {
+        logger.error`Shortcut "${shortcut.key}" failed: ${error}`;
+        return shortcut;
+      } finally {
+        actionRunning = false;
+      }
+    },
+  };
+}
 
 export interface BindCLIShortcutsOptions {
-  /**
-   * Print a one-line hint (`press h + enter to show help`) after binding.
-   * Only meaningful when {@link helpKey} is true.
-   */
-  print?: boolean;
   /** Shortcuts contributed by plugins, in registration order. */
-  customShortcuts?: readonly CLIShortcut[];
-  /**
-   * When true, register an `h` help action that lists every shortcut's key +
-   * description. Default `false` so core owns no keys; plugins may register `h`.
-   */
-  helpKey?: boolean;
-  /**
-   * Readable stream the readline interface binds to. Defaults to
-   * `process.stdin`. Exposed primarily for tests; production callers pass TTY
-   * stdin and let the {@link enabled} gate handle non-TTY/CI no-ops.
-   */
-  input?: NodeJS.ReadableStream | NodeJS.ReadStream;
+  customShortcuts?: readonly PluginCliShortcut[];
 }
 
 /**
  * Bind the shortcuts readline loop to `process.stdin`.
  *
+ * Core never registers a key of its own; if `customShortcuts` is empty, this
+ * is a no-op that attaches no readline interface (so `ev dev` streams are
+ * untouched when no plugin contributes a shortcut).
+ *
  * @param session Capability handle surfaced to plugin actions.
- * @param opts    Plugin-contributed shortcuts + help/print toggles.
+ * @param opts    Plugin-contributed shortcuts.
  * @param enabled Defaults to `process.stdin.isTTY && !process.env.CI`, so the
  *                engine is a no-op in CI / non-TTY / programmatic runs.
  * @returns An unbind function that closes the readline interface. Always a
@@ -72,87 +119,29 @@ export interface BindCLIShortcutsOptions {
  *          invoke it unconditionally on shutdown.
  */
 export function bindCLIShortcuts(
-  session: DevSession,
+  session: PluginDevSession,
   opts: BindCLIShortcutsOptions = {},
   enabled: boolean = process.stdin.isTTY && !process.env.CI,
 ): () => void {
   if (!enabled) return () => {};
 
-  // First-writer-wins: an earlier plugin's key wins; later duplicates are
-  // dropped. This keeps the help list stable and matches a developer's
-  // mental model that the first plugin to claim a key owns it.
-  const seen = new Set<string>();
-  const customShortcuts: readonly CLIShortcut[] = (
-    opts.customShortcuts ?? []
-  ).filter((shortcut) => {
-    if (seen.has(shortcut.key)) return false;
-    seen.add(shortcut.key);
-    return true;
-  });
-
-  const shortcuts = opts.helpKey
-    ? [
-        {
-          key: "h",
-          description: "show help",
-          action() {
-            printShortcutHelp(customShortcuts);
-          },
-        },
-        ...customShortcuts,
-      ]
-    : customShortcuts;
-
+  const shortcuts = dedupeShortcuts(opts.customShortcuts ?? []);
   if (shortcuts.length === 0) {
-    // Nothing to bind. Avoid attaching a readline interface (and stealing
-    // stdin) when no plugin registered a shortcut and help is disabled.
+    // No plugin contributed a shortcut. Don't attach a readline interface (and
+    // thus never disturb process.stdin) when there is nothing to dispatch.
     return () => {};
   }
+  const dispatcher = createShortcutDispatcher(session, shortcuts);
 
-  if (opts.print && opts.helpKey) {
-    logger.info`  ➜  press h + enter to show help`;
-  }
-
-  let actionRunning = false;
-  const rl = readline.createInterface({ input: opts.input ?? process.stdin });
-
-  const onLine = async (raw: string): Promise<void> => {
-    if (actionRunning) return;
-    const input = raw.trim().toLowerCase();
-    if (input === "") return;
-    const shortcut = shortcuts.find((candidate) => candidate.key === input);
-    if (!shortcut || shortcut.action == null) return;
-    actionRunning = true;
-    try {
-      await shortcut.action(session);
-    } catch (error) {
-      logger.error`Shortcut "${shortcut.key}" failed: ${error}`;
-    } finally {
-      actionRunning = false;
-    }
+  const onLine = (raw: string): void => {
+    void dispatcher.dispatch(raw);
   };
 
+  const rl = readline.createInterface({ input: process.stdin });
   rl.on("line", onLine);
 
   return () => {
     rl.off("line", onLine);
     rl.close();
   };
-}
-
-function printShortcutHelp(customShortcuts: readonly CLIShortcut[]): void {
-  const loggedKeys = new Set<string>();
-  const lines: readonly string[] = [
-    "",
-    "  Shortcuts",
-    ...customShortcuts.flatMap((shortcut) => {
-      if (loggedKeys.has(shortcut.key)) return [];
-      loggedKeys.add(shortcut.key);
-      if (shortcut.action == null) return [];
-      return [`  press ${shortcut.key} + enter to ${shortcut.description}`];
-    }),
-  ];
-  for (const line of lines) {
-    logger.info`${line}`;
-  }
 }

--- a/packages/ev/src/_internal/build/cli-shortcuts.ts
+++ b/packages/ev/src/_internal/build/cli-shortcuts.ts
@@ -1,0 +1,158 @@
+/**
+ * CLI shortcuts engine for `ev dev`.
+ *
+ * This is the core registration + execution surface only. It deliberately ships
+ * no built-in shortcuts (no `r`/`u`/`o`/`c`/`q`): plugins contribute every
+ * shortcut via the `configureShortcuts` setup hook. The engine mirrors the
+ * mechanics of Vite's `bindCLIShortcuts` (readline `'line'` events, an
+ * `actionRunning` guard that drops concurrent presses, and a TTY + non-CI
+ * no-op default) but is bundler-agnostic and owns no default keys.
+ *
+ * Scope: this engine targets the standard Node dev server — the utoopack dev
+ * worker (the stdin/TTY owner) plus the Hono API server child owned by
+ * `restartApiServer`. The wasm/web (Fetch runtime) dev surface has no Node
+ * child process and no interactive TTY loop, so the engine stays a no-op
+ * there. Pass an explicit `enabled` to force-enable in non-TTY tests.
+ *
+ * @see package "vite" `packages/vite/src/node/shortcuts.ts` (mechanical reference)
+ */
+
+import readline from "node:readline";
+import { getLogger } from "@logtape/logtape";
+import type {
+  PluginCliShortcut,
+  PluginDevSession,
+} from "../../plugin/index.js";
+
+const logger = getLogger(["evjs", "cli-shortcuts"]);
+
+/**
+ * Capability handle passed to plugin-registered shortcut actions.
+ *
+ * Canonical alias of {@link PluginDevSession}; defined on the build side so
+ * `_internal/build` callers can name it without depending on the plugin
+ * surface. `origin` is the client dev server URL reported by
+ * `BundlerDevContext.callbacks.onDevServerReady({ origin })`.
+ */
+export type DevSession = PluginDevSession;
+
+/** A single keyboard shortcut contributed by a plugin. */
+export type CLIShortcut = PluginCliShortcut;
+
+export interface BindCLIShortcutsOptions {
+  /**
+   * Print a one-line hint (`press h + enter to show help`) after binding.
+   * Only meaningful when {@link helpKey} is true.
+   */
+  print?: boolean;
+  /** Shortcuts contributed by plugins, in registration order. */
+  customShortcuts?: readonly CLIShortcut[];
+  /**
+   * When true, register an `h` help action that lists every shortcut's key +
+   * description. Default `false` so core owns no keys; plugins may register `h`.
+   */
+  helpKey?: boolean;
+  /**
+   * Readable stream the readline interface binds to. Defaults to
+   * `process.stdin`. Exposed primarily for tests; production callers pass TTY
+   * stdin and let the {@link enabled} gate handle non-TTY/CI no-ops.
+   */
+  input?: NodeJS.ReadableStream | NodeJS.ReadStream;
+}
+
+/**
+ * Bind the shortcuts readline loop to `process.stdin`.
+ *
+ * @param session Capability handle surfaced to plugin actions.
+ * @param opts    Plugin-contributed shortcuts + help/print toggles.
+ * @param enabled Defaults to `process.stdin.isTTY && !process.env.CI`, so the
+ *                engine is a no-op in CI / non-TTY / programmatic runs.
+ * @returns An unbind function that closes the readline interface. Always a
+ *          real function (never undefined), even when disabled, so callers can
+ *          invoke it unconditionally on shutdown.
+ */
+export function bindCLIShortcuts(
+  session: DevSession,
+  opts: BindCLIShortcutsOptions = {},
+  enabled: boolean = process.stdin.isTTY && !process.env.CI,
+): () => void {
+  if (!enabled) return () => {};
+
+  // First-writer-wins: an earlier plugin's key wins; later duplicates are
+  // dropped. This keeps the help list stable and matches a developer's
+  // mental model that the first plugin to claim a key owns it.
+  const seen = new Set<string>();
+  const customShortcuts: readonly CLIShortcut[] = (
+    opts.customShortcuts ?? []
+  ).filter((shortcut) => {
+    if (seen.has(shortcut.key)) return false;
+    seen.add(shortcut.key);
+    return true;
+  });
+
+  const shortcuts = opts.helpKey
+    ? [
+        {
+          key: "h",
+          description: "show help",
+          action() {
+            printShortcutHelp(customShortcuts);
+          },
+        },
+        ...customShortcuts,
+      ]
+    : customShortcuts;
+
+  if (shortcuts.length === 0) {
+    // Nothing to bind. Avoid attaching a readline interface (and stealing
+    // stdin) when no plugin registered a shortcut and help is disabled.
+    return () => {};
+  }
+
+  if (opts.print && opts.helpKey) {
+    logger.info`  ➜  press h + enter to show help`;
+  }
+
+  let actionRunning = false;
+  const rl = readline.createInterface({ input: opts.input ?? process.stdin });
+
+  const onLine = async (raw: string): Promise<void> => {
+    if (actionRunning) return;
+    const input = raw.trim().toLowerCase();
+    if (input === "") return;
+    const shortcut = shortcuts.find((candidate) => candidate.key === input);
+    if (!shortcut || shortcut.action == null) return;
+    actionRunning = true;
+    try {
+      await shortcut.action(session);
+    } catch (error) {
+      logger.error`Shortcut "${shortcut.key}" failed: ${error}`;
+    } finally {
+      actionRunning = false;
+    }
+  };
+
+  rl.on("line", onLine);
+
+  return () => {
+    rl.off("line", onLine);
+    rl.close();
+  };
+}
+
+function printShortcutHelp(customShortcuts: readonly CLIShortcut[]): void {
+  const loggedKeys = new Set<string>();
+  const lines: readonly string[] = [
+    "",
+    "  Shortcuts",
+    ...customShortcuts.flatMap((shortcut) => {
+      if (loggedKeys.has(shortcut.key)) return [];
+      loggedKeys.add(shortcut.key);
+      if (shortcut.action == null) return [];
+      return [`  press ${shortcut.key} + enter to ${shortcut.description}`];
+    }),
+  ];
+  for (const line of lines) {
+    logger.info`${line}`;
+  }
+}

--- a/packages/ev/src/_internal/build/cli-shortcuts.ts
+++ b/packages/ev/src/_internal/build/cli-shortcuts.ts
@@ -3,7 +3,7 @@
  *
  * This is the core registration + execution surface only. Core ships no
  * built-in shortcuts — not even `h` (help) — every key is contributed by a
- * plugin via the `configureShortcuts` setup hook. The engine mirrors the
+ * plugin via the descriptor-level `cliShortcuts()` contribution. The engine mirrors the
  * mechanics of Vite's `bindCLIShortcuts` (readline `'line'` events, an
  * `actionRunning` guard that drops concurrent presses, and a TTY + non-CI
  * no-op default) but is bundler-agnostic and owns no default keys.

--- a/packages/ev/src/_internal/build/cli-shortcuts.ts
+++ b/packages/ev/src/_internal/build/cli-shortcuts.ts
@@ -60,37 +60,34 @@ export function dedupeShortcuts(
 
 export interface ShortcutDispatcher {
   /**
-   * Dispatch one pressed input line. Returns the matching shortcut when its
-   * `action` ran (or would have run), or `undefined` when nothing matched.
-   * Concurrent presses while an action is already running are dropped.
+   * Dispatch one pressed input line. Concurrent presses while an action is
+   * already running are dropped. Action errors are swallowed (logged) so the
+   * loop survives a failing shortcut.
    */
-  dispatch(input: string): Promise<PluginCliShortcut | undefined>;
+  dispatch(input: string): Promise<void>;
 }
 
 /**
- * Build a reusable shortcut dispatcher from contributed shortcuts + the live
- * session. Exposed so the dispatch path (key matching, `actionRunning` guard,
- * action error handling) is unit-testable without binding a readline interface.
- * `bindCLIShortcuts` uses this internally.
+ * Build a reusable shortcut dispatcher from already-deduplicated shortcuts +
+ * the live session. Exposed so the dispatch path (key matching,
+ * `actionRunning` guard, action error handling) is unit-testable without
+ * binding a readline interface. `bindCLIShortcuts` uses this internally.
  */
 export function createShortcutDispatcher(
   session: PluginDevSession,
   shortcuts: readonly PluginCliShortcut[],
 ): ShortcutDispatcher {
-  const deduped = dedupeShortcuts(shortcuts);
   let actionRunning = false;
   return {
     async dispatch(input) {
-      if (actionRunning) return undefined;
-      const shortcut = resolveShortcut(input, deduped);
-      if (!shortcut || shortcut.action == null) return undefined;
+      if (actionRunning) return;
+      const shortcut = resolveShortcut(input, shortcuts);
+      if (!shortcut || shortcut.action == null) return;
       actionRunning = true;
       try {
         await shortcut.action(session);
-        return shortcut;
       } catch (error) {
         logger.error`Shortcut "${shortcut.key}" failed: ${error}`;
-        return shortcut;
       } finally {
         actionRunning = false;
       }

--- a/packages/ev/src/_internal/build/commands.ts
+++ b/packages/ev/src/_internal/build/commands.ts
@@ -35,7 +35,7 @@ import {
   preflightBundlerDevUpdate,
 } from "./bundler.js";
 import { resolveBundler, withActiveBundler } from "./bundler-config.js";
-import { bindCLIShortcuts } from "./cli-shortcuts.js";
+import { bindCLIShortcuts, type UnbindCLIShortcuts } from "./cli-shortcuts.js";
 import {
   withPageRoutingDefaults,
   withServerConventionDefaults,
@@ -119,6 +119,8 @@ import {
 import { createProductionOutputTransaction } from "./production-output-transaction.js";
 import { CANONICAL_SERVER_ROUTE_ROOT } from "./server-route-conventions.js";
 import { isInsideCwd } from "./utils.js";
+
+const DEV_CLI_SHORTCUT_ACTION_DRAIN_TIMEOUT_MS = 1_000;
 
 type MutablePluginSetupContext<TBundlerCfg> = Omit<
   PluginSetupContext<TBundlerCfg>,
@@ -481,11 +483,11 @@ function withCliShortcutsOverride<TBundlerCfg>(
   config: Config<TBundlerCfg> | undefined,
   override: false | undefined,
 ): Config<TBundlerCfg> | undefined {
-  if (override !== false || !config) return config;
+  if (override !== false) return config;
   return {
-    ...config,
+    ...(config ?? {}),
     dev: {
-      ...(config.dev ?? {}),
+      ...(config?.dev ?? {}),
       cliShortcuts: false,
     },
   };
@@ -1457,7 +1459,30 @@ async function runDevSession<TBundlerCfg = unknown>(
   const lastScheduledDevChanges = new Map<string, ScheduledDevChangeSnapshot>();
   let pendingForcedConfigReload = false;
   let devSessionEnding = false;
-  let unbindCliShortcuts: (() => void) | undefined;
+  let devServerOrigin: string | undefined;
+  let pendingDevServerOrigin: string | undefined;
+  let devShortcutPublicationSuspended = false;
+  let restoreDevCliShortcutsAfterUpdate = false;
+  let cliShortcutsBinding:
+    | {
+        pluginExecution: DevPluginExecutionSnapshot<TBundlerCfg>;
+        unbind: UnbindCLIShortcuts;
+      }
+    | undefined;
+  const pendingShortcutActionsByPluginExecution = new Map<
+    DevPluginExecutionSnapshot<TBundlerCfg>,
+    Set<Promise<void>>
+  >();
+  const deferredPluginExecutionDisposals = new Map<
+    DevPluginExecutionSnapshot<TBundlerCfg>,
+    () => Promise<void>
+  >();
+  const cliShortcutContributionsByPluginExecution = new WeakMap<
+    DevPluginExecutionSnapshot<TBundlerCfg>,
+    ReturnType<typeof collectConfigureShortcutsHooks<TBundlerCfg>>
+  >();
+  let cliShortcutsRestoreScheduled = false;
+  let cliShortcutsRefreshQueue = Promise.resolve();
   const expectedApiExits = new WeakSet<ApiProcess>();
   const apiProcessController = new DevApiProcessController<ApiProcess>({
     expectExit(process) {
@@ -1594,15 +1619,119 @@ async function runDevSession<TBundlerCfg = unknown>(
     await restartQueue;
   };
 
-  const installDevCliShortcuts = (origin: string): void => {
-    const cliShortcuts = activeConfig.dev.cliShortcuts;
-    if (cliShortcuts === false) return;
+  const trackPendingShortcutAction = (
+    pluginExecution: DevPluginExecutionSnapshot<TBundlerCfg>,
+    idle: Promise<void>,
+  ): void => {
+    let pending = pendingShortcutActionsByPluginExecution.get(pluginExecution);
+    if (!pending) {
+      pending = new Set();
+      pendingShortcutActionsByPluginExecution.set(pluginExecution, pending);
+    }
+    pending.add(idle);
+    void idle.then(() => {
+      pending?.delete(idle);
+      if (pending?.size === 0) {
+        pendingShortcutActionsByPluginExecution.delete(pluginExecution);
+      }
+    });
+  };
+
+  const listPendingShortcutActions = (): Promise<void>[] =>
+    [...pendingShortcutActionsByPluginExecution.values()].flatMap((pending) => [
+      ...pending,
+    ]);
+
+  const scheduleDevCliShortcutsRestore = (
+    pendingShortcutActions: readonly Promise<void>[],
+  ): void => {
+    if (cliShortcutsRestoreScheduled) return;
+    cliShortcutsRestoreScheduled = true;
+    void Promise.all(pendingShortcutActions).then(() => {
+      cliShortcutsRestoreScheduled = false;
+      if (devSessionEnding) return;
+      if (devShortcutPublicationSuspended) {
+        restoreDevCliShortcutsAfterUpdate = true;
+        return;
+      }
+      void refreshDevCliShortcuts().catch((error) => {
+        logger.warn`Plugin CLI shortcuts could not be restored after an action finished: ${error}`;
+      });
+    });
+  };
+
+  const disposeDevPluginExecution = async (
+    pluginExecution: DevPluginExecutionSnapshot<TBundlerCfg>,
+    deferForShortcutActions: boolean,
+  ): Promise<void> => {
+    const existingDeferredDispose =
+      deferredPluginExecutionDisposals.get(pluginExecution);
+    if (existingDeferredDispose) {
+      if (!deferForShortcutActions) await existingDeferredDispose();
+      return;
+    }
+    const pendingShortcutActions = [
+      ...(pendingShortcutActionsByPluginExecution.get(pluginExecution) ?? []),
+    ];
+    const dispose = async () => {
+      await pluginExecution.waitForIdle();
+      await runDisposeHooks(pluginExecution.hooks, pluginExecution.context);
+    };
+    if (deferForShortcutActions && pendingShortcutActions.length > 0) {
+      let disposePromise: Promise<void> | undefined;
+      const disposeOnce = () => {
+        disposePromise ??= dispose().finally(() => {
+          if (
+            deferredPluginExecutionDisposals.get(pluginExecution) ===
+            disposeOnce
+          ) {
+            deferredPluginExecutionDisposals.delete(pluginExecution);
+          }
+        });
+        return disposePromise;
+      };
+      deferredPluginExecutionDisposals.set(pluginExecution, disposeOnce);
+      void Promise.allSettled(pendingShortcutActions)
+        .then(disposeOnce)
+        .catch((error) => {
+          logger.warn`Deferred plugin cleanup after a CLI shortcut action failed: ${error}`;
+        });
+      return;
+    }
+    await dispose();
+  };
+
+  const clearDevCliShortcuts = async (
+    actionDrainTimeoutMs = DEV_CLI_SHORTCUT_ACTION_DRAIN_TIMEOUT_MS,
+  ): Promise<{ drained: boolean; idle?: Promise<void> }> => {
+    const binding = cliShortcutsBinding;
+    cliShortcutsBinding = undefined;
+    if (!binding) return { drained: true };
+    const result = await binding.unbind({ actionDrainTimeoutMs });
+    if (!result.drained) {
+      trackPendingShortcutAction(binding.pluginExecution, result.idle);
+    }
+    return result;
+  };
+
+  const refreshDevCliShortcutsNow = async (
+    origin: string | undefined,
+    cliShortcutsEnabled: boolean,
+    pluginExecution: DevPluginExecutionSnapshot<TBundlerCfg>,
+  ): Promise<void> => {
+    if (origin !== undefined) devServerOrigin = origin;
+    if (!devServerOrigin) return;
+
+    if (!cliShortcutsEnabled) {
+      await clearDevCliShortcuts();
+      return;
+    }
 
     // Plugins contribute every key; core ships none. The session exposes only
     // the dev origin and a shutdown trigger — any richer action (restart,
     // open browser, …) is implemented by plugins from these primitives.
     const session: PluginDevSession = {
-      origin,
+      origin: devServerOrigin,
       close() {
         if (devSessionEnding) return Promise.resolve();
         resolveShutdown?.();
@@ -1610,15 +1739,56 @@ async function runDevSession<TBundlerCfg = unknown>(
       },
     };
 
-    // collectConfigureShortcutsHooks is async; bind as soon as plugins answer.
-    void collectConfigureShortcutsHooks(hooks)
-      .then((customShortcuts) => {
-        if (devSessionEnding) return;
-        unbindCliShortcuts = bindCLIShortcuts(session, { customShortcuts });
-      })
-      .catch((error) => {
-        logger.warn`CLI shortcuts could not be installed: ${error}`;
-      });
+    let customShortcutsPromise =
+      cliShortcutContributionsByPluginExecution.get(pluginExecution);
+    if (!customShortcutsPromise) {
+      customShortcutsPromise = collectConfigureShortcutsHooks(
+        pluginExecution.hooks,
+        {
+          onError(error) {
+            logger.warn`A plugin CLI shortcut contribution was ignored: ${error}`;
+          },
+        },
+      );
+      cliShortcutContributionsByPluginExecution.set(
+        pluginExecution,
+        customShortcutsPromise,
+      );
+    }
+    const customShortcuts = await customShortcutsPromise;
+    if (devSessionEnding) return;
+
+    // Drain the previous snapshot before its plugin hooks are disposed, then
+    // publish the replacement binding for the active snapshot.
+    const previousBinding = await clearDevCliShortcuts();
+    if (devSessionEnding) return;
+    const pendingShortcutActions = listPendingShortcutActions();
+    if (pendingShortcutActions.length > 0) {
+      if (!previousBinding.drained) {
+        logger.warn`Plugin CLI shortcuts were detached, but the running action did not finish within ${DEV_CLI_SHORTCUT_ACTION_DRAIN_TIMEOUT_MS}ms. New shortcuts will be restored after it finishes.`;
+      }
+      scheduleDevCliShortcutsRestore(pendingShortcutActions);
+      return;
+    }
+    cliShortcutsBinding = {
+      pluginExecution,
+      unbind: bindCLIShortcuts(session, { customShortcuts }),
+    };
+  };
+
+  const refreshDevCliShortcuts = (
+    origin: string | undefined = devServerOrigin,
+  ): Promise<void> => {
+    const cliShortcutsEnabled = activeConfig.dev.cliShortcuts !== false;
+    const pluginExecution = activePluginExecution;
+    const refresh = cliShortcutsRefreshQueue.then(
+      () =>
+        refreshDevCliShortcutsNow(origin, cliShortcutsEnabled, pluginExecution),
+      () =>
+        refreshDevCliShortcutsNow(origin, cliShortcutsEnabled, pluginExecution),
+    );
+    cliShortcutsRefreshQueue = refresh.catch(() => {});
+    return refresh;
   };
 
   const loadCurrentConfig = async (
@@ -1780,8 +1950,7 @@ async function runDevSession<TBundlerCfg = unknown>(
         }
         settlement = "committed";
         retirePreviousPluginContext();
-        await previousPluginExecution.waitForIdle();
-        await runDisposeHooks(previousHooks, previousPluginCtx);
+        await disposeDevPluginExecution(previousPluginExecution, true);
       },
       async rollback() {
         if (settlement !== "pending") return;
@@ -2083,6 +2252,7 @@ async function runDevSession<TBundlerCfg = unknown>(
 
   const commitStagedPluginHooks = async (
     stagedPluginHooks: Awaited<ReturnType<typeof stagePluginHooks>> | undefined,
+    nextDevServerOrigin: string | undefined,
     reconcileFrom?: PreparedWatchFilesPlan,
     additionalBaselines: Iterable<PreparedWatchFilesPlan> = [],
   ) => {
@@ -2090,6 +2260,18 @@ async function runDevSession<TBundlerCfg = unknown>(
       ...(stagedPluginHooks?.watchBaselines.values() ?? []),
       ...additionalBaselines,
     ];
+    if (stagedPluginHooks || nextDevServerOrigin !== undefined) {
+      try {
+        await refreshDevCliShortcuts(nextDevServerOrigin);
+      } catch (error) {
+        logger.warn`Plugin CLI shortcuts could not be refreshed: ${error}`;
+        try {
+          await clearDevCliShortcuts();
+        } catch (cleanupError) {
+          logger.warn`Plugin CLI shortcuts could not be cleared after a refresh failure: ${cleanupError}`;
+        }
+      }
+    }
     try {
       await stagedPluginHooks?.commit();
     } catch (error) {
@@ -2100,13 +2282,12 @@ async function runDevSession<TBundlerCfg = unknown>(
     }
   };
 
-  const handleDevDependencyChange = async (
+  const applyDevDependencyChange = async (
     changedFiles: readonly string[],
     forceConfigReload = false,
     devWatchReconcileFrom?: PreparedWatchFilesPlan,
     candidateWatchReconcileFrom?: PreparedWatchFilesPlan,
   ) => {
-    if (devSessionEnding || devWatchFailed) return;
     let currentDevWatchReconcileFrom = devWatchReconcileFrom;
     const configDependencyFiles = new Set([
       ...listConfigDependencyFiles(cwd),
@@ -2658,8 +2839,11 @@ async function runDevSession<TBundlerCfg = unknown>(
       activeServerRouteWatchState = nextServerRouteWatchState;
       commitCandidateConfigDependencies();
       commitCandidateObservedSourceDependencies();
+      const committedDevServerOrigin = pendingDevServerOrigin;
+      pendingDevServerOrigin = undefined;
       await commitStagedPluginHooks(
         stagedPluginHooks,
+        committedDevServerOrigin,
         currentDevWatchReconcileFrom,
         [...candidateRouteWatchBaselines, ...candidateSourceBaselines.values()],
       );
@@ -2681,6 +2865,34 @@ async function runDevSession<TBundlerCfg = unknown>(
         "[evjs] Framework dev state update failed and rollback also failed.",
       );
     }
+  };
+
+  const handleDevDependencyChange = (
+    changedFiles: readonly string[],
+    forceConfigReload = false,
+    devWatchReconcileFrom?: PreparedWatchFilesPlan,
+    candidateWatchReconcileFrom?: PreparedWatchFilesPlan,
+  ): Promise<void> => {
+    if (devSessionEnding || devWatchFailed) return Promise.resolve();
+    devShortcutPublicationSuspended = true;
+    restoreDevCliShortcutsAfterUpdate = false;
+    pendingDevServerOrigin = undefined;
+    return applyDevDependencyChange(
+      changedFiles,
+      forceConfigReload,
+      devWatchReconcileFrom,
+      candidateWatchReconcileFrom,
+    ).finally(() => {
+      const restoreShortcuts = restoreDevCliShortcutsAfterUpdate;
+      restoreDevCliShortcutsAfterUpdate = false;
+      pendingDevServerOrigin = undefined;
+      devShortcutPublicationSuspended = false;
+      if (restoreShortcuts && !devSessionEnding) {
+        void refreshDevCliShortcuts().catch((error) => {
+          logger.warn`Plugin CLI shortcuts could not be restored after a framework update: ${error}`;
+        });
+      }
+    });
   };
 
   function overlapsCandidateWatchDependency(changedFile: string): boolean {
@@ -2757,7 +2969,10 @@ async function runDevSession<TBundlerCfg = unknown>(
     await runCleanupTasks([
       () => clearDevDependencyWatcher(),
       () => clearCandidateDependencyWatcher(),
-      () => unbindCliShortcuts?.(),
+      async () => {
+        await cliShortcutsRefreshQueue;
+        await clearDevCliShortcuts(0);
+      },
       () => devController?.close?.(),
       () => devUpdateQueue.catch(() => {}),
       () => outputCycleQueue,
@@ -2778,8 +2993,12 @@ async function runDevSession<TBundlerCfg = unknown>(
         const execution = activePluginExecution;
         retireBundlerGeneration(activeBundlerGeneration);
         retirePluginContext();
-        await execution.waitForIdle();
-        await runDisposeHooks(execution.hooks, execution.context);
+        await runCleanupTasks([
+          ...[...deferredPluginExecutionDisposals.values()].map(
+            (dispose) => dispose,
+          ),
+          () => disposeDevPluginExecution(execution, false),
+        ]);
       },
     ]);
   };
@@ -2798,13 +3017,17 @@ async function runDevSession<TBundlerCfg = unknown>(
         plan: activePlan,
         addWatchFile: addBundlerConfigWatchFile,
         callbacks: {
-          onDevServerReady(context) {
+          async onDevServerReady(context) {
             logger.info`${formatDevServerReady(
               context,
               activeConfig,
               activePlan,
             )}`;
-            installDevCliShortcuts(context.origin);
+            if (devShortcutPublicationSuspended) {
+              pendingDevServerOrigin = context.origin;
+              return;
+            }
+            await refreshDevCliShortcuts(context.origin);
           },
           async onBuildFacts(generation, bundlerFacts, options) {
             const { isRebuild } = options;

--- a/packages/ev/src/_internal/build/commands.ts
+++ b/packages/ev/src/_internal/build/commands.ts
@@ -19,6 +19,8 @@ import {
 } from "../../config/index.js";
 import type {
   CliFlags,
+  Plugin,
+  PluginCliShortcut,
   PluginDevSession,
   PluginHooks,
   PluginSetupContext,
@@ -96,7 +98,7 @@ import {
 } from "./page-route-types.js";
 import { type CreateBuildPlanOptions, diffBuildPlan } from "./plan/index.js";
 import {
-  collectConfigureShortcutsHooks,
+  collectPluginCliShortcuts,
   collectPluginHooks,
   hasSamePluginIdentity,
   orderPluginsByDependencies,
@@ -137,6 +139,7 @@ interface DevCycleTracker {
 interface DevPluginExecutionSnapshot<TBundlerCfg> extends DevCycleTracker {
   readonly hooks: PluginHooks<TBundlerCfg>[];
   readonly context: MutablePluginSetupContext<TBundlerCfg>;
+  collectShortcutContributions(): Promise<PluginCliShortcut[]>;
 }
 
 interface ScheduledDevChangeSnapshot {
@@ -291,12 +294,22 @@ function createDevFrameworkOutputTransaction(
 }
 
 function createDevPluginExecutionSnapshot<TBundlerCfg>(
+  plugins: readonly Plugin<TBundlerCfg>[],
   hooks: PluginHooks<TBundlerCfg>[],
   context: MutablePluginSetupContext<TBundlerCfg>,
 ): DevPluginExecutionSnapshot<TBundlerCfg> {
+  let shortcutContributions: Promise<PluginCliShortcut[]> | undefined;
   return {
     hooks: [...hooks],
     context,
+    collectShortcutContributions() {
+      shortcutContributions ??= collectPluginCliShortcuts(plugins, {
+        onError(error) {
+          logger.warn`A plugin CLI shortcut contribution was ignored: ${error}`;
+        },
+      });
+      return shortcutContributions;
+    },
     ...createDevCycleTracker(),
   };
 }
@@ -1245,6 +1258,7 @@ async function runDevSession<TBundlerCfg = unknown>(
     throw error;
   }
   let activePluginExecution = createDevPluginExecutionSnapshot(
+    activeConfig.plugins,
     hooks,
     pluginCtx,
   );
@@ -1477,10 +1491,6 @@ async function runDevSession<TBundlerCfg = unknown>(
     DevPluginExecutionSnapshot<TBundlerCfg>,
     () => Promise<void>
   >();
-  const cliShortcutContributionsByPluginExecution = new WeakMap<
-    DevPluginExecutionSnapshot<TBundlerCfg>,
-    ReturnType<typeof collectConfigureShortcutsHooks<TBundlerCfg>>
-  >();
   let cliShortcutsRestoreScheduled = false;
   let cliShortcutsRefreshQueue = Promise.resolve();
   const expectedApiExits = new WeakSet<ApiProcess>();
@@ -1647,7 +1657,7 @@ async function runDevSession<TBundlerCfg = unknown>(
   ): void => {
     if (cliShortcutsRestoreScheduled) return;
     cliShortcutsRestoreScheduled = true;
-    void Promise.all(pendingShortcutActions).then(() => {
+    void Promise.allSettled(pendingShortcutActions).then(() => {
       cliShortcutsRestoreScheduled = false;
       if (devSessionEnding) return;
       if (devShortcutPublicationSuspended) {
@@ -1739,23 +1749,8 @@ async function runDevSession<TBundlerCfg = unknown>(
       },
     };
 
-    let customShortcutsPromise =
-      cliShortcutContributionsByPluginExecution.get(pluginExecution);
-    if (!customShortcutsPromise) {
-      customShortcutsPromise = collectConfigureShortcutsHooks(
-        pluginExecution.hooks,
-        {
-          onError(error) {
-            logger.warn`A plugin CLI shortcut contribution was ignored: ${error}`;
-          },
-        },
-      );
-      cliShortcutContributionsByPluginExecution.set(
-        pluginExecution,
-        customShortcutsPromise,
-      );
-    }
-    const customShortcuts = await customShortcutsPromise;
+    const customShortcuts =
+      await pluginExecution.collectShortcutContributions();
     if (devSessionEnding) return;
 
     // Drain the previous snapshot before its plugin hooks are disposed, then
@@ -1922,6 +1917,7 @@ async function runDevSession<TBundlerCfg = unknown>(
       throw error;
     }
     const nextPluginExecution = createDevPluginExecutionSnapshot(
+      nextConfig.plugins,
       nextHooks,
       nextPluginCtx,
     );

--- a/packages/ev/src/_internal/build/commands.ts
+++ b/packages/ev/src/_internal/build/commands.ts
@@ -34,6 +34,7 @@ import {
   preflightBundlerDevUpdate,
 } from "./bundler.js";
 import { resolveBundler, withActiveBundler } from "./bundler-config.js";
+import { bindCLIShortcuts, type DevSession } from "./cli-shortcuts.js";
 import {
   withPageRoutingDefaults,
   withServerConventionDefaults,
@@ -94,6 +95,7 @@ import {
 } from "./page-route-types.js";
 import { type CreateBuildPlanOptions, diffBuildPlan } from "./plan/index.js";
 import {
+  collectConfigureShortcutsHooks,
   collectPluginHooks,
   hasSamePluginIdentity,
   orderPluginsByDependencies,
@@ -391,6 +393,13 @@ export interface DevOptions<TBundlerCfg = unknown> {
   flags?: CliFlags;
   /** Reload the initial config through loadConfig inside the watcher handshake. */
   reloadInitialConfig?: boolean;
+  /**
+   * Override `dev.cliShortcuts`. Set `false` to disable the interactive CLI
+   * shortcuts engine regardless of config (mirrors `ev dev --no-shortcuts`).
+   * `true` is ignored (the config default is already on); undefined defers to
+   * `ev.config.ts` → resolved `dev.cliShortcuts`.
+   */
+  cliShortcuts?: boolean;
   loadConfig?: (
     cwd: string,
     context?: {
@@ -459,6 +468,26 @@ interface DevApiRuntimeState<TBundlerCfg> {
   frameworkRuntime: ReturnType<typeof createFrameworkRuntime> | undefined;
   plan: BuildPlan;
   serverEntry: string | undefined;
+}
+
+/**
+ * Apply the programmatic `cliShortcuts` override (e.g. `ev dev --no-shortcuts`)
+ * to the configure-hook output before resolution. `false` forces the engine
+ * off; any other value defers to the user's `ev.config.ts` →
+ * `dev.cliShortcuts`. Returns the input untouched when there is nothing to do.
+ */
+function withCliShortcutsOverride<TBundlerCfg>(
+  config: Config<TBundlerCfg> | undefined,
+  override: boolean | undefined,
+): Config<TBundlerCfg> | undefined {
+  if (override !== false || !config) return config;
+  return {
+    ...config,
+    dev: {
+      ...(config.dev ?? {}),
+      cliShortcuts: false,
+    },
+  };
 }
 
 async function createGeneratedDevStateSnapshot(
@@ -998,11 +1027,14 @@ async function runDev<TBundlerCfg = unknown>(
           },
         })
       : userConfig;
-  const configuredConfig = await runConfigureHooks(initialUserConfig, {
-    mode: "development",
-    cwd,
-    flags,
-  });
+  const configuredConfig = withCliShortcutsOverride(
+    await runConfigureHooks(initialUserConfig, {
+      mode: "development",
+      cwd,
+      flags,
+    }),
+    options?.cliShortcuts,
+  );
   const baseResolvedConfig = resolveConfig(configuredConfig);
   const pageRoot = baseResolvedConfig.application
     ? path.resolve(cwd, baseResolvedConfig.application.pageRoot)
@@ -1424,6 +1456,7 @@ async function runDevSession<TBundlerCfg = unknown>(
   const lastScheduledDevChanges = new Map<string, ScheduledDevChangeSnapshot>();
   let pendingForcedConfigReload = false;
   let devSessionEnding = false;
+  let unbindCliShortcuts: (() => void) | undefined;
   const expectedApiExits = new WeakSet<ApiProcess>();
   const apiProcessController = new DevApiProcessController<ApiProcess>({
     expectExit(process) {
@@ -1560,6 +1593,65 @@ async function runDevSession<TBundlerCfg = unknown>(
     await restartQueue;
   };
 
+  const installDevCliShortcuts = (origin: string): void => {
+    const cliShortcuts = activeConfig.dev.cliShortcuts;
+    if (cliShortcuts === false) return;
+
+    // Plugins contribute every key (core ships none). The session's
+    // restartServerRuntime re-enters the same serialized restart path the
+    // framework uses when a server bundle becomes ready, rebuilt from the
+    // active generation state so it reflects the latest server entry.
+    const session: DevSession = {
+      origin,
+      restartServerRuntime() {
+        const state = (() => {
+          const generationState = getBundlerGenerationStateForFacts(
+            activeBundlerGeneration,
+          );
+          if (!generationState) return undefined;
+          const runtimeState: DevApiRuntimeState<TBundlerCfg> = {
+            config: generationState.config,
+            frameworkRuntime: generationState.frameworkRuntime,
+            plan: generationState.plan,
+            serverEntry: generationState.serverEntry,
+          };
+          return runtimeState;
+        })();
+        if (!state) return Promise.resolve();
+        restartQueue = restartQueue
+          .catch(() => {})
+          .then(() => {
+            if (devSessionEnding) return;
+            return restartApiServer(state);
+          })
+          .then(() => {});
+        return restartQueue.then(
+          () => undefined,
+          () => undefined,
+        );
+      },
+      close() {
+        if (devSessionEnding) return Promise.resolve();
+        resolveShutdown?.();
+        return Promise.resolve();
+      },
+    };
+
+    // collectConfigureShortcuts Hooks is async; bind as soon as plugins answer.
+    void collectConfigureShortcutsHooks(hooks)
+      .then((customShortcuts) => {
+        if (devSessionEnding) return;
+        unbindCliShortcuts = bindCLIShortcuts(session, {
+          print: cliShortcuts.print,
+          customShortcuts,
+          helpKey: true,
+        });
+      })
+      .catch((error) => {
+        logger.warn`CLI shortcuts could not be installed: ${error}`;
+      });
+  };
+
   const loadCurrentConfig = async (
     reloadConfiguredConfig: boolean,
     onRouteWatchState?: (state: {
@@ -1568,22 +1660,25 @@ async function runDevSession<TBundlerCfg = unknown>(
     }) => void,
     onConfigDependency?: (file: string) => void,
   ) => {
-    const nextConfiguredConfig = reloadConfiguredConfig
-      ? await runConfigureHooks(
-          options?.loadConfig
-            ? await options.loadConfig(cwd, {
-                onDependency(file) {
-                  onConfigDependency?.(file);
-                },
-              })
-            : userConfig,
-          {
-            mode: "development",
-            cwd,
-            flags,
-          },
-        )
-      : activeConfiguredConfig;
+    const nextConfiguredConfig = withCliShortcutsOverride(
+      reloadConfiguredConfig
+        ? await runConfigureHooks(
+            options?.loadConfig
+              ? await options.loadConfig(cwd, {
+                  onDependency(file) {
+                    onConfigDependency?.(file);
+                  },
+                })
+              : userConfig,
+            {
+              mode: "development",
+              cwd,
+              flags,
+            },
+          )
+        : activeConfiguredConfig,
+      options?.cliShortcuts,
+    );
     const nextBaseResolvedConfig = resolveConfig(nextConfiguredConfig);
     const nextPageRoot = nextBaseResolvedConfig.application
       ? path.resolve(cwd, nextBaseResolvedConfig.application.pageRoot)
@@ -2693,6 +2788,7 @@ async function runDevSession<TBundlerCfg = unknown>(
     await runCleanupTasks([
       () => clearDevDependencyWatcher(),
       () => clearCandidateDependencyWatcher(),
+      () => unbindCliShortcuts?.(),
       () => devController?.close?.(),
       () => devUpdateQueue.catch(() => {}),
       () => outputCycleQueue,
@@ -2739,6 +2835,7 @@ async function runDevSession<TBundlerCfg = unknown>(
               activeConfig,
               activePlan,
             )}`;
+            installDevCliShortcuts(context.origin);
           },
           async onBuildFacts(generation, bundlerFacts, options) {
             const { isRebuild } = options;

--- a/packages/ev/src/_internal/build/commands.ts
+++ b/packages/ev/src/_internal/build/commands.ts
@@ -19,6 +19,7 @@ import {
 } from "../../config/index.js";
 import type {
   CliFlags,
+  PluginDevSession,
   PluginHooks,
   PluginSetupContext,
 } from "../../plugin/index.js";
@@ -34,7 +35,7 @@ import {
   preflightBundlerDevUpdate,
 } from "./bundler.js";
 import { resolveBundler, withActiveBundler } from "./bundler-config.js";
-import { bindCLIShortcuts, type DevSession } from "./cli-shortcuts.js";
+import { bindCLIShortcuts } from "./cli-shortcuts.js";
 import {
   withPageRoutingDefaults,
   withServerConventionDefaults,
@@ -394,12 +395,12 @@ export interface DevOptions<TBundlerCfg = unknown> {
   /** Reload the initial config through loadConfig inside the watcher handshake. */
   reloadInitialConfig?: boolean;
   /**
-   * Override `dev.cliShortcuts`. Set `false` to disable the interactive CLI
-   * shortcuts engine regardless of config (mirrors `ev dev --no-shortcuts`).
-   * `true` is ignored (the config default is already on); undefined defers to
-   * `ev.config.ts` → resolved `dev.cliShortcuts`.
+   * Disable the interactive CLI shortcuts engine regardless of
+   * `ev.config.ts` (mirrors `ev dev --no-shortcuts`). Only `false` is
+   * meaningful; undefined defers to the resolved `dev.cliShortcuts` value
+   * (default on).
    */
-  cliShortcuts?: boolean;
+  cliShortcuts?: false;
   loadConfig?: (
     cwd: string,
     context?: {
@@ -473,12 +474,12 @@ interface DevApiRuntimeState<TBundlerCfg> {
 /**
  * Apply the programmatic `cliShortcuts` override (e.g. `ev dev --no-shortcuts`)
  * to the configure-hook output before resolution. `false` forces the engine
- * off; any other value defers to the user's `ev.config.ts` →
- * `dev.cliShortcuts`. Returns the input untouched when there is nothing to do.
+ * off; undefined defers to the user's `ev.config.ts` → `dev.cliShortcuts`.
+ * Returns the input untouched when there is nothing to do.
  */
 function withCliShortcutsOverride<TBundlerCfg>(
   config: Config<TBundlerCfg> | undefined,
-  override: boolean | undefined,
+  override: false | undefined,
 ): Config<TBundlerCfg> | undefined {
   if (override !== false || !config) return config;
   return {
@@ -1597,39 +1598,11 @@ async function runDevSession<TBundlerCfg = unknown>(
     const cliShortcuts = activeConfig.dev.cliShortcuts;
     if (cliShortcuts === false) return;
 
-    // Plugins contribute every key (core ships none). The session's
-    // restartServerRuntime re-enters the same serialized restart path the
-    // framework uses when a server bundle becomes ready, rebuilt from the
-    // active generation state so it reflects the latest server entry.
-    const session: DevSession = {
+    // Plugins contribute every key; core ships none. The session exposes only
+    // the dev origin and a shutdown trigger — any richer action (restart,
+    // open browser, …) is implemented by plugins from these primitives.
+    const session: PluginDevSession = {
       origin,
-      restartServerRuntime() {
-        const state = (() => {
-          const generationState = getBundlerGenerationStateForFacts(
-            activeBundlerGeneration,
-          );
-          if (!generationState) return undefined;
-          const runtimeState: DevApiRuntimeState<TBundlerCfg> = {
-            config: generationState.config,
-            frameworkRuntime: generationState.frameworkRuntime,
-            plan: generationState.plan,
-            serverEntry: generationState.serverEntry,
-          };
-          return runtimeState;
-        })();
-        if (!state) return Promise.resolve();
-        restartQueue = restartQueue
-          .catch(() => {})
-          .then(() => {
-            if (devSessionEnding) return;
-            return restartApiServer(state);
-          })
-          .then(() => {});
-        return restartQueue.then(
-          () => undefined,
-          () => undefined,
-        );
-      },
       close() {
         if (devSessionEnding) return Promise.resolve();
         resolveShutdown?.();
@@ -1637,15 +1610,11 @@ async function runDevSession<TBundlerCfg = unknown>(
       },
     };
 
-    // collectConfigureShortcuts Hooks is async; bind as soon as plugins answer.
+    // collectConfigureShortcutsHooks is async; bind as soon as plugins answer.
     void collectConfigureShortcutsHooks(hooks)
       .then((customShortcuts) => {
         if (devSessionEnding) return;
-        unbindCliShortcuts = bindCLIShortcuts(session, {
-          print: cliShortcuts.print,
-          customShortcuts,
-          helpKey: true,
-        });
+        unbindCliShortcuts = bindCLIShortcuts(session, { customShortcuts });
       })
       .catch((error) => {
         logger.warn`CLI shortcuts could not be installed: ${error}`;

--- a/packages/ev/src/_internal/build/plugin-lifecycle.ts
+++ b/packages/ev/src/_internal/build/plugin-lifecycle.ts
@@ -22,9 +22,24 @@ import type {
   TransformOutputContext,
 } from "../../plugin/index.js";
 import type { BundlerEmittedFiles } from "./bundler.js";
+import { normalizeShortcutKey } from "./cli-shortcuts.js";
 import { assertAfterBuildDeploymentOutputsAvailable } from "./deployment-output-reservations.js";
 
 const typedPluginHookNames: readonly (keyof PluginHooks)[] = PLUGIN_HOOK_NAMES;
+interface PluginHookOwnership {
+  pluginIds: Set<string>;
+  shortcutOwner?: string;
+  shortcutDescriptor?: Readonly<{
+    configurable: boolean;
+    enumerable: boolean;
+    value: NonNullable<PluginHooks["configureShortcuts"]>;
+    writable: boolean;
+  }>;
+}
+
+const pluginHookOwnership = new WeakMap<object, PluginHookOwnership>();
+
+class ReusedPluginHooksError extends Error {}
 
 interface PluginOrderDeclaration {
   id: string;
@@ -194,8 +209,14 @@ export async function collectPluginHooks<TBundlerCfg>(
       try {
         hooks = resolvePluginSetupHooks<TBundlerCfg>(plugin.id, setupResult);
       } catch (error) {
+        const setupResultAlreadyOwned =
+          setupResult !== null &&
+          typeof setupResult === "object" &&
+          pluginHookOwnership.has(setupResult);
         const rollbackHooks =
-          captureSetupRollbackHooks<TBundlerCfg>(setupResult);
+          error instanceof ReusedPluginHooksError || setupResultAlreadyOwned
+            ? undefined
+            : captureSetupRollbackHooks<TBundlerCfg>(setupResult);
         if (rollbackHooks) allHooks.push(rollbackHooks);
         throw error;
       }
@@ -266,6 +287,18 @@ function resolvePluginSetupHooks<TBundlerCfg>(
   }
 
   const hookConfig = hooks as Record<string, unknown>;
+  const existingOwnership = pluginHookOwnership.get(hookConfig);
+  if (existingOwnership?.shortcutOwner !== undefined) {
+    if (existingOwnership.shortcutOwner !== pluginId) {
+      throw new ReusedPluginHooksError(
+        `[evjs] Plugin "${pluginId}" setup hook cannot reuse shortcut hooks owned by plugin "${existingOwnership.shortcutOwner}". Hooks objects containing configureShortcuts cannot be shared by distinct plugin ids.`,
+      );
+    }
+    throw new ReusedPluginHooksError(
+      `[evjs] Plugin "${pluginId}" setup hook cannot reuse a hooks object containing configureShortcuts across setup snapshots. Return a fresh hooks object from each setup call.`,
+    );
+  }
+  let shortcutDescriptor: PluginHookOwnership["shortcutDescriptor"];
   for (const key of Reflect.ownKeys(hookConfig)) {
     if (typeof key !== "string") {
       throw new Error(
@@ -289,7 +322,40 @@ function resolvePluginSetupHooks<TBundlerCfg>(
         `[evjs] Plugin "${pluginId}" setup hook returned ${key} must be a function.`,
       );
     }
+    if (
+      key === "configureShortcuts" &&
+      typeof descriptor.value === "function"
+    ) {
+      shortcutDescriptor = Object.freeze({
+        configurable: descriptor.configurable ?? false,
+        enumerable: descriptor.enumerable ?? false,
+        value: descriptor.value as NonNullable<
+          PluginHooks["configureShortcuts"]
+        >,
+        writable: descriptor.writable ?? false,
+      });
+    }
   }
+  if (shortcutDescriptor && existingOwnership) {
+    const existingShortcutOwner = [...existingOwnership.pluginIds].find(
+      (existingPluginId) => existingPluginId !== pluginId,
+    );
+    if (existingShortcutOwner !== undefined) {
+      throw new ReusedPluginHooksError(
+        `[evjs] Plugin "${pluginId}" setup hook cannot reuse shortcut hooks owned by plugin "${existingShortcutOwner}". Hooks objects containing configureShortcuts cannot be shared by distinct plugin ids.`,
+      );
+    }
+    throw new ReusedPluginHooksError(
+      `[evjs] Plugin "${pluginId}" setup hook cannot reuse a hooks object containing configureShortcuts across setup snapshots. Return a fresh hooks object from each setup call.`,
+    );
+  }
+  const ownership = existingOwnership ?? { pluginIds: new Set<string>() };
+  ownership.pluginIds.add(pluginId);
+  if (shortcutDescriptor) {
+    ownership.shortcutOwner = pluginId;
+    ownership.shortcutDescriptor = shortcutDescriptor;
+  }
+  pluginHookOwnership.set(hookConfig, ownership);
   return hookConfig as PluginHooks<TBundlerCfg>;
 }
 
@@ -542,25 +608,172 @@ export async function runAfterBuildHooks<TBundlerCfg>(
 /**
  * Collect every plugin-contributed CLI shortcut, in plugin order.
  *
- * `configureShortcuts` runs at setup time, so the returned descriptors are
- * static; shortcut `action` callbacks receive the live {@link PluginDevSession}
- * only when the key is later pressed.
+ * `configureShortcuts` runs once per setup snapshot, so the returned
+ * descriptors are static for that snapshot; shortcut `action` callbacks
+ * receive the live {@link PluginDevSession} only when the key is later pressed.
  */
 export async function collectConfigureShortcutsHooks<TBundlerCfg>(
   hooks: PluginHooks<TBundlerCfg>[],
+  options: { onError?: (error: unknown) => void } = {},
 ): Promise<PluginCliShortcut[]> {
   const collected: PluginCliShortcut[] = [];
   // Snapshot so a config-reload `hooks.splice(...)` cannot mutate the array
   // mid-iteration across the per-hook `await` (see runDisposeHooks for the same
   // pattern).
+  const seenShortcutHooks = new WeakSet<object>();
   for (const hook of [...hooks]) {
-    if (!hook.configureShortcuts) continue;
-    const shortcuts = await hook.configureShortcuts();
-    for (const shortcut of shortcuts) {
-      collected.push(shortcut);
+    if (seenShortcutHooks.has(hook)) continue;
+    seenShortcutHooks.add(hook);
+    try {
+      const ownership = pluginHookOwnership.get(hook);
+      const descriptor = Object.getOwnPropertyDescriptor(
+        hook,
+        "configureShortcuts",
+      );
+      const expectedDescriptor = ownership?.shortcutDescriptor;
+      let configureShortcuts: NonNullable<PluginHooks["configureShortcuts"]>;
+      if (ownership?.shortcutOwner !== undefined) {
+        if (
+          !descriptor ||
+          !expectedDescriptor ||
+          !("value" in descriptor) ||
+          descriptor.value !== expectedDescriptor.value ||
+          (descriptor.configurable ?? false) !==
+            expectedDescriptor.configurable ||
+          (descriptor.enumerable ?? false) !== expectedDescriptor.enumerable ||
+          (descriptor.writable ?? false) !== expectedDescriptor.writable
+        ) {
+          throw new ReusedPluginHooksError(
+            `[evjs] Plugin "${ownership.shortcutOwner}" configureShortcuts hook was mutated after setup validation. Return a fresh hooks object from setup instead of mutating a validated snapshot.`,
+          );
+        }
+        configureShortcuts = expectedDescriptor.value;
+      } else {
+        if (
+          !descriptor ||
+          ("value" in descriptor && descriptor.value === undefined)
+        ) {
+          continue;
+        }
+        if (
+          !descriptor.enumerable ||
+          !("value" in descriptor) ||
+          typeof descriptor.value !== "function"
+        ) {
+          throw new ReusedPluginHooksError(
+            `[evjs] configureShortcuts added after setup validation must be an enumerable own data function. Return a fresh hooks object from setup.`,
+          );
+        }
+        if (ownership) {
+          throw new ReusedPluginHooksError(
+            `[evjs] Hooks object owned by ${[...ownership.pluginIds]
+              .map((pluginId) => `"${pluginId}"`)
+              .join(
+                ", ",
+              )} cannot add configureShortcuts after setup validation. Return a fresh hooks object from setup.`,
+          );
+        }
+        configureShortcuts = descriptor.value as NonNullable<
+          PluginHooks["configureShortcuts"]
+        >;
+      }
+      const pluginId = ownership?.shortcutOwner ?? "unknown";
+      let value: unknown;
+      try {
+        value = await Reflect.apply(configureShortcuts, hook, []);
+      } catch (error) {
+        throw new Error(
+          `[evjs] Plugin "${pluginId}" configureShortcuts hook failed: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error },
+        );
+      }
+      const shortcuts = resolvePluginCliShortcuts(pluginId, value);
+      collected.push(...shortcuts);
+    } catch (error) {
+      if (!options.onError) throw error;
+      options.onError(error);
     }
   }
   return collected;
+}
+
+function resolvePluginCliShortcuts(
+  pluginId: string,
+  value: unknown,
+): PluginCliShortcut[] {
+  if (!Array.isArray(value)) {
+    throw new Error(
+      `[evjs] Plugin "${pluginId}" configureShortcuts hook must return an array.`,
+    );
+  }
+
+  const resolved: PluginCliShortcut[] = [];
+  for (let index = 0; index < value.length; index++) {
+    const path = `Plugin "${pluginId}" configureShortcuts item ${index}`;
+    const itemDescriptor = Object.getOwnPropertyDescriptor(
+      value,
+      String(index),
+    );
+    if (!itemDescriptor?.enumerable || !("value" in itemDescriptor)) {
+      throw new Error(`[evjs] ${path} must be an array data property.`);
+    }
+    const shortcut = itemDescriptor.value;
+    if (
+      !shortcut ||
+      typeof shortcut !== "object" ||
+      Array.isArray(shortcut) ||
+      !isPlainObject(shortcut)
+    ) {
+      throw new Error(`[evjs] ${path} must be a shortcut object.`);
+    }
+
+    const record = shortcut as Record<string, unknown>;
+    for (const key of Reflect.ownKeys(record)) {
+      const descriptor = Object.getOwnPropertyDescriptor(record, key);
+      if (
+        typeof key !== "string" ||
+        !["key", "description", "action"].includes(key) ||
+        !descriptor?.enumerable ||
+        !("value" in descriptor)
+      ) {
+        throw new Error(
+          `[evjs] ${path} must contain only key, description, and optional action data properties.`,
+        );
+      }
+    }
+
+    if (typeof record.key !== "string") {
+      throw new Error(`[evjs] ${path}.key must be a string.`);
+    }
+    let key: string;
+    try {
+      key = normalizeShortcutKey(record.key);
+    } catch {
+      throw new Error(
+        `[evjs] ${path}.key must be a single non-whitespace character.`,
+      );
+    }
+    if (
+      typeof record.description !== "string" ||
+      record.description.trim() === ""
+    ) {
+      throw new Error(`[evjs] ${path}.description must be a non-empty string.`);
+    }
+    if (record.action !== undefined && typeof record.action !== "function") {
+      throw new Error(
+        `[evjs] ${path}.action must be a function when provided.`,
+      );
+    }
+
+    resolved.push(
+      Object.freeze({
+        key,
+        description: record.description,
+        ...(record.action === undefined ? {} : { action: record.action }),
+      }) as PluginCliShortcut,
+    );
+  }
+  return resolved;
 }
 
 export async function runDisposeHooks<TBundlerCfg>(

--- a/packages/ev/src/_internal/build/plugin-lifecycle.ts
+++ b/packages/ev/src/_internal/build/plugin-lifecycle.ts
@@ -551,7 +551,10 @@ export async function collectConfigureShortcutsHooks<TBundlerCfg>(
   hooks: PluginHooks<TBundlerCfg>[],
 ): Promise<PluginCliShortcut[]> {
   const collected: PluginCliShortcut[] = [];
-  for (const hook of hooks) {
+  // Snapshot so a config-reload `hooks.splice(...)` cannot mutate the array
+  // mid-iteration across the per-hook `await` (see runDisposeHooks for the same
+  // pattern).
+  for (const hook of [...hooks]) {
     if (!hook.configureShortcuts) continue;
     const shortcuts = await hook.configureShortcuts();
     for (const shortcut of shortcuts ?? []) {

--- a/packages/ev/src/_internal/build/plugin-lifecycle.ts
+++ b/packages/ev/src/_internal/build/plugin-lifecycle.ts
@@ -14,6 +14,7 @@ import type {
   BuildResult,
   CliFlags,
   Plugin,
+  PluginCliShortcut,
   PluginConfigureContext,
   PluginConfigureInput,
   PluginHooks,
@@ -536,6 +537,28 @@ export async function runAfterBuildHooks<TBundlerCfg>(
   for (const hook of hooks) {
     await hook.afterBuild?.(structuredClone(snapshot));
   }
+}
+
+/**
+ * Collect every plugin-contributed CLI shortcut, in plugin order.
+ *
+ * `configureShortcuts` runs at setup time, so the returned descriptors are
+ * static; shortcut `action` callbacks receive the live {@link PluginDevSession}
+ * only when the key is later pressed. A returned `undefined` shortcut array is
+ * treated as "no shortcuts from this plugin".
+ */
+export async function collectConfigureShortcutsHooks<TBundlerCfg>(
+  hooks: PluginHooks<TBundlerCfg>[],
+): Promise<PluginCliShortcut[]> {
+  const collected: PluginCliShortcut[] = [];
+  for (const hook of hooks) {
+    if (!hook.configureShortcuts) continue;
+    const shortcuts = await hook.configureShortcuts();
+    for (const shortcut of shortcuts ?? []) {
+      collected.push(shortcut);
+    }
+  }
+  return collected;
 }
 
 export async function runDisposeHooks<TBundlerCfg>(

--- a/packages/ev/src/_internal/build/plugin-lifecycle.ts
+++ b/packages/ev/src/_internal/build/plugin-lifecycle.ts
@@ -544,8 +544,7 @@ export async function runAfterBuildHooks<TBundlerCfg>(
  *
  * `configureShortcuts` runs at setup time, so the returned descriptors are
  * static; shortcut `action` callbacks receive the live {@link PluginDevSession}
- * only when the key is later pressed. A returned `undefined` shortcut array is
- * treated as "no shortcuts from this plugin".
+ * only when the key is later pressed.
  */
 export async function collectConfigureShortcutsHooks<TBundlerCfg>(
   hooks: PluginHooks<TBundlerCfg>[],
@@ -557,7 +556,7 @@ export async function collectConfigureShortcutsHooks<TBundlerCfg>(
   for (const hook of [...hooks]) {
     if (!hook.configureShortcuts) continue;
     const shortcuts = await hook.configureShortcuts();
-    for (const shortcut of shortcuts ?? []) {
+    for (const shortcut of shortcuts) {
       collected.push(shortcut);
     }
   }

--- a/packages/ev/src/_internal/build/plugin-lifecycle.ts
+++ b/packages/ev/src/_internal/build/plugin-lifecycle.ts
@@ -26,20 +26,6 @@ import { normalizeShortcutKey } from "./cli-shortcuts.js";
 import { assertAfterBuildDeploymentOutputsAvailable } from "./deployment-output-reservations.js";
 
 const typedPluginHookNames: readonly (keyof PluginHooks)[] = PLUGIN_HOOK_NAMES;
-interface PluginHookOwnership {
-  pluginIds: Set<string>;
-  shortcutOwner?: string;
-  shortcutDescriptor?: Readonly<{
-    configurable: boolean;
-    enumerable: boolean;
-    value: NonNullable<PluginHooks["configureShortcuts"]>;
-    writable: boolean;
-  }>;
-}
-
-const pluginHookOwnership = new WeakMap<object, PluginHookOwnership>();
-
-class ReusedPluginHooksError extends Error {}
 
 interface PluginOrderDeclaration {
   id: string;
@@ -209,14 +195,8 @@ export async function collectPluginHooks<TBundlerCfg>(
       try {
         hooks = resolvePluginSetupHooks<TBundlerCfg>(plugin.id, setupResult);
       } catch (error) {
-        const setupResultAlreadyOwned =
-          setupResult !== null &&
-          typeof setupResult === "object" &&
-          pluginHookOwnership.has(setupResult);
         const rollbackHooks =
-          error instanceof ReusedPluginHooksError || setupResultAlreadyOwned
-            ? undefined
-            : captureSetupRollbackHooks<TBundlerCfg>(setupResult);
+          captureSetupRollbackHooks<TBundlerCfg>(setupResult);
         if (rollbackHooks) allHooks.push(rollbackHooks);
         throw error;
       }
@@ -287,18 +267,6 @@ function resolvePluginSetupHooks<TBundlerCfg>(
   }
 
   const hookConfig = hooks as Record<string, unknown>;
-  const existingOwnership = pluginHookOwnership.get(hookConfig);
-  if (existingOwnership?.shortcutOwner !== undefined) {
-    if (existingOwnership.shortcutOwner !== pluginId) {
-      throw new ReusedPluginHooksError(
-        `[evjs] Plugin "${pluginId}" setup hook cannot reuse shortcut hooks owned by plugin "${existingOwnership.shortcutOwner}". Hooks objects containing configureShortcuts cannot be shared by distinct plugin ids.`,
-      );
-    }
-    throw new ReusedPluginHooksError(
-      `[evjs] Plugin "${pluginId}" setup hook cannot reuse a hooks object containing configureShortcuts across setup snapshots. Return a fresh hooks object from each setup call.`,
-    );
-  }
-  let shortcutDescriptor: PluginHookOwnership["shortcutDescriptor"];
   for (const key of Reflect.ownKeys(hookConfig)) {
     if (typeof key !== "string") {
       throw new Error(
@@ -322,40 +290,7 @@ function resolvePluginSetupHooks<TBundlerCfg>(
         `[evjs] Plugin "${pluginId}" setup hook returned ${key} must be a function.`,
       );
     }
-    if (
-      key === "configureShortcuts" &&
-      typeof descriptor.value === "function"
-    ) {
-      shortcutDescriptor = Object.freeze({
-        configurable: descriptor.configurable ?? false,
-        enumerable: descriptor.enumerable ?? false,
-        value: descriptor.value as NonNullable<
-          PluginHooks["configureShortcuts"]
-        >,
-        writable: descriptor.writable ?? false,
-      });
-    }
   }
-  if (shortcutDescriptor && existingOwnership) {
-    const existingShortcutOwner = [...existingOwnership.pluginIds].find(
-      (existingPluginId) => existingPluginId !== pluginId,
-    );
-    if (existingShortcutOwner !== undefined) {
-      throw new ReusedPluginHooksError(
-        `[evjs] Plugin "${pluginId}" setup hook cannot reuse shortcut hooks owned by plugin "${existingShortcutOwner}". Hooks objects containing configureShortcuts cannot be shared by distinct plugin ids.`,
-      );
-    }
-    throw new ReusedPluginHooksError(
-      `[evjs] Plugin "${pluginId}" setup hook cannot reuse a hooks object containing configureShortcuts across setup snapshots. Return a fresh hooks object from each setup call.`,
-    );
-  }
-  const ownership = existingOwnership ?? { pluginIds: new Set<string>() };
-  ownership.pluginIds.add(pluginId);
-  if (shortcutDescriptor) {
-    ownership.shortcutOwner = pluginId;
-    ownership.shortcutDescriptor = shortcutDescriptor;
-  }
-  pluginHookOwnership.set(hookConfig, ownership);
   return hookConfig as PluginHooks<TBundlerCfg>;
 }
 
@@ -608,86 +543,28 @@ export async function runAfterBuildHooks<TBundlerCfg>(
 /**
  * Collect every plugin-contributed CLI shortcut, in plugin order.
  *
- * `configureShortcuts` runs once per setup snapshot, so the returned
- * descriptors are static for that snapshot; shortcut `action` callbacks
- * receive the live {@link PluginDevSession} only when the key is later pressed.
+ * `cliShortcuts` is a descriptor-level contribution collected once per
+ * resolved plugin snapshot. Shortcut `action` callbacks receive the live
+ * {@link PluginDevSession} only when the key is later pressed.
  */
-export async function collectConfigureShortcutsHooks<TBundlerCfg>(
-  hooks: PluginHooks<TBundlerCfg>[],
+export async function collectPluginCliShortcuts<TBundlerCfg>(
+  plugins: readonly Plugin<TBundlerCfg>[],
   options: { onError?: (error: unknown) => void } = {},
 ): Promise<PluginCliShortcut[]> {
   const collected: PluginCliShortcut[] = [];
-  // Snapshot so a config-reload `hooks.splice(...)` cannot mutate the array
-  // mid-iteration across the per-hook `await` (see runDisposeHooks for the same
-  // pattern).
-  const seenShortcutHooks = new WeakSet<object>();
-  for (const hook of [...hooks]) {
-    if (seenShortcutHooks.has(hook)) continue;
-    seenShortcutHooks.add(hook);
+  for (const plugin of [...plugins]) {
+    if (!plugin.cliShortcuts) continue;
     try {
-      const ownership = pluginHookOwnership.get(hook);
-      const descriptor = Object.getOwnPropertyDescriptor(
-        hook,
-        "configureShortcuts",
-      );
-      const expectedDescriptor = ownership?.shortcutDescriptor;
-      let configureShortcuts: NonNullable<PluginHooks["configureShortcuts"]>;
-      if (ownership?.shortcutOwner !== undefined) {
-        if (
-          !descriptor ||
-          !expectedDescriptor ||
-          !("value" in descriptor) ||
-          descriptor.value !== expectedDescriptor.value ||
-          (descriptor.configurable ?? false) !==
-            expectedDescriptor.configurable ||
-          (descriptor.enumerable ?? false) !== expectedDescriptor.enumerable ||
-          (descriptor.writable ?? false) !== expectedDescriptor.writable
-        ) {
-          throw new ReusedPluginHooksError(
-            `[evjs] Plugin "${ownership.shortcutOwner}" configureShortcuts hook was mutated after setup validation. Return a fresh hooks object from setup instead of mutating a validated snapshot.`,
-          );
-        }
-        configureShortcuts = expectedDescriptor.value;
-      } else {
-        if (
-          !descriptor ||
-          ("value" in descriptor && descriptor.value === undefined)
-        ) {
-          continue;
-        }
-        if (
-          !descriptor.enumerable ||
-          !("value" in descriptor) ||
-          typeof descriptor.value !== "function"
-        ) {
-          throw new ReusedPluginHooksError(
-            `[evjs] configureShortcuts added after setup validation must be an enumerable own data function. Return a fresh hooks object from setup.`,
-          );
-        }
-        if (ownership) {
-          throw new ReusedPluginHooksError(
-            `[evjs] Hooks object owned by ${[...ownership.pluginIds]
-              .map((pluginId) => `"${pluginId}"`)
-              .join(
-                ", ",
-              )} cannot add configureShortcuts after setup validation. Return a fresh hooks object from setup.`,
-          );
-        }
-        configureShortcuts = descriptor.value as NonNullable<
-          PluginHooks["configureShortcuts"]
-        >;
-      }
-      const pluginId = ownership?.shortcutOwner ?? "unknown";
       let value: unknown;
       try {
-        value = await Reflect.apply(configureShortcuts, hook, []);
+        value = await Reflect.apply(plugin.cliShortcuts, plugin, []);
       } catch (error) {
         throw new Error(
-          `[evjs] Plugin "${pluginId}" configureShortcuts hook failed: ${error instanceof Error ? error.message : String(error)}`,
+          `[evjs] Plugin "${plugin.id}" cliShortcuts contribution failed: ${error instanceof Error ? error.message : String(error)}`,
           { cause: error },
         );
       }
-      const shortcuts = resolvePluginCliShortcuts(pluginId, value);
+      const shortcuts = resolvePluginCliShortcuts(plugin.id, value);
       collected.push(...shortcuts);
     } catch (error) {
       if (!options.onError) throw error;
@@ -703,13 +580,13 @@ function resolvePluginCliShortcuts(
 ): PluginCliShortcut[] {
   if (!Array.isArray(value)) {
     throw new Error(
-      `[evjs] Plugin "${pluginId}" configureShortcuts hook must return an array.`,
+      `[evjs] Plugin "${pluginId}" cliShortcuts contribution must return an array.`,
     );
   }
 
   const resolved: PluginCliShortcut[] = [];
   for (let index = 0; index < value.length; index++) {
-    const path = `Plugin "${pluginId}" configureShortcuts item ${index}`;
+    const path = `Plugin "${pluginId}" cliShortcuts item ${index}`;
     const itemDescriptor = Object.getOwnPropertyDescriptor(
       value,
       String(index),

--- a/packages/ev/src/config/index.ts
+++ b/packages/ev/src/config/index.ts
@@ -57,8 +57,8 @@ export interface ResolvedDevConfig {
   proxy: DevProxyRule[];
   /**
    * Whether the interactive CLI shortcuts engine is enabled (default `true`).
-   * Shortcuts themselves are contributed by plugins via the
-   * `configureShortcuts` setup hook; this flag only gates the engine.
+   * Shortcuts themselves are contributed by plugins through descriptor-level
+   * `cliShortcuts()` contributions; this flag only gates the engine.
    */
   cliShortcuts: boolean;
 }
@@ -222,8 +222,9 @@ export interface DevConfig {
   /**
    * Interactive CLI keyboard shortcuts while `ev dev` runs. `false` disables
    * the engine (default `true`). Shortcuts themselves are registered by plugins
-   * via the `configureShortcuts` setup hook — core ships none. The engine is
-   * always a no-op in CI and non-TTY contexts, regardless of this option.
+   * through descriptor-level `cliShortcuts()` contributions — core ships none.
+   * The engine is always a no-op in CI and non-TTY contexts, regardless of
+   * this option.
    */
   cliShortcuts?: boolean;
 }
@@ -554,6 +555,7 @@ const PUBLIC_PLUGIN_KEYS = new Set([
   "enforce",
   "configure",
   "setup",
+  "cliShortcuts",
   "emitIR",
 ]);
 const PUBLIC_BUNDLER_CONFIG_KEYS = new Set([
@@ -758,7 +760,7 @@ function resolvePlugin<TBundlerCfg = unknown>(
     pluginDescriptor,
     PUBLIC_PLUGIN_KEYS,
     path,
-    "id, dependencies, optionalDependencies, enforce, configure, setup, or emitIR",
+    "id, dependencies, optionalDependencies, enforce, configure, setup, cliShortcuts, or emitIR",
     (key) =>
       isPluginLifecycleDescriptorField(key)
         ? `[evjs] ${path}.${key} is not a Plugin descriptor field. Return the hook from ${path}.setup() instead.`
@@ -771,6 +773,7 @@ function resolvePlugin<TBundlerCfg = unknown>(
     enforce: rawEnforce,
     configure: rawConfigure,
     setup: rawSetup,
+    cliShortcuts: rawCliShortcuts,
     emitIR: rawEmitIR,
   } = pluginDescriptor;
 
@@ -784,6 +787,12 @@ function resolvePlugin<TBundlerCfg = unknown>(
     assertFunction<NonNullable<Plugin<TBundlerCfg>["setup"]>>(
       rawSetup,
       `${path}.setup`,
+    );
+  }
+  if (rawCliShortcuts !== undefined) {
+    assertFunction<NonNullable<Plugin<TBundlerCfg>["cliShortcuts"]>>(
+      rawCliShortcuts,
+      `${path}.cliShortcuts`,
     );
   }
   if (rawEmitIR !== undefined) {
@@ -833,6 +842,7 @@ function resolvePlugin<TBundlerCfg = unknown>(
       : {}),
     ...(rawConfigure !== undefined ? { configure: rawConfigure } : {}),
     ...(rawSetup !== undefined ? { setup: rawSetup } : {}),
+    ...(rawCliShortcuts !== undefined ? { cliShortcuts: rawCliShortcuts } : {}),
     ...(rawEmitIR !== undefined ? { emitIR: rawEmitIR } : {}),
   };
   copyDefinedPluginRuntime(plugin as Plugin<TBundlerCfg>, resolved);

--- a/packages/ev/src/config/index.ts
+++ b/packages/ev/src/config/index.ts
@@ -223,8 +223,7 @@ export interface DevConfig {
    * Interactive CLI keyboard shortcuts while `ev dev` runs. `false` disables
    * the engine (default `true`). Shortcuts themselves are registered by plugins
    * via the `configureShortcuts` setup hook — core ships none. The engine is
-   * always a no-op in CI / non-TTY contexts and on the wasm/web (Fetch
-   * runtime) dev surface, regardless of this option.
+   * always a no-op in CI and non-TTY contexts, regardless of this option.
    */
   cliShortcuts?: boolean;
 }
@@ -665,7 +664,8 @@ export function resolveConfig<TBundlerCfg = unknown>(
   const rscEndpoint = resolveRscEndpoint(serverRscConfig);
   const devHttps = resolveDevHttpsConfig(devConfig.https);
   const serverHttps = resolveServerDevHttpsConfig(serverDevConfig.https);
-  const cliShortcuts = devConfig.cliShortcuts !== false;
+  const cliShortcuts =
+    assertOptionalBoolean(devConfig.cliShortcuts, "dev.cliShortcuts") ?? true;
 
   return {
     conventions,
@@ -1549,7 +1549,7 @@ function validateDevConfigKeys(dev: DevConfig): void {
     dev,
     PUBLIC_DEV_CONFIG_KEYS,
     "dev",
-    "port, https, or proxy",
+    "port, https, proxy, or cliShortcuts",
   );
 }
 

--- a/packages/ev/src/config/index.ts
+++ b/packages/ev/src/config/index.ts
@@ -55,6 +55,19 @@ export interface ResolvedDevConfig {
   https: boolean | { key: string; cert: string };
   /** Dev proxy rules. */
   proxy: DevProxyRule[];
+  /**
+   * Resolved CLI shortcuts option. `false` disables the shortcuts engine;
+   * `true` (default) enables it with no custom options. Custom shortcuts are
+   * contributed by plugins via the `configureShortcuts` setup hook, so the
+   * resolved value only carries the enable flag and a print hint toggle.
+   */
+  cliShortcuts: false | ResolvedCliShortcutsOptions;
+}
+
+/** Static CLI-shortcuts options surviving config resolution. */
+export interface ResolvedCliShortcutsOptions {
+  /** Whether to print the one-line "press h + enter" hint after binding. */
+  print: boolean;
 }
 
 /** Proxy rule for the dev server. */
@@ -213,6 +226,23 @@ export interface DevConfig {
    * are not included here.
    */
   proxy?: DevProxyRule[];
+  /**
+   * Interactive CLI keyboard shortcuts while `ev dev` runs. `false` disables
+   * the engine; `true` (default) enables it. Shortcuts themselves are
+   * registered by plugins via the `configureShortcuts` setup hook — core
+   * ships none. The engine is always a no-op in CI / non-TTY contexts and on
+   * the wasm/web (Fetch runtime) dev surface, regardless of this option.
+   */
+  cliShortcuts?: boolean | CliShortcutsConfig;
+}
+
+/** Static CLI-shortcuts config accepted on `dev.cliShortcuts`. */
+export interface CliShortcutsConfig {
+  /**
+   * Whether to print the one-line "press h + enter to show help" hint when the
+   * dev server is ready. Default `true`.
+   */
+  print?: boolean;
 }
 
 /** Server configuration. */
@@ -511,7 +541,12 @@ const PUBLIC_CONFIG_ROUTE_APPLICATION_DOCUMENT_KEYS = new Set([
   "template",
   "mount",
 ]);
-const PUBLIC_DEV_CONFIG_KEYS = new Set(["port", "https", "proxy"]);
+const PUBLIC_DEV_CONFIG_KEYS = new Set([
+  "port",
+  "https",
+  "proxy",
+  "cliShortcuts",
+]);
 const PUBLIC_SERVER_CONFIG_KEYS = new Set(["basePath", "rsc", "dev"]);
 const PUBLIC_SERVER_DEV_CONFIG_KEYS = new Set(["port", "https"]);
 const PUBLIC_SERVER_RSC_CONFIG_KEYS = new Set(["endpoint"]);
@@ -522,6 +557,7 @@ const PUBLIC_OUTPUT_CONFIG_KEYS = new Set([
   "crossOriginLoading",
 ]);
 const PUBLIC_HTTPS_CONFIG_KEYS = new Set(["key", "cert"]);
+const PUBLIC_CLI_SHORTCUTS_CONFIG_KEYS = new Set(["print"]);
 const PUBLIC_DEV_PROXY_RULE_KEYS = new Set([
   "context",
   "target",
@@ -646,6 +682,7 @@ export function resolveConfig<TBundlerCfg = unknown>(
   const rscEndpoint = resolveRscEndpoint(serverRscConfig);
   const devHttps = resolveDevHttpsConfig(devConfig.https);
   const serverHttps = resolveServerDevHttpsConfig(serverDevConfig.https);
+  const cliShortcuts = resolveDevCliShortcuts(devConfig.cliShortcuts);
 
   return {
     conventions,
@@ -659,6 +696,7 @@ export function resolveConfig<TBundlerCfg = unknown>(
       port: clientPort,
       https: devHttps,
       proxy: resolveDevProxyRules(devConfig.proxy),
+      cliShortcuts,
     },
     server: {
       basePath: serverBasePath,
@@ -1690,6 +1728,33 @@ function validateHttpsConfigKeys(
   path: "dev.https" | "server.dev.https",
 ): void {
   assertKnownConfigKeys(https, PUBLIC_HTTPS_CONFIG_KEYS, path, "key and cert");
+}
+
+function resolveDevCliShortcuts(
+  cliShortcuts: DevConfig["cliShortcuts"],
+): ResolvedDevConfig["cliShortcuts"] {
+  if (cliShortcuts === undefined || cliShortcuts === true) {
+    return { print: true };
+  }
+  if (cliShortcuts === false) return false;
+  const config = assertPlainConfigRecord(
+    cliShortcuts,
+    "dev.cliShortcuts",
+    "a CLI shortcuts config object",
+  );
+  assertKnownConfigKeys(
+    config,
+    PUBLIC_CLI_SHORTCUTS_CONFIG_KEYS,
+    "dev.cliShortcuts",
+    "print",
+  );
+  const { print } = config;
+  if (print !== undefined && typeof print !== "boolean") {
+    throw new Error(
+      `[evjs] dev.cliShortcuts.print must be a boolean. Received ${typeof print}.`,
+    );
+  }
+  return { print: print ?? true };
 }
 
 function resolveDevProxyRules(proxy: DevConfig["proxy"]): DevProxyRule[] {

--- a/packages/ev/src/config/index.ts
+++ b/packages/ev/src/config/index.ts
@@ -56,18 +56,11 @@ export interface ResolvedDevConfig {
   /** Dev proxy rules. */
   proxy: DevProxyRule[];
   /**
-   * Resolved CLI shortcuts option. `false` disables the shortcuts engine;
-   * `true` (default) enables it with no custom options. Custom shortcuts are
-   * contributed by plugins via the `configureShortcuts` setup hook, so the
-   * resolved value only carries the enable flag and a print hint toggle.
+   * Whether the interactive CLI shortcuts engine is enabled (default `true`).
+   * Shortcuts themselves are contributed by plugins via the
+   * `configureShortcuts` setup hook; this flag only gates the engine.
    */
-  cliShortcuts: false | ResolvedCliShortcutsOptions;
-}
-
-/** Static CLI-shortcuts options surviving config resolution. */
-export interface ResolvedCliShortcutsOptions {
-  /** Whether to print the one-line "press h + enter" hint after binding. */
-  print: boolean;
+  cliShortcuts: boolean;
 }
 
 /** Proxy rule for the dev server. */
@@ -228,21 +221,12 @@ export interface DevConfig {
   proxy?: DevProxyRule[];
   /**
    * Interactive CLI keyboard shortcuts while `ev dev` runs. `false` disables
-   * the engine; `true` (default) enables it. Shortcuts themselves are
-   * registered by plugins via the `configureShortcuts` setup hook — core
-   * ships none. The engine is always a no-op in CI / non-TTY contexts and on
-   * the wasm/web (Fetch runtime) dev surface, regardless of this option.
+   * the engine (default `true`). Shortcuts themselves are registered by plugins
+   * via the `configureShortcuts` setup hook — core ships none. The engine is
+   * always a no-op in CI / non-TTY contexts and on the wasm/web (Fetch
+   * runtime) dev surface, regardless of this option.
    */
-  cliShortcuts?: boolean | CliShortcutsConfig;
-}
-
-/** Static CLI-shortcuts config accepted on `dev.cliShortcuts`. */
-export interface CliShortcutsConfig {
-  /**
-   * Whether to print the one-line "press h + enter to show help" hint when the
-   * dev server is ready. Default `true`.
-   */
-  print?: boolean;
+  cliShortcuts?: boolean;
 }
 
 /** Server configuration. */
@@ -557,7 +541,6 @@ const PUBLIC_OUTPUT_CONFIG_KEYS = new Set([
   "crossOriginLoading",
 ]);
 const PUBLIC_HTTPS_CONFIG_KEYS = new Set(["key", "cert"]);
-const PUBLIC_CLI_SHORTCUTS_CONFIG_KEYS = new Set(["print"]);
 const PUBLIC_DEV_PROXY_RULE_KEYS = new Set([
   "context",
   "target",
@@ -682,7 +665,7 @@ export function resolveConfig<TBundlerCfg = unknown>(
   const rscEndpoint = resolveRscEndpoint(serverRscConfig);
   const devHttps = resolveDevHttpsConfig(devConfig.https);
   const serverHttps = resolveServerDevHttpsConfig(serverDevConfig.https);
-  const cliShortcuts = resolveDevCliShortcuts(devConfig.cliShortcuts);
+  const cliShortcuts = devConfig.cliShortcuts !== false;
 
   return {
     conventions,
@@ -1728,33 +1711,6 @@ function validateHttpsConfigKeys(
   path: "dev.https" | "server.dev.https",
 ): void {
   assertKnownConfigKeys(https, PUBLIC_HTTPS_CONFIG_KEYS, path, "key and cert");
-}
-
-function resolveDevCliShortcuts(
-  cliShortcuts: DevConfig["cliShortcuts"],
-): ResolvedDevConfig["cliShortcuts"] {
-  if (cliShortcuts === undefined || cliShortcuts === true) {
-    return { print: true };
-  }
-  if (cliShortcuts === false) return false;
-  const config = assertPlainConfigRecord(
-    cliShortcuts,
-    "dev.cliShortcuts",
-    "a CLI shortcuts config object",
-  );
-  assertKnownConfigKeys(
-    config,
-    PUBLIC_CLI_SHORTCUTS_CONFIG_KEYS,
-    "dev.cliShortcuts",
-    "print",
-  );
-  const { print } = config;
-  if (print !== undefined && typeof print !== "boolean") {
-    throw new Error(
-      `[evjs] dev.cliShortcuts.print must be a boolean. Received ${typeof print}.`,
-    );
-  }
-  return { print: print ?? true };
 }
 
 function resolveDevProxyRules(proxy: DevConfig["proxy"]): DevProxyRule[] {

--- a/packages/ev/src/plugin/defined.ts
+++ b/packages/ev/src/plugin/defined.ts
@@ -576,6 +576,7 @@ export interface DefinedPluginDescriptor<
   readonly enforce?: "pre" | "normal" | "post";
   readonly configure?: DefinedPluginConfigureHook<TApplication, TBundlerCfg>;
   readonly setup?: DefinedPluginSetupHook<TApplication, TBundlerCfg>;
+  readonly cliShortcuts?: Plugin<TBundlerCfg>["cliShortcuts"];
   /** Emit application-wide `.ev` IR with all enabled Pages in `ctx.pages`. */
   readonly emitIR?: DefinedPluginEmitIRHook<TApplication, TPage, TBundlerCfg>;
   /** Emit `.ev` IR once for each enabled Page. */
@@ -821,6 +822,7 @@ export function definePlugin<
     });
     const configure = definition.configure;
     const setup = definition.setup;
+    const cliShortcuts = definition.cliShortcuts;
     const emitIR = definition.emitIR;
     const emitPageIR = definition.emitPageIR;
     const plugin: Plugin<TBundlerCfg> = {
@@ -859,6 +861,7 @@ export function definePlugin<
             },
           }
         : {}),
+      ...(cliShortcuts ? { cliShortcuts } : {}),
       ...(emitIR || emitPageIR
         ? {
             async emitIR(context) {
@@ -1362,6 +1365,7 @@ const DEFINED_PLUGIN_DESCRIPTOR_FIELDS = [
   "enforce",
   "configure",
   "setup",
+  "cliShortcuts",
   "emitIR",
   "emitPageIR",
 ] as const;
@@ -1502,7 +1506,13 @@ function assertDefinedPluginDescriptor<
       '[evjs] definePlugin() enforce must be "pre", "normal", or "post".',
     );
   }
-  for (const field of ["configure", "setup", "emitIR", "emitPageIR"] as const) {
+  for (const field of [
+    "configure",
+    "setup",
+    "cliShortcuts",
+    "emitIR",
+    "emitPageIR",
+  ] as const) {
     if (
       descriptor[field] !== undefined &&
       typeof descriptor[field] !== "function"

--- a/packages/ev/src/plugin/hook-names.ts
+++ b/packages/ev/src/plugin/hook-names.ts
@@ -4,7 +4,6 @@ export const PLUGIN_HOOK_NAMES = [
   "transformOutput",
   "transformHtml",
   "afterBuild",
-  "configureShortcuts",
   "dispose",
 ] as const;
 

--- a/packages/ev/src/plugin/hook-names.ts
+++ b/packages/ev/src/plugin/hook-names.ts
@@ -4,6 +4,7 @@ export const PLUGIN_HOOK_NAMES = [
   "transformOutput",
   "transformHtml",
   "afterBuild",
+  "configureShortcuts",
   "dispose",
 ] as const;
 

--- a/packages/ev/src/plugin/index.ts
+++ b/packages/ev/src/plugin/index.ts
@@ -783,11 +783,58 @@ export interface PluginHooks<TBundlerCfg = unknown> {
   afterBuild?: (result: BuildResult) => void | Promise<void>;
 
   /**
+   * Contribute interactive CLI keyboard shortcuts for `ev dev`.
+   *
+   * Runs once at setup time. Plugins return static shortcut descriptors whose
+   * `action` receives the live {@link PluginDevSession} only when the key is
+   * pressed later, so actions may close over setup-time values without
+   * needing the runtime origin eagerly. Core ships no built-in shortcuts;
+   * every key (including `h` help) is plugin-contributed. The first plugin to
+   * register a key owns it; later duplicates are dropped. The engine is a
+   * no-op in CI / non-TTY contexts and on the wasm/web (Fetch runtime) dev
+   * surface.
+   */
+  configureShortcuts?: () => PluginCliShortcut[] | Promise<PluginCliShortcut[]>;
+
+  /**
    * Retire this plugin snapshot after a production build, dev shutdown,
    * configuration replacement, or initialization rollback. Ordinary dev
    * rebuilds do not dispose the active snapshot.
    */
   dispose?: DisposeHook<TBundlerCfg>;
+}
+
+/**
+ * Capability handle surfaced to a plugin shortcut action at press time.
+ *
+ * This is the dev-facing shape; the build orchestrator (`_internal/build`)
+ * constructs the concrete implementation. `origin` is the client dev server
+ * URL reported by `BundlerDevContext.callbacks.onDevServerReady({ origin })`.
+ */
+export interface PluginDevSession {
+  /** Client dev server origin, e.g. `http://localhost:3000`. */
+  readonly origin: string;
+  /**
+   * Restart the server runtime (the Hono API child). No-ops when there is no
+   * server-runtime entry to restart.
+   */
+  restartServerRuntime(): Promise<void>;
+  /** Trigger dev shutdown (equivalent to Ctrl-C). */
+  close(): Promise<void>;
+}
+
+/** A plugin-contributed CLI keyboard shortcut. */
+export interface PluginCliShortcut {
+  /** Lowercase single-character key matched against a pressed line. */
+  key: string;
+  /** Human description shown in the help list. */
+  description: string;
+  /**
+   * Action invoked with the live {@link PluginDevSession}. `undefined`
+   * disables a shortcut registered with the same key by an earlier plugin
+   * without removing its description.
+   */
+  action?(session: PluginDevSession): void | Promise<void>;
 }
 
 /** Build result passed to plugin hooks. */

--- a/packages/ev/src/plugin/index.ts
+++ b/packages/ev/src/plugin/index.ts
@@ -290,6 +290,19 @@ export interface Plugin<TBundlerCfg = unknown> {
   setup?: PluginSetupHook<TBundlerCfg>;
 
   /**
+   * Declare interactive CLI keyboard shortcuts for `ev dev`.
+   *
+   * This contribution is collected once for each resolved plugin snapshot.
+   * Its static descriptors are independent from setup lifecycle state; each
+   * `action` receives the live {@link PluginDevSession} when its key is pressed.
+   * Core ships no built-in shortcuts, including help. The first plugin to
+   * register a key owns it, and the engine is a no-op in CI / non-TTY contexts.
+   */
+  cliShortcuts?: () =>
+    | readonly PluginCliShortcut[]
+    | Promise<readonly PluginCliShortcut[]>;
+
+  /**
    * Emit generated framework modules and slots into the `.ev` IR.
    *
    * This hook is separate from setup() lifecycle hooks. It declares generated
@@ -781,24 +794,6 @@ export interface PluginHooks<TBundlerCfg = unknown> {
    * isolated snapshot; mutations do not affect later hooks or artifacts.
    */
   afterBuild?: (result: BuildResult) => void | Promise<void>;
-
-  /**
-   * Contribute interactive CLI keyboard shortcuts for `ev dev`.
-   *
-   * Runs once per plugin setup snapshot. Plugins return static shortcut
-   * descriptors whose `action` receives the live {@link PluginDevSession} only
-   * when the key is pressed later, so actions may close over setup-time values
-   * without needing the runtime origin eagerly. Core ships no built-in shortcuts;
-   * every key (including `h` help) is plugin-contributed. A plugin that wants a
-   * help listing should register `h` itself. The first plugin to register a
-   * key owns it; later duplicates are dropped. The engine is a no-op in CI /
-   * non-TTY contexts. Return a fresh hooks object from each setup call when it
-   * contains this hook; reusing it across snapshots or plugin ids would make
-   * shortcut diagnostics and lifecycle ownership ambiguous.
-   */
-  configureShortcuts?: () =>
-    | readonly PluginCliShortcut[]
-    | Promise<readonly PluginCliShortcut[]>;
 
   /**
    * Retire this plugin snapshot after a production build, dev shutdown,

--- a/packages/ev/src/plugin/index.ts
+++ b/packages/ev/src/plugin/index.ts
@@ -785,16 +785,20 @@ export interface PluginHooks<TBundlerCfg = unknown> {
   /**
    * Contribute interactive CLI keyboard shortcuts for `ev dev`.
    *
-   * Runs once at setup time. Plugins return static shortcut descriptors whose
-   * `action` receives the live {@link PluginDevSession} only when the key is
-   * pressed later, so actions may close over setup-time values without
-   * needing the runtime origin eagerly. Core ships no built-in shortcuts;
+   * Runs once per plugin setup snapshot. Plugins return static shortcut
+   * descriptors whose `action` receives the live {@link PluginDevSession} only
+   * when the key is pressed later, so actions may close over setup-time values
+   * without needing the runtime origin eagerly. Core ships no built-in shortcuts;
    * every key (including `h` help) is plugin-contributed. A plugin that wants a
    * help listing should register `h` itself. The first plugin to register a
    * key owns it; later duplicates are dropped. The engine is a no-op in CI /
-   * non-TTY contexts and on the wasm/web (Fetch runtime) dev surface.
+   * non-TTY contexts. Return a fresh hooks object from each setup call when it
+   * contains this hook; reusing it across snapshots or plugin ids would make
+   * shortcut diagnostics and lifecycle ownership ambiguous.
    */
-  configureShortcuts?: () => PluginCliShortcut[] | Promise<PluginCliShortcut[]>;
+  configureShortcuts?: () =>
+    | readonly PluginCliShortcut[]
+    | Promise<readonly PluginCliShortcut[]>;
 
   /**
    * Retire this plugin snapshot after a production build, dev shutdown,
@@ -818,22 +822,22 @@ export interface PluginHooks<TBundlerCfg = unknown> {
 export interface PluginDevSession {
   /** Client dev server origin, e.g. `http://localhost:3000`. */
   readonly origin: string;
-  /** Trigger dev shutdown (equivalent to Ctrl-C). */
+  /** Request dev shutdown (equivalent to Ctrl-C); resolves after the request. */
   close(): Promise<void>;
 }
 
 /** A plugin-contributed CLI keyboard shortcut. */
 export interface PluginCliShortcut {
   /** Lowercase single-character key matched against a pressed line. */
-  key: string;
+  readonly key: string;
   /** Human description of what the shortcut does. */
-  description: string;
+  readonly description: string;
   /**
-   * Action invoked with the live {@link PluginDevSession}. `undefined`
-   * disables a shortcut registered with the same key by an earlier plugin
-   * without removing its description.
+   * Action invoked with the live {@link PluginDevSession}. Omitting it reserves
+   * the key and description without running an action; later duplicates remain
+   * ignored by the first-writer-wins rule.
    */
-  action?(session: PluginDevSession): void | Promise<void>;
+  readonly action?: (session: PluginDevSession) => void | Promise<void>;
 }
 
 /** Build result passed to plugin hooks. */

--- a/packages/ev/src/plugin/index.ts
+++ b/packages/ev/src/plugin/index.ts
@@ -789,10 +789,10 @@ export interface PluginHooks<TBundlerCfg = unknown> {
    * `action` receives the live {@link PluginDevSession} only when the key is
    * pressed later, so actions may close over setup-time values without
    * needing the runtime origin eagerly. Core ships no built-in shortcuts;
-   * every key (including `h` help) is plugin-contributed. The first plugin to
-   * register a key owns it; later duplicates are dropped. The engine is a
-   * no-op in CI / non-TTY contexts and on the wasm/web (Fetch runtime) dev
-   * surface.
+   * every key (including `h` help) is plugin-contributed. A plugin that wants a
+   * help listing should register `h` itself. The first plugin to register a
+   * key owns it; later duplicates are dropped. The engine is a no-op in CI /
+   * non-TTY contexts and on the wasm/web (Fetch runtime) dev surface.
    */
   configureShortcuts?: () => PluginCliShortcut[] | Promise<PluginCliShortcut[]>;
 
@@ -810,15 +810,14 @@ export interface PluginHooks<TBundlerCfg = unknown> {
  * This is the dev-facing shape; the build orchestrator (`_internal/build`)
  * constructs the concrete implementation. `origin` is the client dev server
  * URL reported by `BundlerDevContext.callbacks.onDevServerReady({ origin })`.
+ * Surface is intentionally minimal: it exposes only data and a shutdown
+ * trigger. Core ships no built-in shortcut actions (no `restart`, `open`,
+ * etc.); plugins that want such behavior implement it themselves from these
+ * primitives plus their own utilities.
  */
 export interface PluginDevSession {
   /** Client dev server origin, e.g. `http://localhost:3000`. */
   readonly origin: string;
-  /**
-   * Restart the server runtime (the Hono API child). No-ops when there is no
-   * server-runtime entry to restart.
-   */
-  restartServerRuntime(): Promise<void>;
   /** Trigger dev shutdown (equivalent to Ctrl-C). */
   close(): Promise<void>;
 }
@@ -827,7 +826,7 @@ export interface PluginDevSession {
 export interface PluginCliShortcut {
   /** Lowercase single-character key matched against a pressed line. */
   key: string;
-  /** Human description shown in the help list. */
+  /** Human description of what the shortcut does. */
   description: string;
   /**
    * Action invoked with the live {@link PluginDevSession}. `undefined`

--- a/packages/ev/tests/cli-shortcuts.test.ts
+++ b/packages/ev/tests/cli-shortcuts.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   bindCLIShortcuts,
+  createShortcutDispatcher,
+  dedupeShortcuts,
   resolveShortcut,
 } from "../src/_internal/build/cli-shortcuts.js";
 import type {
@@ -45,17 +47,89 @@ describe("resolveShortcut (pure dispatch logic)", () => {
     ];
     expect(resolveShortcut("d", disabled)?.key).toBe("d");
   });
+});
 
-  it("first registered shortcut wins when keys collide", () => {
+describe("dedupeShortcuts", () => {
+  it("drops later duplicates, keeping first-writer order", () => {
     const first = { key: "p", description: "first", action: vi.fn() };
     const second = { key: "p", description: "second", action: vi.fn() };
-    // Note: dedupe happens in bindCLIShortcuts, not resolveShortcut. resolveShortcut
-    // uses Array.find and returns the FIRST match, mirroring that contract.
-    expect(resolveShortcut("p", [first, second])).toBe(first);
+    const third = { key: "q", description: "third", action: vi.fn() };
+    expect(dedupeShortcuts([first, second, third]).map((s) => s.key)).toEqual([
+      "p",
+      "q",
+    ]);
+    // The kept "p" is the first one.
+    expect(dedupeShortcuts([first, second, third])[0]).toBe(first);
   });
 });
 
-describe("bindCLIShortcuts enable/empty gating", () => {
+describe("createShortcutDispatcher", () => {
+  it("drops concurrent presses while an action is already running", async () => {
+    // The action returns a long-pending promise on its first call (which we
+    // control), and a self-resolving promise thereafter so the second press
+    // can be awaited deterministically.
+    let resolveFirst: () => void = () => {};
+    let calls = 0;
+    const action = vi.fn(() => {
+      calls += 1;
+      return calls === 1
+        ? new Promise<void>((resolve) => {
+            resolveFirst = resolve;
+          })
+        : Promise.resolve();
+    });
+    const session = createSession();
+    const dispatcher = createShortcutDispatcher(session, [
+      { key: "p", description: "ping", action },
+    ]);
+
+    // Fire the first press without awaiting; its action stays pending while we
+    // re-enter.
+    const first = dispatcher.dispatch("p");
+    // These presses arrive while the first action is still pending; they must
+    // be dropped.
+    await dispatcher.dispatch("p");
+    await dispatcher.dispatch("p");
+    expect(action).toHaveBeenCalledTimes(1);
+
+    resolveFirst();
+    await first;
+
+    // Once the first action finished, the next press runs again (and resolves).
+    await dispatcher.dispatch("p");
+    expect(action).toHaveBeenCalledTimes(2);
+  });
+
+  it("survives a throwing action; the loop keeps dispatching", async () => {
+    const firstAction = vi.fn(() => Promise.reject(new Error("boom")));
+    const secondAction = vi.fn().mockResolvedValue(undefined);
+    const session = createSession();
+    const dispatcher = createShortcutDispatcher(session, [
+      { key: "a", description: "throws", action: firstAction },
+      { key: "b", description: "ok", action: secondAction },
+    ]);
+
+    await expect(dispatcher.dispatch("a")).resolves.toBeUndefined();
+    await dispatcher.dispatch("b");
+    expect(firstAction).toHaveBeenCalledTimes(1);
+    expect(secondAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops for unknown keys and shortcuts with undefined action", async () => {
+    const action = vi.fn();
+    const dispatcher = createShortcutDispatcher(createSession(), [
+      { key: "d", description: "disabled" },
+      { key: "p", description: "ping", action },
+    ]);
+    await dispatcher.dispatch("z");
+    await dispatcher.dispatch("d");
+    expect(action).not.toHaveBeenCalled();
+    await dispatcher.dispatch("p");
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("bindCLIShortcuts enable gating", () => {
   const originalIsTTY = process.stdin.isTTY;
   const originalCI = process.env.CI;
 
@@ -68,7 +142,7 @@ describe("bindCLIShortcuts enable/empty gating", () => {
     else process.env.CI = originalCI;
   });
 
-  it("is a no-op when disabled and attaches nothing to stdin", () => {
+  it("is a no-op when disabled", () => {
     const unbind = bindCLIShortcuts(
       createSession(),
       {
@@ -89,14 +163,6 @@ describe("bindCLIShortcuts enable/empty gating", () => {
     const unbind = bindCLIShortcuts(createSession(), {
       customShortcuts: [{ key: "p", description: "ping", action: vi.fn() }],
     });
-    expect(typeof unbind).toBe("function");
-    unbind();
-  });
-
-  it("does not attach when no plugin contributed shortcuts", () => {
-    // With helpKey removed, an empty customShortcuts list yields a no-op unbind
-    // and never touches process.stdin.
-    const unbind = bindCLIShortcuts(createSession(), {}, true);
     expect(typeof unbind).toBe("function");
     unbind();
   });

--- a/packages/ev/tests/cli-shortcuts.test.ts
+++ b/packages/ev/tests/cli-shortcuts.test.ts
@@ -3,6 +3,7 @@ import {
   bindCLIShortcuts,
   createShortcutDispatcher,
   dedupeShortcuts,
+  normalizeShortcutKey,
   resolveShortcut,
 } from "../src/_internal/build/cli-shortcuts.js";
 import type {
@@ -35,10 +36,11 @@ describe("resolveShortcut (pure dispatch logic)", () => {
     expect(resolveShortcut("O\n", shortcuts)?.key).toBe("o");
   });
 
-  it("returns undefined for unknown keys and empty input", () => {
+  it("returns undefined for unknown, empty, and multi-character input", () => {
     expect(resolveShortcut("z", shortcuts)).toBeUndefined();
     expect(resolveShortcut("", shortcuts)).toBeUndefined();
     expect(resolveShortcut("   ", shortcuts)).toBeUndefined();
+    expect(resolveShortcut("open", shortcuts)).toBeUndefined();
   });
 
   it("returns a shortcut even when its action is undefined (caller skips)", () => {
@@ -50,16 +52,20 @@ describe("resolveShortcut (pure dispatch logic)", () => {
 });
 
 describe("dedupeShortcuts", () => {
-  it("drops later duplicates, keeping first-writer order", () => {
-    const first = { key: "p", description: "first", action: vi.fn() };
+  it("normalizes keys and drops later duplicates by first-writer order", () => {
+    const first = { key: " P ", description: "first", action: vi.fn() };
     const second = { key: "p", description: "second", action: vi.fn() };
     const third = { key: "q", description: "third", action: vi.fn() };
-    expect(dedupeShortcuts([first, second, third]).map((s) => s.key)).toEqual([
-      "p",
-      "q",
-    ]);
-    // The kept "p" is the first one.
-    expect(dedupeShortcuts([first, second, third])[0]).toBe(first);
+    const deduped = dedupeShortcuts([first, second, third]);
+    expect(deduped.map((s) => s.key)).toEqual(["p", "q"]);
+    expect(deduped[0]?.description).toBe("first");
+    expect(deduped[0]?.action).toBe(first.action);
+    expect(Object.isFrozen(deduped[0])).toBe(true);
+  });
+
+  it("rejects empty and multi-character registration keys", () => {
+    expect(() => normalizeShortcutKey(" ")).toThrow("single non-whitespace");
+    expect(() => normalizeShortcutKey("open")).toThrow("single non-whitespace");
   });
 });
 
@@ -127,6 +133,31 @@ describe("createShortcutDispatcher", () => {
     await dispatcher.dispatch("p");
     expect(action).toHaveBeenCalledTimes(1);
   });
+
+  it("waits for an in-flight action before becoming idle", async () => {
+    let resolveAction: () => void = () => {};
+    const action = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAction = resolve;
+        }),
+    );
+    const dispatcher = createShortcutDispatcher(createSession(), [
+      { key: "p", description: "pending", action },
+    ]);
+
+    const dispatch = dispatcher.dispatch("p");
+    let idle = false;
+    const waitForIdle = dispatcher.waitForIdle().then(() => {
+      idle = true;
+    });
+    await Promise.resolve();
+    expect(idle).toBe(false);
+
+    resolveAction();
+    await Promise.all([dispatch, waitForIdle]);
+    expect(idle).toBe(true);
+  });
 });
 
 describe("bindCLIShortcuts enable gating", () => {
@@ -142,7 +173,8 @@ describe("bindCLIShortcuts enable gating", () => {
     else process.env.CI = originalCI;
   });
 
-  it("is a no-op when disabled", () => {
+  it("is a no-op when disabled", async () => {
+    const dataListeners = process.stdin.listenerCount("data");
     const unbind = bindCLIShortcuts(
       createSession(),
       {
@@ -151,19 +183,52 @@ describe("bindCLIShortcuts enable gating", () => {
       false,
     );
     expect(typeof unbind).toBe("function");
-    unbind();
+    expect(process.stdin.listenerCount("data")).toBe(dataListeners);
+    await unbind();
   });
 
-  it("defaults to disabled under CI / non-TTY", () => {
+  it("defaults to disabled under CI / non-TTY", async () => {
     Object.defineProperty(process.stdin, "isTTY", {
       configurable: true,
       value: false,
     });
     process.env.CI = "1";
+    const dataListeners = process.stdin.listenerCount("data");
     const unbind = bindCLIShortcuts(createSession(), {
       customShortcuts: [{ key: "p", description: "ping", action: vi.fn() }],
     });
     expect(typeof unbind).toBe("function");
-    unbind();
+    expect(process.stdin.listenerCount("data")).toBe(dataListeners);
+    await unbind();
+  });
+
+  it("detaches input without waiting forever for a stuck action", async () => {
+    const action = vi.fn(() => new Promise<void>(() => {}));
+    const unbind = bindCLIShortcuts(
+      createSession(),
+      {
+        customShortcuts: [{ key: "p", description: "pending", action }],
+      },
+      true,
+    );
+    process.stdin.emit("data", Buffer.from("p\n"));
+    await vi.waitFor(() => expect(action).toHaveBeenCalledOnce());
+
+    const result = await unbind({ actionDrainTimeoutMs: 5 });
+    expect(result.drained).toBe(false);
+  });
+
+  it("reports an idle binding as drained with a zero timeout", async () => {
+    const unbind = bindCLIShortcuts(
+      createSession(),
+      {
+        customShortcuts: [{ key: "p", description: "unused", action: vi.fn() }],
+      },
+      true,
+    );
+
+    const result = await unbind({ actionDrainTimeoutMs: 0 });
+    expect(result.drained).toBe(true);
+    await expect(result.idle).resolves.toBeUndefined();
   });
 });

--- a/packages/ev/tests/cli-shortcuts.test.ts
+++ b/packages/ev/tests/cli-shortcuts.test.ts
@@ -1,46 +1,61 @@
-import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   bindCLIShortcuts,
-  type DevSession,
+  resolveShortcut,
 } from "../src/_internal/build/cli-shortcuts.js";
-import {
-  collectConfigureShortcutsHooks,
-  collectPluginHooks,
-} from "../src/_internal/build/plugin-lifecycle.js";
-import type { Plugin, PluginSetupContext } from "../src/plugin/index.js";
+import type {
+  PluginCliShortcut,
+  PluginDevSession,
+} from "../src/plugin/index.js";
 
-/** Minimal setup context satisfying collectPluginHooks without a real config. */
-const testSetupContext = {
-  mode: "development",
-  cwd: "/project",
-  config: {} as PluginSetupContext["config"],
-  logger: {} as PluginSetupContext["logger"],
-  addWatchFile() {},
-} satisfies PluginSetupContext;
-
-function createSession(): DevSession & {
-  restartServerRuntime: ReturnType<typeof vi.fn>;
+function createSession(): PluginDevSession & {
   close: ReturnType<typeof vi.fn>;
 } {
   return {
     origin: "http://localhost:3000",
-    restartServerRuntime: vi.fn().mockResolvedValue(undefined),
     close: vi.fn().mockResolvedValue(undefined),
   };
 }
 
-/**
- * A small helper that mirrors how readline consumes a stream: write a line
- * terminated by a newline. Returns a promise that resolves on the next tick so
- * the async `onLine` handler has run.
- */
-function sendLine(stream: PassThrough, line: string): Promise<void> {
-  stream.write(`${line}\n`);
-  return new Promise((resolve) => setImmediate(resolve));
-}
+describe("resolveShortcut (pure dispatch logic)", () => {
+  const shortcuts: PluginCliShortcut[] = [
+    { key: "p", description: "ping", action: vi.fn() },
+    { key: "o", description: "open", action: vi.fn() },
+  ];
 
-describe("bindCLIShortcuts", () => {
+  it("matches a registered key", () => {
+    expect(resolveShortcut("p", shortcuts)?.key).toBe("p");
+    expect(resolveShortcut("o", shortcuts)?.key).toBe("o");
+  });
+
+  it("trims whitespace and is case-insensitive", () => {
+    expect(resolveShortcut("  P ", shortcuts)?.key).toBe("p");
+    expect(resolveShortcut("O\n", shortcuts)?.key).toBe("o");
+  });
+
+  it("returns undefined for unknown keys and empty input", () => {
+    expect(resolveShortcut("z", shortcuts)).toBeUndefined();
+    expect(resolveShortcut("", shortcuts)).toBeUndefined();
+    expect(resolveShortcut("   ", shortcuts)).toBeUndefined();
+  });
+
+  it("returns a shortcut even when its action is undefined (caller skips)", () => {
+    const disabled: PluginCliShortcut[] = [
+      { key: "d", description: "disabled" },
+    ];
+    expect(resolveShortcut("d", disabled)?.key).toBe("d");
+  });
+
+  it("first registered shortcut wins when keys collide", () => {
+    const first = { key: "p", description: "first", action: vi.fn() };
+    const second = { key: "p", description: "second", action: vi.fn() };
+    // Note: dedupe happens in bindCLIShortcuts, not resolveShortcut. resolveShortcut
+    // uses Array.find and returns the FIRST match, mirroring that contract.
+    expect(resolveShortcut("p", [first, second])).toBe(first);
+  });
+});
+
+describe("bindCLIShortcuts enable/empty gating", () => {
   const originalIsTTY = process.stdin.isTTY;
   const originalCI = process.env.CI;
 
@@ -53,314 +68,36 @@ describe("bindCLIShortcuts", () => {
     else process.env.CI = originalCI;
   });
 
-  it("is a no-op when disabled (CI / non-TTY) and attaches no listeners", async () => {
-    const session = createSession();
-    const input = new PassThrough();
-    const before = input.listenerCount("data");
+  it("is a no-op when disabled and attaches nothing to stdin", () => {
     const unbind = bindCLIShortcuts(
-      session,
+      createSession(),
       {
-        customShortcuts: [
-          {
-            key: "p",
-            description: "ping",
-            action: vi.fn(),
-          },
-        ],
-        input,
+        customShortcuts: [{ key: "p", description: "ping", action: vi.fn() }],
       },
       false,
     );
     expect(typeof unbind).toBe("function");
-    expect(input.listenerCount("data")).toBe(before);
-    await sendLine(input, "p");
-    expect(session.restartServerRuntime).not.toHaveBeenCalled();
     unbind();
   });
 
-  it("dispatches a pressed key to the matching plugin shortcut action with the live session", async () => {
-    const session = createSession();
-    const action = vi.fn();
-    const input = new PassThrough();
-    const unbind = bindCLIShortcuts(
-      session,
-      {
-        customShortcuts: [{ key: "p", description: "ping", action }],
-        input,
-      },
-      true,
-    );
-    await sendLine(input, "p");
-    unbind();
-    expect(action).toHaveBeenCalledTimes(1);
-    expect(action).toHaveBeenCalledWith(session);
-  });
-
-  it("ignores unknown keys and no-ops", async () => {
-    const session = createSession();
-    const action = vi.fn();
-    const input = new PassThrough();
-    const unbind = bindCLIShortcuts(
-      session,
-      {
-        customShortcuts: [{ key: "p", description: "ping", action }],
-        input,
-      },
-      true,
-    );
-    await sendLine(input, "z");
-    await sendLine(input, "");
-    unbind();
-    expect(action).not.toHaveBeenCalled();
-  });
-
-  it("drops presses while an action is already running (actionRunning guard)", async () => {
-    const session = createSession();
-    let resolveAction: () => void = () => {};
-    const action = vi.fn(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveAction = resolve;
-        }),
-    );
-    const input = new PassThrough();
-    const unbind = bindCLIShortcuts(
-      session,
-      {
-        customShortcuts: [{ key: "p", description: "ping", action }],
-        input,
-      },
-      true,
-    );
-    await sendLine(input, "p");
-    await sendLine(input, "p"); // re-entrant press must be dropped
-    expect(action).toHaveBeenCalledTimes(1);
-    resolveAction();
-    await new Promise((resolve) => setImmediate(resolve));
-    await sendLine(input, "p"); // now allowed again
-    unbind();
-    resolveAction();
-    await new Promise((resolve) => setImmediate(resolve));
-    expect(action).toHaveBeenCalledTimes(2);
-  });
-
-  it("first writer wins: a duplicate key registered by a later plugin is ignored", async () => {
-    const session = createSession();
-    const first = vi.fn();
-    const second = vi.fn();
-    const input = new PassThrough();
-    const unbind = bindCLIShortcuts(
-      session,
-      {
-        customShortcuts: [
-          { key: "p", description: "first", action: first },
-          { key: "p", description: "second", action: second },
-        ],
-        input,
-      },
-      true,
-    );
-    await sendLine(input, "p");
-    unbind();
-    expect(first).toHaveBeenCalledTimes(1);
-    expect(second).not.toHaveBeenCalled();
-  });
-
-  it("registers an h help action that lists registered shortcuts (helpKey)", async () => {
-    const session = createSession();
-    const input = new PassThrough();
-    const unbind = bindCLIShortcuts(
-      session,
-      {
-        customShortcuts: [{ key: "p", description: "ping", action: vi.fn() }],
-        helpKey: true,
-        input,
-      },
-      true,
-    );
-    await sendLine(input, "h");
-    unbind();
-    // help action ran without throwing; no shortcut dispatched.
-    expect(session.restartServerRuntime).not.toHaveBeenCalled();
-  });
-
-  it("does not attach a readline interface when there are no shortcuts and helpKey is disabled", () => {
-    const session = createSession();
-    const input = new PassThrough();
-    const before = input.listenerCount("data");
-    const unbind = bindCLIShortcuts(session, { input }, true);
-    expect(input.listenerCount("data")).toBe(before);
-    unbind();
-  });
-
-  it("unbind removes the line listener and closes the readline interface", async () => {
-    const session = createSession();
-    const action = vi.fn();
-    const input = new PassThrough();
-    const unbind = bindCLIShortcuts(
-      session,
-      {
-        customShortcuts: [{ key: "p", description: "ping", action }],
-        input,
-      },
-      true,
-    );
-    unbind();
-    await sendLine(input, "p"); // after unbind, presses must not dispatch
-    expect(action).not.toHaveBeenCalled();
-  });
-
-  it("swallows a throwing action so the loop survives", async () => {
-    const session = createSession();
-    const action = vi.fn(() => Promise.reject(new Error("boom")));
-    const input = new PassThrough();
-    const unbind = bindCLIShortcuts(
-      session,
-      {
-        customShortcuts: [{ key: "p", description: "ping", action }],
-        input,
-      },
-      true,
-    );
-    await sendLine(input, "p");
-    unbind();
-    expect(action).toHaveBeenCalledTimes(1);
-  });
-
-  it("defaults to enabled = isTTY && !CI", () => {
+  it("defaults to disabled under CI / non-TTY", () => {
     Object.defineProperty(process.stdin, "isTTY", {
       configurable: true,
       value: false,
     });
     process.env.CI = "1";
-    const session = createSession();
-    const unbind = bindCLIShortcuts(session, {
+    const unbind = bindCLIShortcuts(createSession(), {
       customShortcuts: [{ key: "p", description: "ping", action: vi.fn() }],
     });
-    // disabled path returns a noop unbind that never attached to stdin
     expect(typeof unbind).toBe("function");
     unbind();
   });
 
-  it("a shortcut with action: undefined is registered but never runs", async () => {
-    const session = createSession();
-    const action = vi.fn();
-    const input = new PassThrough();
-    const unbind = bindCLIShortcuts(
-      session,
-      {
-        customShortcuts: [
-          { key: "p", description: "disabled" },
-          { key: "q", description: "active", action },
-        ],
-        input,
-      },
-      true,
-    );
-    await sendLine(input, "p");
-    await sendLine(input, "q");
+  it("does not attach when no plugin contributed shortcuts", () => {
+    // With helpKey removed, an empty customShortcuts list yields a no-op unbind
+    // and never touches process.stdin.
+    const unbind = bindCLIShortcuts(createSession(), {}, true);
+    expect(typeof unbind).toBe("function");
     unbind();
-    expect(action).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("plugin-contributed shortcut (end-to-end)", () => {
-  let consoleLog: ReturnType<typeof vi.spyOn>;
-
-  afterEach(() => {
-    consoleLog?.mockRestore();
-  });
-
-  it("logs the test-case name to stdout when its plugin-registered key is pressed", async () => {
-    // The test-case name is what the plugin's shortcut action writes via console.log.
-    const TEST_CASE_NAME = "test-log-fired-x4k7";
-    let resolveAction: () => void = () => {};
-    const actionRan = new Promise<void>((resolve) => {
-      resolveAction = resolve;
-    });
-
-    const input = new PassThrough();
-    const plugin: Plugin = {
-      id: "test-log-plugin",
-      setup() {
-        return {
-          configureShortcuts() {
-            return [
-              {
-                key: "t",
-                description: "log the test-case name to stdout",
-                action() {
-                  // biome-ignore lint/suspicious/noConsole: the shortcut action's job is to log the test-case name
-                  console.log(TEST_CASE_NAME);
-                  resolveAction();
-                },
-              },
-            ];
-          },
-        };
-      },
-    };
-
-    // Collect shortcuts the way the dev() orchestrator does: plugin setup hook
-    // -> lifecycle collector -> engine binding.
-    const hooks = await collectPluginHooks([plugin], testSetupContext);
-    const customShortcuts = await collectConfigureShortcutsHooks(hooks);
-    expect(customShortcuts.map((s) => s.key)).toEqual(["t"]);
-
-    consoleLog = vi.spyOn(console, "log");
-    const unbind = bindCLIShortcuts(
-      createSession(),
-      { customShortcuts, input },
-      true,
-    );
-
-    input.write("t\n");
-    await actionRan;
-    unbind();
-
-    expect(consoleLog).toHaveBeenCalledTimes(1);
-    expect(consoleLog).toHaveBeenCalledWith(TEST_CASE_NAME);
-  });
-
-  it("pressing an unregistered key does not write the test-case name", async () => {
-    const TEST_CASE_NAME = "test-log-should-not-fire";
-    const action = vi.fn(() => {
-      // biome-ignore lint/suspicious/noConsole: the shortcut action's job is to log the test-case name
-      console.log(TEST_CASE_NAME);
-    });
-    const input = new PassThrough();
-    const plugin: Plugin = {
-      id: "test-log-plugin",
-      setup() {
-        return {
-          configureShortcuts() {
-            return [
-              {
-                key: "t",
-                description: "log the test-case name to stdout",
-                action,
-              },
-            ];
-          },
-        };
-      },
-    };
-
-    const hooks = await collectPluginHooks([plugin], testSetupContext);
-    const customShortcuts = await collectConfigureShortcutsHooks(hooks);
-
-    consoleLog = vi.spyOn(console, "log");
-    const unbind = bindCLIShortcuts(
-      createSession(),
-      { customShortcuts, input },
-      true,
-    );
-
-    input.write("z\n"); // key not registered
-    await sendLine(input, "z");
-    unbind();
-
-    expect(action).not.toHaveBeenCalled();
-    expect(consoleLog).not.toHaveBeenCalled();
   });
 });

--- a/packages/ev/tests/cli-shortcuts.test.ts
+++ b/packages/ev/tests/cli-shortcuts.test.ts
@@ -4,6 +4,20 @@ import {
   bindCLIShortcuts,
   type DevSession,
 } from "../src/_internal/build/cli-shortcuts.js";
+import {
+  collectConfigureShortcutsHooks,
+  collectPluginHooks,
+} from "../src/_internal/build/plugin-lifecycle.js";
+import type { Plugin, PluginSetupContext } from "../src/plugin/index.js";
+
+/** Minimal setup context satisfying collectPluginHooks without a real config. */
+const testSetupContext = {
+  mode: "development",
+  cwd: "/project",
+  config: {} as PluginSetupContext["config"],
+  logger: {} as PluginSetupContext["logger"],
+  addWatchFile() {},
+} satisfies PluginSetupContext;
 
 function createSession(): DevSession & {
   restartServerRuntime: ReturnType<typeof vi.fn>;
@@ -247,5 +261,106 @@ describe("bindCLIShortcuts", () => {
     await sendLine(input, "q");
     unbind();
     expect(action).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("plugin-contributed shortcut (end-to-end)", () => {
+  let consoleLog: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    consoleLog?.mockRestore();
+  });
+
+  it("logs the test-case name to stdout when its plugin-registered key is pressed", async () => {
+    // The test-case name is what the plugin's shortcut action writes via console.log.
+    const TEST_CASE_NAME = "test-log-fired-x4k7";
+    let resolveAction: () => void = () => {};
+    const actionRan = new Promise<void>((resolve) => {
+      resolveAction = resolve;
+    });
+
+    const input = new PassThrough();
+    const plugin: Plugin = {
+      id: "test-log-plugin",
+      setup() {
+        return {
+          configureShortcuts() {
+            return [
+              {
+                key: "t",
+                description: "log the test-case name to stdout",
+                action() {
+                  // biome-ignore lint/suspicious/noConsole: the shortcut action's job is to log the test-case name
+                  console.log(TEST_CASE_NAME);
+                  resolveAction();
+                },
+              },
+            ];
+          },
+        };
+      },
+    };
+
+    // Collect shortcuts the way the dev() orchestrator does: plugin setup hook
+    // -> lifecycle collector -> engine binding.
+    const hooks = await collectPluginHooks([plugin], testSetupContext);
+    const customShortcuts = await collectConfigureShortcutsHooks(hooks);
+    expect(customShortcuts.map((s) => s.key)).toEqual(["t"]);
+
+    consoleLog = vi.spyOn(console, "log");
+    const unbind = bindCLIShortcuts(
+      createSession(),
+      { customShortcuts, input },
+      true,
+    );
+
+    input.write("t\n");
+    await actionRan;
+    unbind();
+
+    expect(consoleLog).toHaveBeenCalledTimes(1);
+    expect(consoleLog).toHaveBeenCalledWith(TEST_CASE_NAME);
+  });
+
+  it("pressing an unregistered key does not write the test-case name", async () => {
+    const TEST_CASE_NAME = "test-log-should-not-fire";
+    const action = vi.fn(() => {
+      // biome-ignore lint/suspicious/noConsole: the shortcut action's job is to log the test-case name
+      console.log(TEST_CASE_NAME);
+    });
+    const input = new PassThrough();
+    const plugin: Plugin = {
+      id: "test-log-plugin",
+      setup() {
+        return {
+          configureShortcuts() {
+            return [
+              {
+                key: "t",
+                description: "log the test-case name to stdout",
+                action,
+              },
+            ];
+          },
+        };
+      },
+    };
+
+    const hooks = await collectPluginHooks([plugin], testSetupContext);
+    const customShortcuts = await collectConfigureShortcutsHooks(hooks);
+
+    consoleLog = vi.spyOn(console, "log");
+    const unbind = bindCLIShortcuts(
+      createSession(),
+      { customShortcuts, input },
+      true,
+    );
+
+    input.write("z\n"); // key not registered
+    await sendLine(input, "z");
+    unbind();
+
+    expect(action).not.toHaveBeenCalled();
+    expect(consoleLog).not.toHaveBeenCalled();
   });
 });

--- a/packages/ev/tests/cli-shortcuts.test.ts
+++ b/packages/ev/tests/cli-shortcuts.test.ts
@@ -1,0 +1,251 @@
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  bindCLIShortcuts,
+  type DevSession,
+} from "../src/_internal/build/cli-shortcuts.js";
+
+function createSession(): DevSession & {
+  restartServerRuntime: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+} {
+  return {
+    origin: "http://localhost:3000",
+    restartServerRuntime: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/**
+ * A small helper that mirrors how readline consumes a stream: write a line
+ * terminated by a newline. Returns a promise that resolves on the next tick so
+ * the async `onLine` handler has run.
+ */
+function sendLine(stream: PassThrough, line: string): Promise<void> {
+  stream.write(`${line}\n`);
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("bindCLIShortcuts", () => {
+  const originalIsTTY = process.stdin.isTTY;
+  const originalCI = process.env.CI;
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: originalIsTTY,
+    });
+    if (originalCI === undefined) delete process.env.CI;
+    else process.env.CI = originalCI;
+  });
+
+  it("is a no-op when disabled (CI / non-TTY) and attaches no listeners", async () => {
+    const session = createSession();
+    const input = new PassThrough();
+    const before = input.listenerCount("data");
+    const unbind = bindCLIShortcuts(
+      session,
+      {
+        customShortcuts: [
+          {
+            key: "p",
+            description: "ping",
+            action: vi.fn(),
+          },
+        ],
+        input,
+      },
+      false,
+    );
+    expect(typeof unbind).toBe("function");
+    expect(input.listenerCount("data")).toBe(before);
+    await sendLine(input, "p");
+    expect(session.restartServerRuntime).not.toHaveBeenCalled();
+    unbind();
+  });
+
+  it("dispatches a pressed key to the matching plugin shortcut action with the live session", async () => {
+    const session = createSession();
+    const action = vi.fn();
+    const input = new PassThrough();
+    const unbind = bindCLIShortcuts(
+      session,
+      {
+        customShortcuts: [{ key: "p", description: "ping", action }],
+        input,
+      },
+      true,
+    );
+    await sendLine(input, "p");
+    unbind();
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(action).toHaveBeenCalledWith(session);
+  });
+
+  it("ignores unknown keys and no-ops", async () => {
+    const session = createSession();
+    const action = vi.fn();
+    const input = new PassThrough();
+    const unbind = bindCLIShortcuts(
+      session,
+      {
+        customShortcuts: [{ key: "p", description: "ping", action }],
+        input,
+      },
+      true,
+    );
+    await sendLine(input, "z");
+    await sendLine(input, "");
+    unbind();
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("drops presses while an action is already running (actionRunning guard)", async () => {
+    const session = createSession();
+    let resolveAction: () => void = () => {};
+    const action = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAction = resolve;
+        }),
+    );
+    const input = new PassThrough();
+    const unbind = bindCLIShortcuts(
+      session,
+      {
+        customShortcuts: [{ key: "p", description: "ping", action }],
+        input,
+      },
+      true,
+    );
+    await sendLine(input, "p");
+    await sendLine(input, "p"); // re-entrant press must be dropped
+    expect(action).toHaveBeenCalledTimes(1);
+    resolveAction();
+    await new Promise((resolve) => setImmediate(resolve));
+    await sendLine(input, "p"); // now allowed again
+    unbind();
+    resolveAction();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(action).toHaveBeenCalledTimes(2);
+  });
+
+  it("first writer wins: a duplicate key registered by a later plugin is ignored", async () => {
+    const session = createSession();
+    const first = vi.fn();
+    const second = vi.fn();
+    const input = new PassThrough();
+    const unbind = bindCLIShortcuts(
+      session,
+      {
+        customShortcuts: [
+          { key: "p", description: "first", action: first },
+          { key: "p", description: "second", action: second },
+        ],
+        input,
+      },
+      true,
+    );
+    await sendLine(input, "p");
+    unbind();
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it("registers an h help action that lists registered shortcuts (helpKey)", async () => {
+    const session = createSession();
+    const input = new PassThrough();
+    const unbind = bindCLIShortcuts(
+      session,
+      {
+        customShortcuts: [{ key: "p", description: "ping", action: vi.fn() }],
+        helpKey: true,
+        input,
+      },
+      true,
+    );
+    await sendLine(input, "h");
+    unbind();
+    // help action ran without throwing; no shortcut dispatched.
+    expect(session.restartServerRuntime).not.toHaveBeenCalled();
+  });
+
+  it("does not attach a readline interface when there are no shortcuts and helpKey is disabled", () => {
+    const session = createSession();
+    const input = new PassThrough();
+    const before = input.listenerCount("data");
+    const unbind = bindCLIShortcuts(session, { input }, true);
+    expect(input.listenerCount("data")).toBe(before);
+    unbind();
+  });
+
+  it("unbind removes the line listener and closes the readline interface", async () => {
+    const session = createSession();
+    const action = vi.fn();
+    const input = new PassThrough();
+    const unbind = bindCLIShortcuts(
+      session,
+      {
+        customShortcuts: [{ key: "p", description: "ping", action }],
+        input,
+      },
+      true,
+    );
+    unbind();
+    await sendLine(input, "p"); // after unbind, presses must not dispatch
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("swallows a throwing action so the loop survives", async () => {
+    const session = createSession();
+    const action = vi.fn(() => Promise.reject(new Error("boom")));
+    const input = new PassThrough();
+    const unbind = bindCLIShortcuts(
+      session,
+      {
+        customShortcuts: [{ key: "p", description: "ping", action }],
+        input,
+      },
+      true,
+    );
+    await sendLine(input, "p");
+    unbind();
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults to enabled = isTTY && !CI", () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+    process.env.CI = "1";
+    const session = createSession();
+    const unbind = bindCLIShortcuts(session, {
+      customShortcuts: [{ key: "p", description: "ping", action: vi.fn() }],
+    });
+    // disabled path returns a noop unbind that never attached to stdin
+    expect(typeof unbind).toBe("function");
+    unbind();
+  });
+
+  it("a shortcut with action: undefined is registered but never runs", async () => {
+    const session = createSession();
+    const action = vi.fn();
+    const input = new PassThrough();
+    const unbind = bindCLIShortcuts(
+      session,
+      {
+        customShortcuts: [
+          { key: "p", description: "disabled" },
+          { key: "q", description: "active", action },
+        ],
+        input,
+      },
+      true,
+    );
+    await sendLine(input, "p");
+    await sendLine(input, "q");
+    unbind();
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -13923,6 +13923,7 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
       "export default function Home() { return null; }",
       "utf-8",
     );
+    const shortcutAction = vi.fn();
 
     const bundler: BundlerAdapter<Record<string, never>> = {
       name: "mock",
@@ -13935,6 +13936,10 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
           origin: "http://localhost:4722",
         });
         await new Promise((resolve) => setImmediate(resolve));
+        expect(fakeStdin.listenerCount("data")).toBe(dataListenerCountBefore);
+        fakeStdin.write("t\n");
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(shortcutAction).not.toHaveBeenCalled();
         process.emit("SIGINT");
       },
     };
@@ -13944,7 +13949,13 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
       setup() {
         return {
           configureShortcuts() {
-            return [{ key: "t", description: "should not fire", action() {} }];
+            return [
+              {
+                key: "t",
+                description: "should not fire",
+                action: shortcutAction,
+              },
+            ];
           },
         };
       },
@@ -13976,6 +13987,693 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
     // With the engine disabled, no readline 'line' listener was attached to
     // the fake stdin beyond whatever existed before dev().
     expect(fakeStdin.listenerCount("data")).toBe(dataListenerCountBefore);
+  });
+
+  it("applies the cliShortcuts:false override when no config file exists", async () => {
+    const cwd = await createProject();
+    let observedCliShortcuts: boolean | undefined;
+    const bundler: BundlerAdapter<Record<string, never>> = {
+      name: "mock",
+      capabilities: fullBundlerCapabilities,
+      async build() {
+        return {};
+      },
+      async dev({ config }) {
+        observedCliShortcuts = config.dev.cliShortcuts;
+        process.emit("SIGINT");
+      },
+    };
+
+    await dev(undefined, {
+      cwd,
+      bundler,
+      cliShortcuts: false,
+      loadConfig: async () => undefined,
+      reloadInitialConfig: true,
+    });
+
+    expect(observedCliShortcuts).toBe(false);
+  });
+
+  it("replaces plugin CLI shortcuts transactionally across config reloads", async () => {
+    const originalStdin = process.stdin;
+    const originalCI = process.env.CI;
+    const fakeStdin = new PassThrough();
+    Object.defineProperty(fakeStdin, "isTTY", { value: true });
+    Object.defineProperty(process, "stdin", {
+      configurable: true,
+      value: fakeStdin,
+    });
+    delete process.env.CI;
+    const dataListenerCountBefore = fakeStdin.listenerCount("data");
+
+    const cwd = await createProject();
+    const configPath = path.join(cwd, "ev.config.ts");
+    await writeFile(configPath, "export default {};", "utf-8");
+    const controlledWatch = installControlledFsWatch();
+    await writeFile(
+      path.join(cwd, "src/pages/page.tsx"),
+      "export default function Home() { return null; }",
+      "utf-8",
+    );
+    const events: string[] = [];
+    function createPlugin(label: string): Plugin<Record<string, never>> {
+      return {
+        id: "reload-shortcuts",
+        setup() {
+          events.push(`setup:${label}`);
+          return {
+            configureShortcuts() {
+              return [
+                {
+                  key: "t",
+                  description: `shortcut ${label}`,
+                  action() {
+                    events.push(`shortcut:${label}`);
+                  },
+                },
+              ];
+            },
+            dispose() {
+              events.push(`dispose:${label}`);
+            },
+          };
+        },
+      };
+    }
+
+    let currentConfig: Config<Record<string, never>> = {
+      routing: { mode: "mpa" },
+      plugins: [createPlugin("v1")],
+    };
+    const bundler: BundlerAdapter<Record<string, never>> = {
+      name: "mock",
+      capabilities: fullBundlerCapabilities,
+      async build() {
+        return {};
+      },
+      async dev({ callbacks }) {
+        await callbacks.onDevServerReady?.({
+          origin: "http://localhost:4733",
+        });
+        events.push("ready");
+        return createTestDevController({
+          async updatePlan(_update, options) {
+            options.activate();
+            events.push("update");
+          },
+        });
+      },
+    };
+
+    const running = dev(currentConfig, {
+      cwd,
+      bundler,
+      loadConfig() {
+        return currentConfig;
+      },
+    });
+    let settled = false;
+    void running.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    try {
+      await waitForEvent(events, "ready");
+      expect(fakeStdin.listenerCount("data")).toBe(dataListenerCountBefore + 1);
+      fakeStdin.write("t\n");
+      await waitForEvent(events, "shortcut:v1");
+
+      currentConfig = {
+        ...currentConfig,
+        plugins: [createPlugin("v2")],
+      };
+      await writeFile(
+        configPath,
+        "export default {}; // shortcuts v2",
+        "utf-8",
+      );
+      await controlledWatch.dispatchFileChange(configPath);
+      await waitForEvent(events, "dispose:v1");
+      fakeStdin.write("t\n");
+      await waitForEvent(events, "shortcut:v2");
+      expect(events.filter((event) => event === "shortcut:v1")).toHaveLength(1);
+
+      currentConfig = {
+        ...currentConfig,
+        dev: { cliShortcuts: false },
+        plugins: [createPlugin("v3")],
+      };
+      await writeFile(
+        configPath,
+        "export default {}; // shortcuts disabled",
+        "utf-8",
+      );
+      await controlledWatch.dispatchFileChange(configPath);
+      await waitForEvent(events, "dispose:v2");
+      expect(fakeStdin.listenerCount("data")).toBe(dataListenerCountBefore);
+      fakeStdin.write("t\n");
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(events).not.toContain("shortcut:v3");
+
+      process.emit("SIGINT");
+      await running;
+    } finally {
+      if (!settled) {
+        process.emit("SIGINT");
+        await running.catch(() => {});
+      }
+      Object.defineProperty(process, "stdin", {
+        configurable: true,
+        value: originalStdin,
+      });
+      if (originalCI === undefined) delete process.env.CI;
+      else process.env.CI = originalCI;
+      controlledWatch.restore();
+    }
+
+    expect(events).toContain("dispose:v3");
+  });
+
+  it("keeps committed CLI shortcuts when a candidate dev update rolls back", async () => {
+    const originalStdin = process.stdin;
+    const originalCI = process.env.CI;
+    const fakeStdin = new PassThrough();
+    Object.defineProperty(fakeStdin, "isTTY", { value: true });
+    Object.defineProperty(process, "stdin", {
+      configurable: true,
+      value: fakeStdin,
+    });
+    delete process.env.CI;
+
+    const cwd = await createProject();
+    const configPath = path.join(cwd, "ev.config.ts");
+    await writeFile(configPath, "export default {};", "utf-8");
+    const controlledWatch = installControlledFsWatch();
+    await writeFile(
+      path.join(cwd, "src/pages/page.tsx"),
+      "export default function Home() { return null; }",
+      "utf-8",
+    );
+    const events: string[] = [];
+    const createPlugin = (label: string): Plugin<Record<string, never>> => ({
+      id: "rollback-shortcuts",
+      setup() {
+        events.push(`setup:${label}`);
+        return {
+          configureShortcuts() {
+            return [
+              {
+                key: "t",
+                description: `shortcut ${label}`,
+                action() {
+                  events.push(`shortcut:${label}`);
+                },
+              },
+            ];
+          },
+          dispose() {
+            events.push(`dispose:${label}`);
+          },
+        };
+      },
+    });
+    let currentConfig: Config<Record<string, never>> = {
+      routing: { mode: "mpa" },
+      plugins: [createPlugin("v1")],
+    };
+    const bundler: BundlerAdapter<Record<string, never>> = {
+      name: "mock",
+      capabilities: fullBundlerCapabilities,
+      async build() {
+        return {};
+      },
+      async dev({ callbacks }) {
+        await callbacks.onDevServerReady?.({
+          origin: "http://localhost:4744",
+        });
+        events.push("ready");
+        return createTestDevController({
+          async updatePlan(_update, options) {
+            options.activate();
+            await callbacks.onDevServerReady?.({
+              origin: "http://localhost:4745",
+            });
+            events.push("update:throw");
+            throw new Error("candidate update failed");
+          },
+        });
+      },
+    };
+
+    const running = dev(currentConfig, {
+      cwd,
+      bundler,
+      loadConfig() {
+        return currentConfig;
+      },
+    });
+    let settled = false;
+    void running.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    try {
+      await waitForEvent(events, "ready");
+      fakeStdin.write("t\n");
+      await waitForEvent(events, "shortcut:v1");
+
+      currentConfig = {
+        ...currentConfig,
+        plugins: [createPlugin("v2")],
+      };
+      await writeFile(
+        configPath,
+        "export default {}; // rollback shortcuts",
+        "utf-8",
+      );
+      await controlledWatch.dispatchFileChange(configPath);
+      await waitForEvent(events, "dispose:v2");
+
+      fakeStdin.write("t\n");
+      await vi.waitFor(() => {
+        expect(events.filter((event) => event === "shortcut:v1")).toHaveLength(
+          2,
+        );
+      });
+      expect(events).not.toContain("shortcut:v2");
+
+      process.emit("SIGINT");
+      await running;
+    } finally {
+      if (!settled) {
+        process.emit("SIGINT");
+        await running.catch(() => {});
+      }
+      Object.defineProperty(process, "stdin", {
+        configurable: true,
+        value: originalStdin,
+      });
+      if (originalCI === undefined) delete process.env.CI;
+      else process.env.CI = originalCI;
+      controlledWatch.restore();
+    }
+  });
+
+  it("defers old plugin disposal and restores shortcuts after a slow action", async () => {
+    const originalStdin = process.stdin;
+    const originalCI = process.env.CI;
+    const fakeStdin = new PassThrough();
+    Object.defineProperty(fakeStdin, "isTTY", { value: true });
+    Object.defineProperty(process, "stdin", {
+      configurable: true,
+      value: fakeStdin,
+    });
+    delete process.env.CI;
+    const dataListenerCountBefore = fakeStdin.listenerCount("data");
+
+    const cwd = await createProject();
+    const configPath = path.join(cwd, "ev.config.ts");
+    await writeFile(configPath, "export default {};", "utf-8");
+    const controlledWatch = installControlledFsWatch();
+    await writeFile(
+      path.join(cwd, "src/pages/page.tsx"),
+      "export default function Home() { return null; }",
+      "utf-8",
+    );
+    const events: string[] = [];
+    let finishSlowAction: () => void = () => {};
+    const slowAction = new Promise<void>((resolve) => {
+      finishSlowAction = resolve;
+    });
+    const createPlugin = (label: "v1" | "v2"): Plugin => ({
+      id: "slow-reload-shortcut",
+      setup() {
+        events.push(`setup:${label}`);
+        return {
+          configureShortcuts() {
+            return [
+              {
+                key: "t",
+                description: `shortcut ${label}`,
+                action() {
+                  events.push(`shortcut:${label}`);
+                  return label === "v1" ? slowAction : undefined;
+                },
+              },
+            ];
+          },
+          dispose() {
+            events.push(`dispose:${label}`);
+          },
+        };
+      },
+    });
+    let currentConfig: Config = {
+      routing: { mode: "mpa" },
+      plugins: [createPlugin("v1")],
+    };
+    const bundler: BundlerAdapter<Record<string, never>> = {
+      name: "mock",
+      capabilities: fullBundlerCapabilities,
+      async build() {
+        return {};
+      },
+      async dev({ callbacks }) {
+        await callbacks.onDevServerReady?.({
+          origin: "http://localhost:4766",
+        });
+        events.push("ready");
+        return createTestDevController({
+          async updatePlan(_update, options) {
+            options.activate();
+            events.push("update");
+          },
+        });
+      },
+    };
+
+    const running = dev(currentConfig, {
+      cwd,
+      bundler,
+      loadConfig() {
+        return currentConfig;
+      },
+    });
+    let settled = false;
+    void running.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    try {
+      await waitForEvent(events, "ready");
+      fakeStdin.write("t\n");
+      await waitForEvent(events, "shortcut:v1");
+
+      currentConfig = {
+        ...currentConfig,
+        plugins: [createPlugin("v2")],
+      };
+      await writeFile(
+        configPath,
+        "export default {}; // slow action reload",
+        "utf-8",
+      );
+      await controlledWatch.dispatchFileChange(configPath);
+      await waitForEvent(events, "update");
+      await vi.waitFor(
+        () => {
+          expect(fakeStdin.listenerCount("data")).toBe(dataListenerCountBefore);
+        },
+        { timeout: 2_000 },
+      );
+      expect(events).not.toContain("dispose:v1");
+
+      finishSlowAction();
+      await waitForEvent(events, "dispose:v1");
+      await vi.waitFor(() => {
+        expect(fakeStdin.listenerCount("data")).toBe(
+          dataListenerCountBefore + 1,
+        );
+      });
+      fakeStdin.write("t\n");
+      await waitForEvent(events, "shortcut:v2");
+
+      process.emit("SIGINT");
+      await running;
+    } finally {
+      finishSlowAction();
+      if (!settled) {
+        process.emit("SIGINT");
+        await running.catch(() => {});
+      }
+      Object.defineProperty(process, "stdin", {
+        configurable: true,
+        value: originalStdin,
+      });
+      if (originalCI === undefined) delete process.env.CI;
+      else process.env.CI = originalCI;
+      controlledWatch.restore();
+    }
+
+    expect(events).toContain("dispose:v2");
+  });
+
+  it("attempts every plugin disposal when shutdown follows a reload", async () => {
+    const originalStdin = process.stdin;
+    const originalCI = process.env.CI;
+    const fakeStdin = new PassThrough();
+    Object.defineProperty(fakeStdin, "isTTY", { value: true });
+    Object.defineProperty(process, "stdin", {
+      configurable: true,
+      value: fakeStdin,
+    });
+    delete process.env.CI;
+    const dataListenerCountBefore = fakeStdin.listenerCount("data");
+
+    const cwd = await createProject();
+    const configPath = path.join(cwd, "ev.config.ts");
+    await writeFile(configPath, "export default {};", "utf-8");
+    const controlledWatch = installControlledFsWatch();
+    await writeFile(
+      path.join(cwd, "src/pages/page.tsx"),
+      "export default function Home() { return null; }",
+      "utf-8",
+    );
+    const events: string[] = [];
+    const resources = new Set<ReturnType<typeof setInterval>>();
+    const createPlugin = (label: "v1" | "v2"): Plugin => ({
+      id: "retired-stuck-shortcut",
+      setup() {
+        const resource = setInterval(() => {}, 1_000);
+        resources.add(resource);
+        return {
+          configureShortcuts() {
+            return [
+              {
+                key: "t",
+                description: `shortcut ${label}`,
+                action() {
+                  events.push(`shortcut:${label}`);
+                  return label === "v1"
+                    ? new Promise<void>(() => {})
+                    : undefined;
+                },
+              },
+            ];
+          },
+          dispose() {
+            clearInterval(resource);
+            resources.delete(resource);
+            events.push(`dispose:${label}`);
+            if (label === "v1") throw new Error("retired dispose failed");
+          },
+        };
+      },
+    });
+    let currentConfig: Config = {
+      routing: { mode: "mpa" },
+      plugins: [createPlugin("v1")],
+    };
+    const bundler: BundlerAdapter<Record<string, never>> = {
+      name: "mock",
+      capabilities: fullBundlerCapabilities,
+      async build() {
+        return {};
+      },
+      async dev({ callbacks }) {
+        await callbacks.onDevServerReady?.({
+          origin: "http://localhost:4767",
+        });
+        events.push("ready");
+        return createTestDevController({
+          async updatePlan(_update, options) {
+            options.activate();
+            events.push("update");
+          },
+        });
+      },
+    };
+
+    const running = dev(currentConfig, {
+      cwd,
+      bundler,
+      loadConfig() {
+        return currentConfig;
+      },
+    });
+    let settled = false;
+    void running.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    try {
+      await waitForEvent(events, "ready");
+      fakeStdin.write("t\n");
+      await waitForEvent(events, "shortcut:v1");
+
+      currentConfig = {
+        ...currentConfig,
+        plugins: [createPlugin("v2")],
+      };
+      await writeFile(
+        configPath,
+        "export default {}; // retired stuck action",
+        "utf-8",
+      );
+      await controlledWatch.dispatchFileChange(configPath);
+      await waitForEvent(events, "update");
+      await vi.waitFor(
+        () => {
+          expect(fakeStdin.listenerCount("data")).toBe(dataListenerCountBefore);
+        },
+        { timeout: 2_000 },
+      );
+      expect(events).not.toContain("dispose:v1");
+
+      process.emit("SIGINT");
+      await expect(
+        Promise.race([
+          running,
+          new Promise((_, reject) =>
+            setTimeout(
+              () => reject(new Error("retired plugin blocked shutdown")),
+              2_000,
+            ),
+          ),
+        ]),
+      ).rejects.toThrow("retired dispose failed");
+    } finally {
+      if (!settled) {
+        process.emit("SIGINT");
+        await running.catch(() => {});
+      }
+      for (const resource of resources) clearInterval(resource);
+      Object.defineProperty(process, "stdin", {
+        configurable: true,
+        value: originalStdin,
+      });
+      if (originalCI === undefined) delete process.env.CI;
+      else process.env.CI = originalCI;
+      controlledWatch.restore();
+    }
+
+    expect(events.filter((event) => event === "dispose:v1")).toHaveLength(1);
+    expect(events.filter((event) => event === "dispose:v2")).toHaveLength(1);
+    expect(resources.size).toBe(0);
+  });
+
+  it("does not let a stuck shortcut action block dev shutdown", async () => {
+    const originalStdin = process.stdin;
+    const originalCI = process.env.CI;
+    const fakeStdin = new PassThrough();
+    Object.defineProperty(fakeStdin, "isTTY", { value: true });
+    Object.defineProperty(process, "stdin", {
+      configurable: true,
+      value: fakeStdin,
+    });
+    delete process.env.CI;
+
+    const cwd = await createProject();
+    await writeFile(
+      path.join(cwd, "src/pages/page.tsx"),
+      "export default function Home() { return null; }",
+      "utf-8",
+    );
+    let markShortcutStarted: () => void = () => {};
+    const shortcutStarted = new Promise<void>((resolve) => {
+      markShortcutStarted = resolve;
+    });
+    let pluginResource: ReturnType<typeof setInterval> | undefined;
+    const dispose = vi.fn(() => {
+      if (pluginResource) clearInterval(pluginResource);
+      pluginResource = undefined;
+    });
+    const plugin: Plugin = {
+      id: "stuck-shortcut",
+      setup() {
+        pluginResource = setInterval(() => {}, 1_000);
+        return {
+          configureShortcuts() {
+            return [
+              {
+                key: "p",
+                description: "pending forever",
+                action() {
+                  markShortcutStarted();
+                  return new Promise<void>(() => {});
+                },
+              },
+            ];
+          },
+          dispose,
+        };
+      },
+    };
+    const bundler: BundlerAdapter<Record<string, never>> = {
+      name: "mock",
+      capabilities: fullBundlerCapabilities,
+      async build() {
+        return {};
+      },
+      async dev({ callbacks }) {
+        await callbacks.onDevServerReady?.({
+          origin: "http://localhost:4755",
+        });
+        fakeStdin.write("p\n");
+        await shortcutStarted;
+        process.emit("SIGINT");
+      },
+    };
+
+    try {
+      await expect(
+        Promise.race([
+          dev(
+            {
+              routing: { mode: "mpa" },
+              plugins: [plugin],
+            },
+            { cwd, bundler },
+          ),
+          new Promise((_, reject) =>
+            setTimeout(
+              () => reject(new Error("stuck shortcut blocked shutdown")),
+              500,
+            ),
+          ),
+        ]),
+      ).resolves.toBeUndefined();
+      expect(dispose).toHaveBeenCalledOnce();
+    } finally {
+      if (pluginResource) clearInterval(pluginResource);
+      Object.defineProperty(process, "stdin", {
+        configurable: true,
+        value: originalStdin,
+      });
+      if (originalCI === undefined) delete process.env.CI;
+      else process.env.CI = originalCI;
+    }
   });
 
   it("updates generated SPA route types when a nested page route is added during dev", async () => {

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -4,6 +4,7 @@ import fsPromises from "node:fs/promises";
 import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import {
   type BuildOutput,
   type BuildPlan,
@@ -13785,6 +13786,196 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
       .flatMap((entries) => entries ?? [])
       .some((entry) => entry.family === "IPv4" && !entry.internal);
     expect(readyLog?.includes("  Network: ")).toBe(hasNetworkAddress);
+  });
+
+  it("binds plugin CLI shortcuts to the live dev session origin on DevServerReady", async () => {
+    const originalStdin = process.stdin;
+    const originalIsTTY = process.stdin.isTTY;
+    const originalCI = process.env.CI;
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    delete process.env.CI;
+
+    // A fake readable stdin: a PassThrough is a real Readable, so
+    // readline.createInterface({ input }) fully drives it. pressing "t" is
+    // simulated by writing "t\n" to it after the engine has bound.
+    const fakeStdin = new PassThrough();
+    Object.defineProperty(fakeStdin, "isTTY", { value: true });
+    Object.defineProperty(fakeStdin, "setRawMode", { value: () => {} });
+    Object.defineProperty(process, "stdin", {
+      configurable: true,
+      value: fakeStdin,
+    });
+
+    const cwd = await createProject();
+    await writeFile(
+      path.join(cwd, "src/pages/page.tsx"),
+      "export default function Home() { return null; }",
+      "utf-8",
+    );
+
+    const ORIGIN = "http://localhost:4711";
+    let resolveShortcutFired: () => void = () => {};
+    const shortcutFired = new Promise<{ origin: string }>((resolve) => {
+      resolveShortcutFired = () => resolve({ origin: ORIGIN });
+    });
+    let observedOrigin: string | undefined;
+
+    const bundler: BundlerAdapter<Record<string, never>> = {
+      name: "mock",
+      capabilities: fullBundlerCapabilities,
+      async build() {
+        return {};
+      },
+      async dev({ callbacks }) {
+        await callbacks.onDevServerReady?.({ origin: ORIGIN });
+        // Wait at least one macrotask so the engine's
+        // collectConfigureShortcutsHooks().then(bind) microtask has run before
+        // we emit the key press, then emit SIGINT to end the session.
+        await new Promise((resolve) => setImmediate(resolve));
+        fakeStdin.write("t\n");
+        await Promise.race([
+          shortcutFired,
+          new Promise((_, reject) =>
+            setTimeout(
+              () => reject(new Error("plugin shortcut never fired")),
+              devStartupTimeoutMs,
+            ),
+          ),
+        ]);
+        process.emit("SIGINT");
+      },
+    };
+
+    const plugin: Plugin = {
+      id: "log-origin-shortcut",
+      setup() {
+        return {
+          configureShortcuts() {
+            return [
+              {
+                key: "t",
+                description: "log the dev origin",
+                action(session) {
+                  observedOrigin = session.origin;
+                  resolveShortcutFired();
+                },
+              },
+            ];
+          },
+        };
+      },
+    };
+
+    try {
+      await dev(
+        {
+          output: { client: "dist/client", server: "dist/server" },
+          dev: { port: 4711 },
+          routing: { mode: "mpa" },
+          plugins: [plugin],
+        },
+        { cwd, bundler },
+      );
+    } finally {
+      Object.defineProperty(process, "stdin", {
+        configurable: true,
+        value: originalStdin,
+      });
+      Object.defineProperty(originalStdin, "isTTY", {
+        configurable: true,
+        value: originalIsTTY,
+      });
+      if (originalCI === undefined) delete process.env.CI;
+      else process.env.CI = originalCI;
+    }
+
+    expect(observedOrigin).toBe(ORIGIN);
+    // The dev session must end cleanly (shortcut action returned; SIGINT shut it down).
+    expect(await shortcutFired).toEqual({ origin: ORIGIN });
+  });
+
+  it("does not bind CLI shortcuts when dev.cliShortcuts is false", async () => {
+    const originalStdin = process.stdin;
+    const originalIsTTY = process.stdin.isTTY;
+    const originalCI = process.env.CI;
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    delete process.env.CI;
+
+    const fakeStdin = new PassThrough();
+    Object.defineProperty(fakeStdin, "isTTY", { value: true });
+    Object.defineProperty(fakeStdin, "setRawMode", { value: () => {} });
+    Object.defineProperty(process, "stdin", {
+      configurable: true,
+      value: fakeStdin,
+    });
+
+    const dataListenerCountBefore = fakeStdin.listenerCount("data");
+
+    const cwd = await createProject();
+    await writeFile(
+      path.join(cwd, "src/pages/page.tsx"),
+      "export default function Home() { return null; }",
+      "utf-8",
+    );
+
+    const bundler: BundlerAdapter<Record<string, never>> = {
+      name: "mock",
+      capabilities: fullBundlerCapabilities,
+      async build() {
+        return {};
+      },
+      async dev({ callbacks }) {
+        await callbacks.onDevServerReady?.({
+          origin: "http://localhost:4722",
+        });
+        await new Promise((resolve) => setImmediate(resolve));
+        process.emit("SIGINT");
+      },
+    };
+
+    const plugin: Plugin = {
+      id: "would-fire-shortcut",
+      setup() {
+        return {
+          configureShortcuts() {
+            return [{ key: "t", description: "should not fire", action() {} }];
+          },
+        };
+      },
+    };
+
+    try {
+      await dev(
+        {
+          output: { client: "dist/client", server: "dist/server" },
+          dev: { port: 4722, cliShortcuts: false },
+          routing: { mode: "mpa" },
+          plugins: [plugin],
+        },
+        { cwd, bundler },
+      );
+    } finally {
+      Object.defineProperty(process, "stdin", {
+        configurable: true,
+        value: originalStdin,
+      });
+      Object.defineProperty(originalStdin, "isTTY", {
+        configurable: true,
+        value: originalIsTTY,
+      });
+      if (originalCI === undefined) delete process.env.CI;
+      else process.env.CI = originalCI;
+    }
+
+    // With the engine disabled, no readline 'line' listener was attached to
+    // the fake stdin beyond whatever existed before dev().
+    expect(fakeStdin.listenerCount("data")).toBe(dataListenerCountBefore);
   });
 
   it("updates generated SPA route types when a nested page route is added during dev", async () => {

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -13832,7 +13832,7 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
       async dev({ callbacks }) {
         await callbacks.onDevServerReady?.({ origin: ORIGIN });
         // Wait at least one macrotask so the engine's
-        // collectConfigureShortcutsHooks().then(bind) microtask has run before
+        // collectPluginCliShortcuts().then(bind) microtask has run before
         // we emit the key press, then emit SIGINT to end the session.
         await new Promise((resolve) => setImmediate(resolve));
         fakeStdin.write("t\n");
@@ -13851,24 +13851,19 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
 
     const plugin: Plugin = {
       id: "log-origin-shortcut",
-      setup() {
-        return {
-          configureShortcuts() {
-            return [
-              {
-                key: "t",
-                description: "log the dev origin",
-                action(session) {
-                  observedOrigin = session.origin;
-                  resolveShortcutFired();
-                },
-              },
-            ];
+      cliShortcuts() {
+        return [
+          {
+            key: "t",
+            description: "log the dev origin",
+            action(session) {
+              observedOrigin = session.origin;
+              resolveShortcutFired();
+            },
           },
-        };
+        ];
       },
     };
-
     try {
       await dev(
         {
@@ -13924,6 +13919,13 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
       "utf-8",
     );
     const shortcutAction = vi.fn();
+    const cliShortcuts = vi.fn(() => [
+      {
+        key: "t",
+        description: "should not fire",
+        action: shortcutAction,
+      },
+    ]);
 
     const bundler: BundlerAdapter<Record<string, never>> = {
       name: "mock",
@@ -13946,19 +13948,7 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
 
     const plugin: Plugin = {
       id: "would-fire-shortcut",
-      setup() {
-        return {
-          configureShortcuts() {
-            return [
-              {
-                key: "t",
-                description: "should not fire",
-                action: shortcutAction,
-              },
-            ];
-          },
-        };
-      },
+      cliShortcuts,
     };
 
     try {
@@ -13987,6 +13977,7 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
     // With the engine disabled, no readline 'line' listener was attached to
     // the fake stdin beyond whatever existed before dev().
     expect(fakeStdin.listenerCount("data")).toBe(dataListenerCountBefore);
+    expect(cliShortcuts).not.toHaveBeenCalled();
   });
 
   it("applies the cliShortcuts:false override when no config file exists", async () => {
@@ -14040,20 +14031,21 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
     function createPlugin(label: string): Plugin<Record<string, never>> {
       return {
         id: "reload-shortcuts",
+        cliShortcuts() {
+          events.push(`contribute:${label}`);
+          return [
+            {
+              key: "t",
+              description: `shortcut ${label}`,
+              action() {
+                events.push(`shortcut:${label}`);
+              },
+            },
+          ];
+        },
         setup() {
           events.push(`setup:${label}`);
           return {
-            configureShortcuts() {
-              return [
-                {
-                  key: "t",
-                  description: `shortcut ${label}`,
-                  action() {
-                    events.push(`shortcut:${label}`);
-                  },
-                },
-              ];
-            },
             dispose() {
               events.push(`dispose:${label}`);
             },
@@ -14157,6 +14149,9 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
       controlledWatch.restore();
     }
 
+    expect(events.filter((event) => event === "contribute:v1")).toHaveLength(1);
+    expect(events.filter((event) => event === "contribute:v2")).toHaveLength(1);
+    expect(events).not.toContain("contribute:v3");
     expect(events).toContain("dispose:v3");
   });
 
@@ -14183,20 +14178,20 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
     const events: string[] = [];
     const createPlugin = (label: string): Plugin<Record<string, never>> => ({
       id: "rollback-shortcuts",
+      cliShortcuts() {
+        return [
+          {
+            key: "t",
+            description: `shortcut ${label}`,
+            action() {
+              events.push(`shortcut:${label}`);
+            },
+          },
+        ];
+      },
       setup() {
         events.push(`setup:${label}`);
         return {
-          configureShortcuts() {
-            return [
-              {
-                key: "t",
-                description: `shortcut ${label}`,
-                action() {
-                  events.push(`shortcut:${label}`);
-                },
-              },
-            ];
-          },
           dispose() {
             events.push(`dispose:${label}`);
           },
@@ -14318,21 +14313,21 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
     });
     const createPlugin = (label: "v1" | "v2"): Plugin => ({
       id: "slow-reload-shortcut",
+      cliShortcuts() {
+        return [
+          {
+            key: "t",
+            description: `shortcut ${label}`,
+            action() {
+              events.push(`shortcut:${label}`);
+              return label === "v1" ? slowAction : undefined;
+            },
+          },
+        ];
+      },
       setup() {
         events.push(`setup:${label}`);
         return {
-          configureShortcuts() {
-            return [
-              {
-                key: "t",
-                description: `shortcut ${label}`,
-                action() {
-                  events.push(`shortcut:${label}`);
-                  return label === "v1" ? slowAction : undefined;
-                },
-              },
-            ];
-          },
           dispose() {
             events.push(`dispose:${label}`);
           },
@@ -14459,24 +14454,22 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
     const resources = new Set<ReturnType<typeof setInterval>>();
     const createPlugin = (label: "v1" | "v2"): Plugin => ({
       id: "retired-stuck-shortcut",
+      cliShortcuts() {
+        return [
+          {
+            key: "t",
+            description: `shortcut ${label}`,
+            action() {
+              events.push(`shortcut:${label}`);
+              return label === "v1" ? new Promise<void>(() => {}) : undefined;
+            },
+          },
+        ];
+      },
       setup() {
         const resource = setInterval(() => {}, 1_000);
         resources.add(resource);
         return {
-          configureShortcuts() {
-            return [
-              {
-                key: "t",
-                description: `shortcut ${label}`,
-                action() {
-                  events.push(`shortcut:${label}`);
-                  return label === "v1"
-                    ? new Promise<void>(() => {})
-                    : undefined;
-                },
-              },
-            ];
-          },
           dispose() {
             clearInterval(resource);
             resources.delete(resource);
@@ -14611,21 +14604,21 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
     });
     const plugin: Plugin = {
       id: "stuck-shortcut",
+      cliShortcuts() {
+        return [
+          {
+            key: "p",
+            description: "pending forever",
+            action() {
+              markShortcutStarted();
+              return new Promise<void>(() => {});
+            },
+          },
+        ];
+      },
       setup() {
         pluginResource = setInterval(() => {}, 1_000);
         return {
-          configureShortcuts() {
-            return [
-              {
-                key: "p",
-                description: "pending forever",
-                action() {
-                  markShortcutStarted();
-                  return new Promise<void>(() => {});
-                },
-              },
-            ];
-          },
           dispose,
         };
       },
@@ -14659,7 +14652,7 @@ describe("dev", { timeout: devUpdateTimeoutMs + 5_000 }, () => {
           new Promise((_, reject) =>
             setTimeout(
               () => reject(new Error("stuck shortcut blocked shutdown")),
-              500,
+              devStartupTimeoutMs,
             ),
           ),
         ]),

--- a/packages/ev/tests/config.test.ts
+++ b/packages/ev/tests/config.test.ts
@@ -494,6 +494,14 @@ describe("resolveConfig", () => {
     expect(resolveConfig({}).dev.cliShortcuts).toBe(true);
   });
 
+  it("rejects non-boolean dev.cliShortcuts values", () => {
+    for (const cliShortcuts of ["false", 0, null, {}, []]) {
+      expect(() =>
+        resolveConfig({ dev: { cliShortcuts } } as unknown as Config),
+      ).toThrow("[evjs] dev.cliShortcuts must be a boolean when provided.");
+    }
+  });
+
   it("accepts only plain config records at root and nested boundaries", () => {
     class ConfigRecord {
       readonly mode = "spa";

--- a/packages/ev/tests/config.test.ts
+++ b/packages/ev/tests/config.test.ts
@@ -1148,11 +1148,13 @@ describe("resolveConfig", () => {
 
   it("accepts only the single plugin descriptor shape", () => {
     const setup = () => ({});
+    const cliShortcuts = () => [{ key: "h", description: "help" }];
     const plugin = {
       id: "test-plugin",
       dependencies: ["required"],
       optionalDependencies: ["optional"],
       enforce: "pre" as const,
+      cliShortcuts,
       setup,
     };
     const resolved = resolveConfig({
@@ -1162,6 +1164,7 @@ describe("resolveConfig", () => {
     expect(resolved.plugins).toEqual([plugin]);
     expect(resolved.plugins[0]).toMatchObject({
       id: "test-plugin",
+      cliShortcuts,
     });
     expect(resolved.plugins[0]).not.toBe(plugin);
     expect(Object.isFrozen(resolved.plugins[0])).toBe(true);
@@ -1200,6 +1203,21 @@ describe("resolveConfig", () => {
         ],
       }),
     ).toThrow("Return the hook from plugins[0].setup() instead");
+    expect(() =>
+      resolveConfig({
+        plugins: [
+          {
+            id: "legacy-shortcuts-hook",
+            configureShortcuts() {},
+          } as never,
+        ],
+      }),
+    ).toThrow("plugins[0].configureShortcuts is not supported");
+    expect(() =>
+      resolveConfig({
+        plugins: [{ id: "invalid-shortcuts", cliShortcuts: true } as never],
+      }),
+    ).toThrow("plugins[0].cliShortcuts must be a function");
     expect(() =>
       resolveConfig({
         plugins: [

--- a/packages/ev/tests/config.test.ts
+++ b/packages/ev/tests/config.test.ts
@@ -481,33 +481,17 @@ describe("resolveConfig", () => {
       crossOriginLoading: "anonymous",
     });
     expect(resolved.dev.proxy).toEqual([]);
-    expect(resolved.dev.cliShortcuts).toEqual({ print: true });
+    expect(resolved.dev.cliShortcuts).toBe(true);
   });
 
-  it("resolves dev.cliShortcuts: false and the print option", () => {
+  it("resolves dev.cliShortcuts as a boolean", () => {
     expect(
       resolveConfig({ dev: { cliShortcuts: false } }).dev.cliShortcuts,
     ).toBe(false);
     expect(
       resolveConfig({ dev: { cliShortcuts: true } }).dev.cliShortcuts,
-    ).toEqual({ print: true });
-    expect(
-      resolveConfig({ dev: { cliShortcuts: { print: false } } }).dev
-        .cliShortcuts,
-    ).toEqual({ print: false });
-  });
-
-  it("rejects unknown dev.cliShortcuts fields and non-boolean print", () => {
-    expect(() =>
-      resolveConfig({
-        dev: { cliShortcuts: { bogus: true } },
-      } as never),
-    ).toThrow(/dev\.cliShortcuts/);
-    expect(() =>
-      resolveConfig({
-        dev: { cliShortcuts: { print: "yes" as unknown as boolean } },
-      } as never),
-    ).toThrow(/dev\.cliShortcuts\.print must be a boolean/);
+    ).toBe(true);
+    expect(resolveConfig({}).dev.cliShortcuts).toBe(true);
   });
 
   it("accepts only plain config records at root and nested boundaries", () => {

--- a/packages/ev/tests/config.test.ts
+++ b/packages/ev/tests/config.test.ts
@@ -481,6 +481,33 @@ describe("resolveConfig", () => {
       crossOriginLoading: "anonymous",
     });
     expect(resolved.dev.proxy).toEqual([]);
+    expect(resolved.dev.cliShortcuts).toEqual({ print: true });
+  });
+
+  it("resolves dev.cliShortcuts: false and the print option", () => {
+    expect(
+      resolveConfig({ dev: { cliShortcuts: false } }).dev.cliShortcuts,
+    ).toBe(false);
+    expect(
+      resolveConfig({ dev: { cliShortcuts: true } }).dev.cliShortcuts,
+    ).toEqual({ print: true });
+    expect(
+      resolveConfig({ dev: { cliShortcuts: { print: false } } }).dev
+        .cliShortcuts,
+    ).toEqual({ print: false });
+  });
+
+  it("rejects unknown dev.cliShortcuts fields and non-boolean print", () => {
+    expect(() =>
+      resolveConfig({
+        dev: { cliShortcuts: { bogus: true } },
+      } as never),
+    ).toThrow(/dev\.cliShortcuts/);
+    expect(() =>
+      resolveConfig({
+        dev: { cliShortcuts: { print: "yes" as unknown as boolean } },
+      } as never),
+    ).toThrow(/dev\.cliShortcuts\.print must be a boolean/);
   });
 
   it("accepts only plain config records at root and nested boundaries", () => {

--- a/packages/ev/tests/plugin-lifecycle.test.ts
+++ b/packages/ev/tests/plugin-lifecycle.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  collectConfigureShortcutsHooks,
+  collectPluginCliShortcuts,
   collectPluginHooks,
   createLatePluginContext,
   createPluginConfigView,
   runAfterBuildHooks,
   runBeforeBuildHooks,
-  runDisposeHooks,
 } from "../src/_internal/build/plugin-lifecycle.js";
 import { resolveConfig } from "../src/config/index.js";
 import {
@@ -162,98 +161,7 @@ describe("collectPluginHooks", () => {
     expect(events).toEqual([]);
   });
 
-  it("rejects a hooks object shared by different plugins", async () => {
-    const dispose = vi.fn();
-    const sharedHooks = {
-      configureShortcuts: () => [],
-      dispose,
-    };
-    const context = {
-      mode: "production",
-      cwd: "/project",
-      config: resolveConfig(),
-      logger: {} as PluginSetupContext["logger"],
-      addWatchFile() {},
-    } satisfies PluginSetupContext;
-
-    await expect(
-      collectPluginHooks(
-        [
-          { id: "first", setup: () => sharedHooks },
-          { id: "second", setup: () => sharedHooks },
-        ],
-        context,
-      ),
-    ).rejects.toThrow(
-      'Plugin "second" setup hook cannot reuse shortcut hooks owned by plugin "first"',
-    );
-    expect(dispose).toHaveBeenCalledOnce();
-  });
-
-  it("does not dispose a hooks object reused by a later collection", async () => {
-    const dispose = vi.fn();
-    const sharedHooks = { configureShortcuts: () => [], dispose };
-    const context = {
-      mode: "production",
-      cwd: "/project",
-      config: resolveConfig(),
-      logger: {} as PluginSetupContext["logger"],
-      addWatchFile() {},
-    } satisfies PluginSetupContext;
-    const firstHooks = await collectPluginHooks(
-      [{ id: "first-snapshot", setup: () => sharedHooks }],
-      context,
-    );
-
-    await expect(
-      collectPluginHooks(
-        [{ id: "second-snapshot", setup: () => sharedHooks }],
-        context,
-      ),
-    ).rejects.toThrow(
-      "Hooks objects containing configureShortcuts cannot be shared by distinct plugin ids",
-    );
-    expect(dispose).not.toHaveBeenCalled();
-
-    await runDisposeHooks(firstHooks, context);
-    expect(dispose).toHaveBeenCalledOnce();
-  });
-
-  it("detects a reused hooks object before validating later mutations", async () => {
-    const dispose = vi.fn();
-    const sharedHooks: Record<string, unknown> = {
-      configureShortcuts: () => [],
-      dispose,
-    };
-    const context = {
-      mode: "production",
-      cwd: "/project",
-      config: resolveConfig(),
-      logger: {} as PluginSetupContext["logger"],
-      addWatchFile() {},
-    } satisfies PluginSetupContext;
-
-    await expect(
-      collectPluginHooks(
-        [
-          { id: "first", setup: () => sharedHooks as PluginHooks },
-          {
-            id: "second",
-            setup() {
-              sharedHooks.unknownHook = () => {};
-              return sharedHooks as PluginHooks;
-            },
-          },
-        ],
-        context,
-      ),
-    ).rejects.toThrow(
-      "Hooks objects containing configureShortcuts cannot be shared by distinct plugin ids",
-    );
-    expect(dispose).toHaveBeenCalledOnce();
-  });
-
-  it("allows ordinary hooks objects to be reused by different plugins", async () => {
+  it("allows hooks objects to be reused independently of CLI contributions", async () => {
     const sharedHooks = { beforeBuild() {} };
     const context = {
       mode: "production",
@@ -266,17 +174,24 @@ describe("collectPluginHooks", () => {
     await expect(
       collectPluginHooks(
         [
-          { id: "first", setup: () => sharedHooks },
-          { id: "second", setup: () => sharedHooks },
+          {
+            id: "first",
+            cliShortcuts: () => [{ key: "a", description: "first" }],
+            setup: () => sharedHooks,
+          },
+          {
+            id: "second",
+            cliShortcuts: () => [{ key: "b", description: "second" }],
+            setup: () => sharedHooks,
+          },
         ],
         context,
       ),
     ).resolves.toEqual([sharedHooks, sharedHooks]);
   });
 
-  it("rejects shortcut hooks reused by later snapshots of one plugin", async () => {
-    const dispose = vi.fn();
-    const sharedHooks = { configureShortcuts: () => [], dispose };
+  it("allows the same hooks object to be reused across setup snapshots", async () => {
+    const sharedHooks = { beforeBuild() {} };
     const context = {
       mode: "production",
       cwd: "/project",
@@ -285,114 +200,16 @@ describe("collectPluginHooks", () => {
       addWatchFile() {},
     } satisfies PluginSetupContext;
 
-    const first = await collectPluginHooks(
-      [{ id: "reused-shortcuts", setup: () => sharedHooks }],
-      context,
-    );
-
+    const plugin: Plugin = {
+      id: "reused-hooks",
+      cliShortcuts: () => [{ key: "r", description: "reload" }],
+      setup: () => sharedHooks,
+    };
+    const first = await collectPluginHooks([plugin], context);
     expect(first).toEqual([sharedHooks]);
-    await expect(
-      collectPluginHooks(
-        [{ id: "reused-shortcuts", setup: () => sharedHooks }],
-        context,
-      ),
-    ).rejects.toThrow(
-      "cannot reuse a hooks object containing configureShortcuts across setup snapshots",
-    );
-    expect(dispose).not.toHaveBeenCalled();
-    await runDisposeHooks(first, context);
-    expect(dispose).toHaveBeenCalledOnce();
-  });
-
-  it("rejects shortcut hooks reused after temporarily removing the hook", async () => {
-    const configureShortcuts = () => [];
-    const sharedHooks: Record<string, unknown> = { configureShortcuts };
-    const context = {
-      mode: "production",
-      cwd: "/project",
-      config: resolveConfig(),
-      logger: {} as PluginSetupContext["logger"],
-      addWatchFile() {},
-    } satisfies PluginSetupContext;
-    await collectPluginHooks(
-      [
-        {
-          id: "temporarily-mutated-shortcuts",
-          setup: () => sharedHooks as PluginHooks,
-        },
-      ],
-      context,
-    );
-
-    delete sharedHooks.configureShortcuts;
-    await expect(
-      collectPluginHooks(
-        [
-          {
-            id: "temporarily-mutated-shortcuts",
-            setup: () => sharedHooks as PluginHooks,
-          },
-        ],
-        context,
-      ),
-    ).rejects.toThrow(
-      "cannot reuse a hooks object containing configureShortcuts across setup snapshots",
-    );
-    sharedHooks.configureShortcuts = configureShortcuts;
-  });
-
-  it("rejects ordinary shared hooks mutated to add shortcuts during setup", async () => {
-    const sharedHooks: Record<string, unknown> = { beforeBuild() {} };
-    const context = {
-      mode: "production",
-      cwd: "/project",
-      config: resolveConfig(),
-      logger: {} as PluginSetupContext["logger"],
-      addWatchFile() {},
-    } satisfies PluginSetupContext;
-
-    await expect(
-      collectPluginHooks(
-        [
-          { id: "first", setup: () => sharedHooks as PluginHooks },
-          {
-            id: "second",
-            setup() {
-              sharedHooks.configureShortcuts = () => [];
-              return sharedHooks as PluginHooks;
-            },
-          },
-        ],
-        context,
-      ),
-    ).rejects.toThrow(
-      "Hooks objects containing configureShortcuts cannot be shared by distinct plugin ids",
-    );
-  });
-
-  it("rejects ordinary shared hooks mutated to add shortcuts after setup", async () => {
-    const configureShortcuts = vi.fn(() => []);
-    const sharedHooks: Record<string, unknown> = { beforeBuild() {} };
-    const context = {
-      mode: "production",
-      cwd: "/project",
-      config: resolveConfig(),
-      logger: {} as PluginSetupContext["logger"],
-      addWatchFile() {},
-    } satisfies PluginSetupContext;
-    const hooks = await collectPluginHooks(
-      [
-        { id: "first", setup: () => sharedHooks as PluginHooks },
-        { id: "second", setup: () => sharedHooks as PluginHooks },
-      ],
-      context,
-    );
-
-    sharedHooks.configureShortcuts = configureShortcuts;
-    await expect(collectConfigureShortcutsHooks(hooks)).rejects.toThrow(
-      "cannot add configureShortcuts after setup validation",
-    );
-    expect(configureShortcuts).not.toHaveBeenCalled();
+    await expect(collectPluginHooks([plugin], context)).resolves.toEqual([
+      sharedHooks,
+    ]);
   });
 
   it("exposes one isolated frozen config view to setup and lifecycle hooks", async () => {
@@ -568,7 +385,7 @@ describe("collectPluginHooks", () => {
   });
 });
 
-describe("collectConfigureShortcutsHooks", () => {
+describe("collectPluginCliShortcuts", () => {
   const context = {
     mode: "development",
     cwd: "/project",
@@ -577,7 +394,7 @@ describe("collectConfigureShortcutsHooks", () => {
     addWatchFile() {},
   } satisfies PluginSetupContext;
 
-  it("does not invoke a configureShortcuts getter during setup validation", async () => {
+  it("rejects configureShortcuts returned from setup without invoking accessors", async () => {
     let getterCalls = 0;
     const hooks: Record<string, unknown> = {};
     Object.defineProperty(hooks, "configureShortcuts", {
@@ -594,159 +411,78 @@ describe("collectConfigureShortcutsHooks", () => {
         [{ id: "shortcut-getter", setup: () => hooks as PluginHooks }],
         context,
       ),
-    ).rejects.toThrow(
-      'setup hook returned "configureShortcuts" must be an enumerable own data property',
-    );
+    ).rejects.toThrow('setup hook returned "configureShortcuts"');
     expect(getterCalls).toBe(0);
   });
 
-  it("rejects replacement of configureShortcuts after setup validation", async () => {
-    const original = vi.fn(() => []);
-    const replacement = vi.fn(() => []);
-    const hooks = await collectPluginHooks(
-      [
-        {
-          id: "replaced-shortcuts",
-          setup: () => ({ configureShortcuts: original }),
-        },
-      ],
-      context,
-    );
-    const hook = hooks[0];
-    if (!hook) throw new Error("Expected plugin hooks to be collected.");
-    hook.configureShortcuts = replacement;
-
-    await expect(collectConfigureShortcutsHooks(hooks)).rejects.toThrow(
-      "configureShortcuts hook was mutated after setup validation",
-    );
-    expect(original).not.toHaveBeenCalled();
-    expect(replacement).not.toHaveBeenCalled();
-  });
-
-  it("does not invoke a configureShortcuts getter added after setup", async () => {
-    let getterCalls = 0;
-    const hooks = await collectPluginHooks(
-      [
-        {
-          id: "late-shortcut-getter",
-          setup: () => ({ beforeBuild() {} }),
-        },
-      ],
-      context,
-    );
-    Object.defineProperty(hooks[0], "configureShortcuts", {
-      configurable: true,
-      enumerable: true,
-      get() {
-        getterCalls += 1;
-        return () => [];
-      },
-    });
-
-    await expect(collectConfigureShortcutsHooks(hooks)).rejects.toThrow(
-      "configureShortcuts added after setup validation must be an enumerable own data function",
-    );
-    expect(getterCalls).toBe(0);
-  });
-
-  it("collects shortcuts from every plugin's configureShortcuts hook, in order", async () => {
+  it("collects shortcuts from every plugin descriptor in order", async () => {
     const plugins: Plugin[] = [
       {
         id: "a",
-        setup() {
-          return {
-            configureShortcuts() {
-              return [{ key: "u", description: "show url", action() {} }];
-            },
-          };
+        cliShortcuts() {
+          return [{ key: "u", description: "show url", action() {} }];
         },
       },
       {
         id: "b",
-        setup() {
-          return {
-            configureShortcuts() {
-              return [
-                { key: "o", description: "open", action() {} },
-                { key: "c", description: "clear", action() {} },
-              ];
-            },
-          };
+        cliShortcuts() {
+          return [
+            { key: "o", description: "open", action() {} },
+            { key: "c", description: "clear", action() {} },
+          ];
         },
       },
     ];
 
-    const hooks = await collectPluginHooks(plugins, context);
-    const shortcuts = await collectConfigureShortcutsHooks(hooks);
+    const shortcuts = await collectPluginCliShortcuts(plugins);
 
     expect(shortcuts.map((s) => s.key)).toEqual(["u", "o", "c"]);
   });
 
-  it("tolerates plugins that omit configureShortcuts and that return an empty list", async () => {
+  it("tolerates plugins that omit cliShortcuts or return an empty list", async () => {
     const plugins: Plugin[] = [
       { id: "none", setup() {} },
       {
         id: "empty",
-        setup() {
-          return { configureShortcuts: () => [] };
-        },
+        cliShortcuts: () => [],
       },
       {
         id: "first",
-        setup() {
-          return {
-            configureShortcuts() {
-              return [{ key: "q", description: "quit", action() {} }];
-            },
-          };
+        cliShortcuts() {
+          return [{ key: "q", description: "quit", action() {} }];
         },
       },
     ];
 
-    const hooks = await collectPluginHooks(plugins, context);
-    const shortcuts = await collectConfigureShortcutsHooks(hooks);
+    const shortcuts = await collectPluginCliShortcuts(plugins);
 
     expect(shortcuts.map((s) => s.key)).toEqual(["q"]);
   });
 
-  it("awaits an async configureShortcuts hook", async () => {
+  it("awaits an async cliShortcuts contribution", async () => {
     const plugins: Plugin[] = [
       {
         id: "async",
-        setup() {
-          return {
-            async configureShortcuts() {
-              return [{ key: "r", description: "restart", action() {} }];
-            },
-          };
+        async cliShortcuts() {
+          return [{ key: "r", description: "restart", action() {} }];
         },
       },
     ];
 
-    const hooks = await collectPluginHooks(plugins, context);
-    const shortcuts = await collectConfigureShortcutsHooks(hooks);
+    const shortcuts = await collectPluginCliShortcuts(plugins);
 
     expect(shortcuts.map((s) => s.key)).toEqual(["r"]);
   });
 
   it("normalizes registration keys before returning descriptors", async () => {
-    const hooks = await collectPluginHooks(
-      [
-        {
-          id: "normalized",
-          setup() {
-            return {
-              configureShortcuts() {
-                return [{ key: " R ", description: "restart", action() {} }];
-              },
-            };
-          },
+    const shortcuts = await collectPluginCliShortcuts([
+      {
+        id: "normalized",
+        cliShortcuts() {
+          return [{ key: " R ", description: "restart", action() {} }];
         },
-      ],
-      context,
-    );
-
-    const shortcuts = await collectConfigureShortcutsHooks(hooks);
+      },
+    ]);
     expect(shortcuts.map((shortcut) => shortcut.key)).toEqual(["r"]);
     expect(Object.isFrozen(shortcuts[0])).toBe(true);
   });
@@ -763,70 +499,44 @@ describe("collectConfigureShortcutsHooks", () => {
     ];
 
     for (const [index, result] of invalidResults.entries()) {
-      const hooks = await collectPluginHooks(
-        [
-          {
-            id: `invalid-${index}`,
-            setup() {
-              return { configureShortcuts: () => result as never };
-            },
-          },
-        ],
-        context,
-      );
-      await expect(collectConfigureShortcutsHooks(hooks)).rejects.toThrow(
-        `Plugin "invalid-${index}" configureShortcuts`,
-      );
+      await expect(
+        collectPluginCliShortcuts([
+          { id: `invalid-${index}`, cliShortcuts: () => result as never },
+        ]),
+      ).rejects.toThrow(`Plugin "invalid-${index}" cliShortcuts`);
     }
   });
 
   it("can isolate an invalid plugin while collecting later shortcuts", async () => {
-    const hooks = await collectPluginHooks(
-      [
-        {
-          id: "invalid",
-          setup() {
-            return { configureShortcuts: () => null as never };
-          },
-        },
-        {
-          id: "valid",
-          setup() {
-            return {
-              configureShortcuts: () => [{ key: "u", description: "show url" }],
-            };
-          },
-        },
-      ],
-      context,
-    );
     const onError = vi.fn();
 
-    const shortcuts = await collectConfigureShortcutsHooks(hooks, { onError });
+    const shortcuts = await collectPluginCliShortcuts(
+      [
+        { id: "invalid", cliShortcuts: () => null as never },
+        {
+          id: "valid",
+          cliShortcuts: () => [{ key: "u", description: "show url" }],
+        },
+      ],
+      { onError },
+    );
 
     expect(onError).toHaveBeenCalledOnce();
     expect(shortcuts.map((shortcut) => shortcut.key)).toEqual(["u"]);
   });
 
-  it("identifies a plugin whose configureShortcuts hook throws", async () => {
-    const hooks = await collectPluginHooks(
-      [
+  it("identifies a plugin whose cliShortcuts contribution throws", async () => {
+    await expect(
+      collectPluginCliShortcuts([
         {
           id: "throwing-shortcuts",
-          setup() {
-            return {
-              configureShortcuts() {
-                throw new Error("contribution failed");
-              },
-            };
+          cliShortcuts() {
+            throw new Error("contribution failed");
           },
         },
-      ],
-      context,
-    );
-
-    await expect(collectConfigureShortcutsHooks(hooks)).rejects.toThrow(
-      'Plugin "throwing-shortcuts" configureShortcuts hook failed: contribution failed',
+      ]),
+    ).rejects.toThrow(
+      'Plugin "throwing-shortcuts" cliShortcuts contribution failed: contribution failed',
     );
   });
 });

--- a/packages/ev/tests/plugin-lifecycle.test.ts
+++ b/packages/ev/tests/plugin-lifecycle.test.ts
@@ -376,13 +376,13 @@ describe("collectConfigureShortcutsHooks", () => {
     expect(shortcuts.map((s) => s.key)).toEqual(["u", "o", "c"]);
   });
 
-  it("tolerates plugins that omit configureShortcuts and that return undefined", async () => {
+  it("tolerates plugins that omit configureShortcuts and that return an empty list", async () => {
     const plugins: Plugin[] = [
       { id: "none", setup() {} },
       {
         id: "empty",
         setup() {
-          return { configureShortcuts: () => undefined };
+          return { configureShortcuts: () => [] };
         },
       },
       {

--- a/packages/ev/tests/plugin-lifecycle.test.ts
+++ b/packages/ev/tests/plugin-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  collectConfigureShortcutsHooks,
   collectPluginHooks,
   createLatePluginContext,
   createPluginConfigView,
@@ -330,6 +331,96 @@ describe("collectPluginHooks", () => {
     expect(() => createPluginConfigView(config)).toThrow(
       "[evjs] Resolved plugin context config.server.basePath must be a data property, not an accessor.",
     );
+  });
+});
+
+describe("collectConfigureShortcutsHooks", () => {
+  const context = {
+    mode: "development",
+    cwd: "/project",
+    config: {} as PluginSetupContext["config"],
+    logger: {} as PluginSetupContext["logger"],
+    addWatchFile() {},
+  } satisfies PluginSetupContext;
+
+  it("collects shortcuts from every plugin's configureShortcuts hook, in order", async () => {
+    const plugins: Plugin[] = [
+      {
+        id: "a",
+        setup() {
+          return {
+            configureShortcuts() {
+              return [{ key: "u", description: "show url", action() {} }];
+            },
+          };
+        },
+      },
+      {
+        id: "b",
+        setup() {
+          return {
+            configureShortcuts() {
+              return [
+                { key: "o", description: "open", action() {} },
+                { key: "c", description: "clear", action() {} },
+              ];
+            },
+          };
+        },
+      },
+    ];
+
+    const hooks = await collectPluginHooks(plugins, context);
+    const shortcuts = await collectConfigureShortcutsHooks(hooks);
+
+    expect(shortcuts.map((s) => s.key)).toEqual(["u", "o", "c"]);
+  });
+
+  it("tolerates plugins that omit configureShortcuts and that return undefined", async () => {
+    const plugins: Plugin[] = [
+      { id: "none", setup() {} },
+      {
+        id: "empty",
+        setup() {
+          return { configureShortcuts: () => undefined };
+        },
+      },
+      {
+        id: "first",
+        setup() {
+          return {
+            configureShortcuts() {
+              return [{ key: "q", description: "quit", action() {} }];
+            },
+          };
+        },
+      },
+    ];
+
+    const hooks = await collectPluginHooks(plugins, context);
+    const shortcuts = await collectConfigureShortcutsHooks(hooks);
+
+    expect(shortcuts.map((s) => s.key)).toEqual(["q"]);
+  });
+
+  it("awaits an async configureShortcuts hook", async () => {
+    const plugins: Plugin[] = [
+      {
+        id: "async",
+        setup() {
+          return {
+            async configureShortcuts() {
+              return [{ key: "r", description: "restart", action() {} }];
+            },
+          };
+        },
+      },
+    ];
+
+    const hooks = await collectPluginHooks(plugins, context);
+    const shortcuts = await collectConfigureShortcutsHooks(hooks);
+
+    expect(shortcuts.map((s) => s.key)).toEqual(["r"]);
   });
 });
 

--- a/packages/ev/tests/plugin-lifecycle.test.ts
+++ b/packages/ev/tests/plugin-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   collectConfigureShortcutsHooks,
   collectPluginHooks,
@@ -6,6 +6,7 @@ import {
   createPluginConfigView,
   runAfterBuildHooks,
   runBeforeBuildHooks,
+  runDisposeHooks,
 } from "../src/_internal/build/plugin-lifecycle.js";
 import { resolveConfig } from "../src/config/index.js";
 import {
@@ -159,6 +160,239 @@ describe("collectPluginHooks", () => {
       "setup hook returned dispose must be a function",
     );
     expect(events).toEqual([]);
+  });
+
+  it("rejects a hooks object shared by different plugins", async () => {
+    const dispose = vi.fn();
+    const sharedHooks = {
+      configureShortcuts: () => [],
+      dispose,
+    };
+    const context = {
+      mode: "production",
+      cwd: "/project",
+      config: resolveConfig(),
+      logger: {} as PluginSetupContext["logger"],
+      addWatchFile() {},
+    } satisfies PluginSetupContext;
+
+    await expect(
+      collectPluginHooks(
+        [
+          { id: "first", setup: () => sharedHooks },
+          { id: "second", setup: () => sharedHooks },
+        ],
+        context,
+      ),
+    ).rejects.toThrow(
+      'Plugin "second" setup hook cannot reuse shortcut hooks owned by plugin "first"',
+    );
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("does not dispose a hooks object reused by a later collection", async () => {
+    const dispose = vi.fn();
+    const sharedHooks = { configureShortcuts: () => [], dispose };
+    const context = {
+      mode: "production",
+      cwd: "/project",
+      config: resolveConfig(),
+      logger: {} as PluginSetupContext["logger"],
+      addWatchFile() {},
+    } satisfies PluginSetupContext;
+    const firstHooks = await collectPluginHooks(
+      [{ id: "first-snapshot", setup: () => sharedHooks }],
+      context,
+    );
+
+    await expect(
+      collectPluginHooks(
+        [{ id: "second-snapshot", setup: () => sharedHooks }],
+        context,
+      ),
+    ).rejects.toThrow(
+      "Hooks objects containing configureShortcuts cannot be shared by distinct plugin ids",
+    );
+    expect(dispose).not.toHaveBeenCalled();
+
+    await runDisposeHooks(firstHooks, context);
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("detects a reused hooks object before validating later mutations", async () => {
+    const dispose = vi.fn();
+    const sharedHooks: Record<string, unknown> = {
+      configureShortcuts: () => [],
+      dispose,
+    };
+    const context = {
+      mode: "production",
+      cwd: "/project",
+      config: resolveConfig(),
+      logger: {} as PluginSetupContext["logger"],
+      addWatchFile() {},
+    } satisfies PluginSetupContext;
+
+    await expect(
+      collectPluginHooks(
+        [
+          { id: "first", setup: () => sharedHooks as PluginHooks },
+          {
+            id: "second",
+            setup() {
+              sharedHooks.unknownHook = () => {};
+              return sharedHooks as PluginHooks;
+            },
+          },
+        ],
+        context,
+      ),
+    ).rejects.toThrow(
+      "Hooks objects containing configureShortcuts cannot be shared by distinct plugin ids",
+    );
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("allows ordinary hooks objects to be reused by different plugins", async () => {
+    const sharedHooks = { beforeBuild() {} };
+    const context = {
+      mode: "production",
+      cwd: "/project",
+      config: resolveConfig(),
+      logger: {} as PluginSetupContext["logger"],
+      addWatchFile() {},
+    } satisfies PluginSetupContext;
+
+    await expect(
+      collectPluginHooks(
+        [
+          { id: "first", setup: () => sharedHooks },
+          { id: "second", setup: () => sharedHooks },
+        ],
+        context,
+      ),
+    ).resolves.toEqual([sharedHooks, sharedHooks]);
+  });
+
+  it("rejects shortcut hooks reused by later snapshots of one plugin", async () => {
+    const dispose = vi.fn();
+    const sharedHooks = { configureShortcuts: () => [], dispose };
+    const context = {
+      mode: "production",
+      cwd: "/project",
+      config: resolveConfig(),
+      logger: {} as PluginSetupContext["logger"],
+      addWatchFile() {},
+    } satisfies PluginSetupContext;
+
+    const first = await collectPluginHooks(
+      [{ id: "reused-shortcuts", setup: () => sharedHooks }],
+      context,
+    );
+
+    expect(first).toEqual([sharedHooks]);
+    await expect(
+      collectPluginHooks(
+        [{ id: "reused-shortcuts", setup: () => sharedHooks }],
+        context,
+      ),
+    ).rejects.toThrow(
+      "cannot reuse a hooks object containing configureShortcuts across setup snapshots",
+    );
+    expect(dispose).not.toHaveBeenCalled();
+    await runDisposeHooks(first, context);
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("rejects shortcut hooks reused after temporarily removing the hook", async () => {
+    const configureShortcuts = () => [];
+    const sharedHooks: Record<string, unknown> = { configureShortcuts };
+    const context = {
+      mode: "production",
+      cwd: "/project",
+      config: resolveConfig(),
+      logger: {} as PluginSetupContext["logger"],
+      addWatchFile() {},
+    } satisfies PluginSetupContext;
+    await collectPluginHooks(
+      [
+        {
+          id: "temporarily-mutated-shortcuts",
+          setup: () => sharedHooks as PluginHooks,
+        },
+      ],
+      context,
+    );
+
+    delete sharedHooks.configureShortcuts;
+    await expect(
+      collectPluginHooks(
+        [
+          {
+            id: "temporarily-mutated-shortcuts",
+            setup: () => sharedHooks as PluginHooks,
+          },
+        ],
+        context,
+      ),
+    ).rejects.toThrow(
+      "cannot reuse a hooks object containing configureShortcuts across setup snapshots",
+    );
+    sharedHooks.configureShortcuts = configureShortcuts;
+  });
+
+  it("rejects ordinary shared hooks mutated to add shortcuts during setup", async () => {
+    const sharedHooks: Record<string, unknown> = { beforeBuild() {} };
+    const context = {
+      mode: "production",
+      cwd: "/project",
+      config: resolveConfig(),
+      logger: {} as PluginSetupContext["logger"],
+      addWatchFile() {},
+    } satisfies PluginSetupContext;
+
+    await expect(
+      collectPluginHooks(
+        [
+          { id: "first", setup: () => sharedHooks as PluginHooks },
+          {
+            id: "second",
+            setup() {
+              sharedHooks.configureShortcuts = () => [];
+              return sharedHooks as PluginHooks;
+            },
+          },
+        ],
+        context,
+      ),
+    ).rejects.toThrow(
+      "Hooks objects containing configureShortcuts cannot be shared by distinct plugin ids",
+    );
+  });
+
+  it("rejects ordinary shared hooks mutated to add shortcuts after setup", async () => {
+    const configureShortcuts = vi.fn(() => []);
+    const sharedHooks: Record<string, unknown> = { beforeBuild() {} };
+    const context = {
+      mode: "production",
+      cwd: "/project",
+      config: resolveConfig(),
+      logger: {} as PluginSetupContext["logger"],
+      addWatchFile() {},
+    } satisfies PluginSetupContext;
+    const hooks = await collectPluginHooks(
+      [
+        { id: "first", setup: () => sharedHooks as PluginHooks },
+        { id: "second", setup: () => sharedHooks as PluginHooks },
+      ],
+      context,
+    );
+
+    sharedHooks.configureShortcuts = configureShortcuts;
+    await expect(collectConfigureShortcutsHooks(hooks)).rejects.toThrow(
+      "cannot add configureShortcuts after setup validation",
+    );
+    expect(configureShortcuts).not.toHaveBeenCalled();
   });
 
   it("exposes one isolated frozen config view to setup and lifecycle hooks", async () => {
@@ -343,6 +577,78 @@ describe("collectConfigureShortcutsHooks", () => {
     addWatchFile() {},
   } satisfies PluginSetupContext;
 
+  it("does not invoke a configureShortcuts getter during setup validation", async () => {
+    let getterCalls = 0;
+    const hooks: Record<string, unknown> = {};
+    Object.defineProperty(hooks, "configureShortcuts", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        getterCalls += 1;
+        return () => [];
+      },
+    });
+
+    await expect(
+      collectPluginHooks(
+        [{ id: "shortcut-getter", setup: () => hooks as PluginHooks }],
+        context,
+      ),
+    ).rejects.toThrow(
+      'setup hook returned "configureShortcuts" must be an enumerable own data property',
+    );
+    expect(getterCalls).toBe(0);
+  });
+
+  it("rejects replacement of configureShortcuts after setup validation", async () => {
+    const original = vi.fn(() => []);
+    const replacement = vi.fn(() => []);
+    const hooks = await collectPluginHooks(
+      [
+        {
+          id: "replaced-shortcuts",
+          setup: () => ({ configureShortcuts: original }),
+        },
+      ],
+      context,
+    );
+    const hook = hooks[0];
+    if (!hook) throw new Error("Expected plugin hooks to be collected.");
+    hook.configureShortcuts = replacement;
+
+    await expect(collectConfigureShortcutsHooks(hooks)).rejects.toThrow(
+      "configureShortcuts hook was mutated after setup validation",
+    );
+    expect(original).not.toHaveBeenCalled();
+    expect(replacement).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke a configureShortcuts getter added after setup", async () => {
+    let getterCalls = 0;
+    const hooks = await collectPluginHooks(
+      [
+        {
+          id: "late-shortcut-getter",
+          setup: () => ({ beforeBuild() {} }),
+        },
+      ],
+      context,
+    );
+    Object.defineProperty(hooks[0], "configureShortcuts", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        getterCalls += 1;
+        return () => [];
+      },
+    });
+
+    await expect(collectConfigureShortcutsHooks(hooks)).rejects.toThrow(
+      "configureShortcuts added after setup validation must be an enumerable own data function",
+    );
+    expect(getterCalls).toBe(0);
+  });
+
   it("collects shortcuts from every plugin's configureShortcuts hook, in order", async () => {
     const plugins: Plugin[] = [
       {
@@ -421,6 +727,107 @@ describe("collectConfigureShortcutsHooks", () => {
     const shortcuts = await collectConfigureShortcutsHooks(hooks);
 
     expect(shortcuts.map((s) => s.key)).toEqual(["r"]);
+  });
+
+  it("normalizes registration keys before returning descriptors", async () => {
+    const hooks = await collectPluginHooks(
+      [
+        {
+          id: "normalized",
+          setup() {
+            return {
+              configureShortcuts() {
+                return [{ key: " R ", description: "restart", action() {} }];
+              },
+            };
+          },
+        },
+      ],
+      context,
+    );
+
+    const shortcuts = await collectConfigureShortcutsHooks(hooks);
+    expect(shortcuts.map((shortcut) => shortcut.key)).toEqual(["r"]);
+    expect(Object.isFrozen(shortcuts[0])).toBe(true);
+  });
+
+  it("rejects invalid hook results and descriptors with plugin diagnostics", async () => {
+    const sparseShortcuts: unknown[] = [];
+    sparseShortcuts.length = 1;
+    const invalidResults: unknown[] = [
+      null,
+      sparseShortcuts,
+      [{ key: "open", description: "multi" }],
+      [{ key: "q", description: "" }],
+      [{ key: "q", description: "quit", action: "not-a-function" }],
+    ];
+
+    for (const [index, result] of invalidResults.entries()) {
+      const hooks = await collectPluginHooks(
+        [
+          {
+            id: `invalid-${index}`,
+            setup() {
+              return { configureShortcuts: () => result as never };
+            },
+          },
+        ],
+        context,
+      );
+      await expect(collectConfigureShortcutsHooks(hooks)).rejects.toThrow(
+        `Plugin "invalid-${index}" configureShortcuts`,
+      );
+    }
+  });
+
+  it("can isolate an invalid plugin while collecting later shortcuts", async () => {
+    const hooks = await collectPluginHooks(
+      [
+        {
+          id: "invalid",
+          setup() {
+            return { configureShortcuts: () => null as never };
+          },
+        },
+        {
+          id: "valid",
+          setup() {
+            return {
+              configureShortcuts: () => [{ key: "u", description: "show url" }],
+            };
+          },
+        },
+      ],
+      context,
+    );
+    const onError = vi.fn();
+
+    const shortcuts = await collectConfigureShortcutsHooks(hooks, { onError });
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(shortcuts.map((shortcut) => shortcut.key)).toEqual(["u"]);
+  });
+
+  it("identifies a plugin whose configureShortcuts hook throws", async () => {
+    const hooks = await collectPluginHooks(
+      [
+        {
+          id: "throwing-shortcuts",
+          setup() {
+            return {
+              configureShortcuts() {
+                throw new Error("contribution failed");
+              },
+            };
+          },
+        },
+      ],
+      context,
+    );
+
+    await expect(collectConfigureShortcutsHooks(hooks)).rejects.toThrow(
+      'Plugin "throwing-shortcuts" configureShortcuts hook failed: contribution failed',
+    );
   });
 });
 

--- a/packages/ev/tests/plugin-settings.test.ts
+++ b/packages/ev/tests/plugin-settings.test.ts
@@ -548,6 +548,12 @@ describe("definePlugin and pluginOptions", () => {
         setup: true,
       } as never),
     ).toThrow("definePlugin() setup must be a function");
+    expect(() =>
+      definePlugin({
+        id: "invalid-cli-shortcuts",
+        cliShortcuts: true,
+      } as never),
+    ).toThrow("definePlugin() cliShortcuts must be a function");
   });
 
   it("captures an immutable descriptor snapshot without executing accessors", () => {
@@ -560,6 +566,9 @@ describe("definePlugin and pluginOptions", () => {
       setup() {
         return {};
       },
+      cliShortcuts() {
+        return [{ key: "h", description: "help" }];
+      },
     };
     const factory = definePlugin(descriptor);
 
@@ -567,6 +576,7 @@ describe("definePlugin and pluginOptions", () => {
     Reflect.set(descriptor, "id", "mutated-plugin");
     Reflect.set(descriptor, "page", undefined);
     Reflect.set(descriptor, "setup", undefined);
+    Reflect.set(descriptor, "cliShortcuts", undefined);
 
     const plugin = factory();
     const registry = collectPluginSettingsRegistry([
@@ -577,6 +587,9 @@ describe("definePlugin and pluginOptions", () => {
     expect(plugin.dependencies).toEqual(["base-plugin"]);
     expect(Object.isFrozen(plugin.dependencies)).toBe(true);
     expect(plugin.setup).toBeTypeOf("function");
+    expect(plugin.cliShortcuts?.()).toEqual([
+      { key: "h", description: "help" },
+    ]);
     expect(registry.catalog.entries["snapshot-plugin"]?.page).toEqual({
       defaultable: true,
     });


### PR DESCRIPTION
## 背景
EVJS 开发服务器需要允许插件贡献交互式 CLI 快捷键，同时保持核心零内置按键，并在配置重载、异步 action 与 shutdown 场景中保证生命周期安全。

## 改动
- 新增插件驱动的 CLI shortcuts engine，接入 CLI、Utoopack 与 Webpack 开发流程。
- 支持配置热切换、候选回滚、异步 action drain、退休插件 cleanup 与 shutdown 强制清理。
- 强化 plugin hooks ownership、descriptor 快照及 getter/replacement mutation 防护。
- 补齐中英文文档与完整回归测试。

## 验证
- npm test：17/17 tasks，EV 841 tests。
- npm run check-types：31/31 tasks。
- npm run lint：509 files。
- 完整 patch 在最新 origin/main 上干净应用，EV typecheck 与 332 项聚焦测试通过。

## 风险
- 影响范围限定在 ev dev 的 TTY CLI shortcut 交互及插件 lifecycle；CI/non-TTY 默认不绑定。
- Webpack/Utoopack adapter 行为均有回归测试覆盖。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive keyboard shortcuts to the development server.
  * Shortcuts are enabled by default in interactive terminals and can be disabled with `dev.cliShortcuts` or `ev dev --no-shortcuts`.
  * Plugins can provide custom shortcuts with descriptions and actions, including server shutdown support.
  * Shortcut bindings update safely as plugins or development configuration change.

* **Documentation**
  * Added English and Simplified Chinese documentation covering configuration, usage, and plugin integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->