### PR TITLE
feat(mpa): support .html document URLs

### DIFF
--- a/docs/docs/build.md
+++ b/docs/docs/build.md
@@ -106,11 +106,16 @@ or edit deployment metadata.
 Both use the same `src/pages/**/page.*` entry, directory scope, and
 semantic route pattern.
 
-Static SSG Pages use their semantic route as the output path in either mode:
-`/` writes `index.html`, while `/report` writes `report/index.html`. The output
-is never derived from the Page id. When a root SSG Page owns `index.html` in a
-mixed SPA that also needs a client-route fallback, Core keeps the Application
-shell separately at `__evjs/<application-id>.html`.
+Static SPA SSG Pages use their semantic route as the output path: `/` writes
+`index.html`, while `/report` writes `report/index.html`. When a root SSG Page
+owns `index.html` in a mixed SPA that also needs a client-route fallback, Core
+keeps the Application shell separately at `__evjs/<application-id>.html`.
+
+MPA keeps those semantic routes internally but exposes Page Documents as HTML
+URLs: `/` writes and serves `index.html`, `/report` uses `report.html`, and
+`/foo/bar` uses `foo/bar.html`. CSR emits those files; SSR and PPR use the same
+URLs for request-time rendering. Outputs are derived from route segments, not
+Page ids.
 
 MPA materializes only static Page routes. `$param` and terminal
 `$...splat` remain valid SPA route identities, but selecting MPA for either

--- a/docs/docs/client-routes.md
+++ b/docs/docs/client-routes.md
@@ -247,8 +247,10 @@ Page-owned Documents without requiring a browser router. It accepts
 only static Page paths; `$param`, terminal `$...splat`, and router-only
 boundaries fail graph validation. Layouts compose around Pages in both modes.
 `ev inspect` and `ev build` reject unsupported combinations instead of asking
-applications to use a second route model. A colocated `index.html` supplies that MPA Page's
-Document template.
+applications to use a second route model. The semantic routes stay `/`,
+`/report`, and `/foo/bar`, while their MPA Document URLs are `/index.html`,
+`/report.html`, and `/foo/bar.html`. A colocated `index.html` supplies that MPA
+Page's Document template.
 
 ## Page Configuration
 

--- a/docs/docs/project-structure.md
+++ b/docs/docs/project-structure.md
@@ -76,6 +76,10 @@ export default defineConfig({
 });
 ```
 
+The semantic Page routes remain `/`, `/about`, and `/foo/bar`. MPA exposes
+their Documents at `/index.html`, `/about.html`, and `/foo/bar.html` for both
+static output and request-time rendering.
+
 ## Convention Discovery Boundary
 
 The top-level `conventions: false` switch disables the framework-owned

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
@@ -98,11 +98,15 @@ metadata。
 二者使用相同 `src/pages/**/page.*` entry、目录 scope 与语义 route
 pattern。
 
-两种 mode 下，静态 SSG Page 都按语义 route 决定输出路径：`/` 写入
-`index.html`，`/report` 写入 `report/index.html`，不会从 Page id 推导文件名。
-如果混合 SPA 的根 SSG Page 已拥有 `index.html`，同时其他 client route 还需要
-fallback，Core 会把 Application shell 单独保留在
-`__evjs/<application-id>.html`。
+静态 SPA SSG Page 按语义 route 决定输出路径：`/` 写入 `index.html`，
+`/report` 写入 `report/index.html`。如果混合 SPA 的根 SSG Page 已拥有
+`index.html`，同时其他 client route 还需要 fallback，Core 会把 Application
+shell 单独保留在 `__evjs/<application-id>.html`。
+
+MPA 在内部保留这些语义 route，但通过 HTML URL 暴露 Page Document：`/` 写入并
+访问 `index.html`，`/report` 使用 `report.html`，`/foo/bar` 使用
+`foo/bar.html`。CSR 会发射这些文件；SSR 与 PPR 的请求时渲染也使用相同 URL。
+输出由 route segment 推导，不使用 Page id。
 
 MPA 只物化静态 Page route。`$param` 与终止 `$...splat` 仍是有效的 SPA
 route 身份，但为它们选择 MPA 会在 graph 校验失败，因为一个动态 pattern

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/client-routes.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/client-routes.md
@@ -240,7 +240,9 @@ MPA 发现相同的 Page 与语义 route pattern，再物化 Page-owned Document
 浏览器 router。它只接受静态 Page path；`$param`、终止 `$...splat` 与
 router-only boundary 会在 graph 校验失败。Layout 在两种 mode 中都会为 Page
 组合。`ev inspect` 和 `ev build` 会拒绝不支持的组合，而不是要求应用改用第二套
-路由模型。同一 Page 目录的 `index.html` 可以作为该 MPA Page 的 Document 模板。
+路由模型。语义 route 仍是 `/`、`/report` 与 `/foo/bar`，对应的 MPA Document
+URL 则是 `/index.html`、`/report.html` 与 `/foo/bar.html`。同一 Page 目录的
+`index.html` 可以作为该 MPA Page 的 Document 模板。
 
 ## Page 配置
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/project-structure.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/project-structure.md
@@ -74,6 +74,9 @@ export default defineConfig({
 });
 ```
 
+语义 Page route 仍是 `/`、`/about` 与 `/foo/bar`。MPA 的静态输出和请求时渲染
+都通过 `/index.html`、`/about.html` 与 `/foo/bar.html` 暴露对应 Document。
+
 ## 约定发现边界
 
 顶层 `conventions: false` 会把框架持有的文件系统约定作为一个整体关闭：

--- a/e2e/cases/mpa.ts
+++ b/e2e/cases/mpa.ts
@@ -104,7 +104,7 @@ test.describe("mpa", () => {
 
     await page.getByRole("link", { name: "Go to About page" }).click();
 
-    await expect(page).toHaveURL(`${baseURL}/about`);
+    await expect(page).toHaveURL(`${baseURL}/about.html`);
     await expect(page.getByRole("heading", { name: "About Page" })).toBeVisible(
       {
         timeout: 10_000,
@@ -133,7 +133,7 @@ test.describe("mpa", () => {
     );
 
     const aboutHtml = fs.readFileSync(
-      path.join(publicDir, "about", "index.html"),
+      path.join(publicDir, "about.html"),
       "utf-8",
     );
     expect(aboutHtml).toContain("<title>evjs MPA About</title>");
@@ -153,7 +153,7 @@ test.describe("mpa", () => {
         expect.objectContaining({
           kind: "page",
           id: "about",
-          fileName: "about/index.html",
+          fileName: "about.html",
           assets: expect.objectContaining({
             js: expect.arrayContaining([expect.stringMatching(/about.*\.js$/)]),
             css: expect.any(Array),

--- a/examples/mpa/README.md
+++ b/examples/mpa/README.md
@@ -28,7 +28,7 @@ npm run build
 | `src/pages/page.config.ts` | Static title/meta and rendering config for `/` |
 | `src/pages/components/PageScopeNote.tsx` | Colocated root Page component without an `_` prefix |
 | `src/pages/about/page.tsx` | Page for `/about` |
-| `src/pages/about/page.config.ts` | Static title/meta and `about.html` Document alias for `/about` |
+| `src/pages/about/page.config.ts` | Static title/meta for `/about` |
 | `src/pages/about/index.html` | Optional Page-specific HTML template baseline |
 
 ## What It Demonstrates
@@ -45,8 +45,8 @@ npm run build
 - `/about` omits `viewport`, so its colocated HTML viewport remains the
   Document baseline
 - A colocated `index.html` customizes one MPA Page without route configuration
-- `document.aliases` emits `/about.html` as an alias of `/about/index.html`
-- Stable `/` and `/about` URLs across SPA and MPA mode
+- `/` and `/about` remain semantic routes while MPA emits their Documents at
+  `/index.html` and `/about.html`
 - No `@evjs/client`, `@evjs/server`, or generated `route-types.d.ts`
   dependency is needed for this router-free client output
 

--- a/examples/mpa/src/pages/about/page.config.ts
+++ b/examples/mpa/src/pages/about/page.config.ts
@@ -6,7 +6,4 @@ export default definePageConfig({
     description: "The about Page in the canonical evjs MPA example.",
     "theme-color": "#f8fafc",
   },
-  document: {
-    aliases: ["about.html"],
-  },
 });

--- a/examples/mpa/src/pages/page.tsx
+++ b/examples/mpa/src/pages/page.tsx
@@ -9,7 +9,7 @@ export default function HomePage() {
       </p>
       <PageScopeNote />
       <p>
-        <a href="/about">Go to About page</a>
+        <a href="/about.html">Go to About page</a>
       </p>
     </main>
   );

--- a/packages/bundler-webpack/tests/adapter.test.ts
+++ b/packages/bundler-webpack/tests/adapter.test.ts
@@ -2033,7 +2033,7 @@ describe("webpackAdapter build", () => {
 
       assertFrameworkManifestShape(output, "Webpack MPA BuildOutput");
       const html = await fs.readFile(
-        path.join(cwd, "dist/client/home/index.html"),
+        path.join(cwd, "dist/client/home.html"),
         "utf-8",
       );
       const bundle = await fs.readFile(
@@ -2136,7 +2136,7 @@ describe("webpackAdapter build", () => {
         `https://evjs.invalid/${cssAsset}`,
       ).pathname.slice(1);
       const html = await fs.readFile(
-        path.join(clientDir, "home/index.html"),
+        path.join(clientDir, "home.html"),
         "utf-8",
       );
 
@@ -2640,7 +2640,7 @@ describe("webpackAdapter dev", () => {
     try {
       await waitForCondition(
         () =>
-          fs.access(path.join(cwd, "dist/client/home/index.html")).then(
+          fs.access(path.join(cwd, "dist/client/home.html")).then(
             () => true,
             () => false,
           ),
@@ -2712,9 +2712,7 @@ describe("webpackAdapter dev", () => {
       const output = onBuildOutput.mock.calls.at(-1)?.[0];
       if (!output) throw new Error("Expected linked BuildOutput.");
       assertFrameworkManifestShape(output, "Webpack dev MPA BuildOutput");
-      const html = await fetchDevText(
-        `http://127.0.0.1:${port}/home/index.html`,
-      );
+      const html = await fetchDevText(`http://127.0.0.1:${port}/home.html`);
       const unsupportedManifestResponse = await fetchDevResponse(
         `http://127.0.0.1:${port}/manifest.json`,
       );

--- a/packages/cli/tests/inspect.test.ts
+++ b/packages/cli/tests/inspect.test.ts
@@ -506,7 +506,7 @@ describe("inspect", () => {
         "export default function About() { return null; }",
       "src/pages/about/page.config.ts": `
         export default {
-          document: { aliases: ["about.html", "legacy/about.htm"] },
+          document: { aliases: ["about-alias.html", "legacy/about.htm"] },
         };
       `,
     });
@@ -518,22 +518,22 @@ describe("inspect", () => {
     );
 
     expect(result.graph.documents.about?.aliases).toEqual([
-      "about.html",
+      "about-alias.html",
       "legacy/about.htm",
     ]);
     expect(result.buildPlan?.html).toEqual([
       expect.objectContaining({
         id: "about",
-        fileName: "about/index.html",
-        aliases: ["about.html", "legacy/about.htm"],
+        fileName: "about.html",
+        aliases: ["about-alias.html", "legacy/about.htm"],
       }),
     ]);
     expect(formatInspectText(result)).toContain(
-      "about: about/index.html (aliases: about.html, legacy/about.htm)",
+      "about: about.html (aliases: about-alias.html, legacy/about.htm)",
     );
     const json = JSON.parse(formatInspectJson(result));
     expect(json.buildPlan.html[0].aliases).toEqual([
-      "about.html",
+      "about-alias.html",
       "legacy/about.htm",
     ]);
   });

--- a/packages/ev/src/_internal/build/dev-session.ts
+++ b/packages/ev/src/_internal/build/dev-session.ts
@@ -350,7 +350,7 @@ export async function startDevSession<TBundlerCfg>(
 function formatDevServerReady(
   origin: string,
   config: Pick<ResolvedFrameworkConfig, "routing">,
-  plan: Pick<BuildPlan, "html">,
+  plan: Pick<BuildPlan, "html" | "server">,
 ): string {
   const pageUrls = formatDevPageUrls(origin, config, plan);
   const lines = ["App listening at:", ...formatDevServerAddresses(origin)];
@@ -380,10 +380,10 @@ function formatDevServerAddresses(origin: string): string[] {
   return addresses;
 }
 
-function formatDevPageUrls(
+export function formatDevPageUrls(
   origin: string,
   config: Pick<ResolvedFrameworkConfig, "routing">,
-  plan: Pick<BuildPlan, "html">,
+  plan: Pick<BuildPlan, "html" | "server">,
 ): Array<{ pageId: string; url: string }> | undefined {
   if (config.routing?.mode !== "mpa") return undefined;
 
@@ -396,7 +396,16 @@ function formatDevPageUrls(
   });
   for (const route of config.routing.routes) {
     if (route.kind === "layout" || htmlPageIds.has(route.id)) continue;
-    pageUrls.push({ pageId: route.id, url: formatDevUrl(origin, route.path) });
+    const serverDocument = plan.server.documents?.find(
+      (document) => document.pageId === route.id,
+    );
+    pageUrls.push({
+      pageId: route.id,
+      url: formatDevUrl(
+        origin,
+        serverDocument ? `/${serverDocument.fileName}` : route.path,
+      ),
+    });
   }
   return pageUrls.length > 0 ? pageUrls : undefined;
 }

--- a/packages/ev/src/_internal/build/framework-output.ts
+++ b/packages/ev/src/_internal/build/framework-output.ts
@@ -793,7 +793,10 @@ async function prerenderStaticPageHtml(options: {
     options;
   const pageId = html.owner.pageId;
   const page = output.pages[pageId];
-  const pathname = findStaticPagePath(output, pageId, page);
+  const pathname =
+    frameworkRuntime.routing.kind === "mpa"
+      ? `/${html.fileName}`
+      : findStaticPagePath(output, pageId, page);
   if (!page || !pathname) return;
 
   const { createReactFrameworkServer } = await import("@evjs/server/react");

--- a/packages/ev/src/_internal/build/graph/core.ts
+++ b/packages/ev/src/_internal/build/graph/core.ts
@@ -19,7 +19,10 @@ import {
   PAGE_ANCHOR_PROVIDER_ID,
 } from "@evjs/shared/manifest";
 import type { ResolvedPageFileConfig } from "../page-config-module.js";
-import { createStaticPageDocumentOutput } from "../page-document-output.js";
+import {
+  createRouteHtmlDocumentOutput,
+  createRouteIndexDocumentOutput,
+} from "../page-document-output.js";
 import { resolvePageRenderMode } from "../page-rendering-contract.js";
 import { CANONICAL_PAGE_ROUTE_ROOT } from "../page-route-conventions.js";
 import type { GraphConfig } from "./index.js";
@@ -565,7 +568,7 @@ function materializeSpaPageDocumentsInPlace(options: {
     }
     const route = pageRoutes[0];
     if (!route) continue;
-    const output = createStaticPageDocumentOutput(route.pattern);
+    const output = createRouteIndexDocumentOutput(route.pattern);
     if (!output) {
       throw new Error(
         `[evjs] SPA SSG Page "${pageId}" config "${source}" cannot materialize dynamic Route "${formatRoutePattern(route.pattern)}" as one static HTML output.`,
@@ -676,7 +679,7 @@ function createCanonicalMpaDocumentOutput(route: CoreClientRouteNode): string {
       `[evjs] Canonical MPA Route "${route.id}" cannot materialize dynamic segment "${dynamic.kind === "param" ? `$${dynamic.name}` : "$..."}" as one static HTML document. Use routing.mode "spa".`,
     );
   }
-  const output = createStaticPageDocumentOutput(route.pattern);
+  const output = createRouteHtmlDocumentOutput(route.pattern);
   if (output) return output;
   throw new Error(
     `[evjs] Canonical MPA Route "${route.id}" contains a non-static segment after materialization validation.`,

--- a/packages/ev/src/_internal/build/page-document-output.ts
+++ b/packages/ev/src/_internal/build/page-document-output.ts
@@ -1,12 +1,12 @@
 import type { CoreRoutePattern } from "@evjs/shared/manifest";
 
 /**
- * Map one static semantic Page route to its canonical HTML output.
+ * Map one static semantic Page route to a directory-index HTML output.
  *
  * Returns undefined for dynamic/catch-all routes because they do not identify
  * one build-time document.
  */
-export function createStaticPageDocumentOutput(
+export function createRouteIndexDocumentOutput(
   route: string | CoreRoutePattern,
 ): string | undefined {
   const segments =
@@ -17,6 +17,21 @@ export function createStaticPageDocumentOutput(
   return segments.length > 0
     ? `${segments.join("/")}/index.html`
     : "index.html";
+}
+
+/** Map `/foo/bar` to the static Page Document output `foo/bar.html`. */
+export function createRouteHtmlDocumentOutput(
+  route: string | CoreRoutePattern,
+): string | undefined {
+  const segments =
+    typeof route === "string"
+      ? staticSegmentsFromPath(route)
+      : staticSegmentsFromPattern(route);
+  if (!segments) return undefined;
+  if (segments.length === 0) return "index.html";
+
+  const fileName = `${segments.at(-1)}.html`;
+  return [...segments.slice(0, -1), fileName].join("/");
 }
 
 function staticSegmentsFromPath(pathname: string): string[] | undefined {

--- a/packages/ev/src/_internal/build/plan/index.ts
+++ b/packages/ev/src/_internal/build/plan/index.ts
@@ -29,7 +29,7 @@ import {
   SERVER_RUNTIME_BUILD_ENTRY_NAME,
 } from "../build-entry-conventions.js";
 import { assertFrameworkOutputOwnership } from "../output-path-conventions.js";
-import { createStaticPageDocumentOutput } from "../page-document-output.js";
+import { createRouteIndexDocumentOutput } from "../page-document-output.js";
 import {
   isPartialPrerenderPage,
   isRscPage,
@@ -445,12 +445,26 @@ function createDevClientRoutes(
 function createServerRenderedRoutePaths(graph: CoreGraph): string[] {
   const paths = graph.routes.flatMap((route) => {
     if (route.target.kind !== "page") return [];
-    const page = graph.pages[route.target.pageId];
+    const pageId = route.target.pageId;
+    const page = graph.pages[pageId];
     // Full SSG renderers run only while emitting HTML. Their canonical route
     // must stay on the static dev host instead of being proxied to the server.
-    return page?.render === "ssr"
-      ? [formatCoreRoutePattern(route.pattern)]
-      : [];
+    if (page?.render !== "ssr") return [];
+
+    const application = graph.applications[route.applicationId];
+    if (application?.routingMode !== "mpa") {
+      return [formatCoreRoutePattern(route.pattern)];
+    }
+    const document = Object.values(graph.documents).find(
+      (candidate) =>
+        candidate.owner.kind === "page" && candidate.owner.pageId === pageId,
+    );
+    if (!document) {
+      throw new Error(
+        `[evjs] Server-rendered MPA Page "${pageId}" must own one HTML Document.`,
+      );
+    }
+    return [`/${document.output}`];
   });
   return [...new Set(paths)];
 }
@@ -938,7 +952,7 @@ function requirePageDocumentId(page: BuildPageFacts): string {
 function resolvePageDocumentOutput(page: BuildPageFacts): string {
   if (page.output) return page.output;
   const output = page.routePath
-    ? createStaticPageDocumentOutput(page.routePath)
+    ? createRouteIndexDocumentOutput(page.routePath)
     : undefined;
   if (page.render === "ssg" && output) return output;
   throw new Error(
@@ -1014,7 +1028,7 @@ function shouldEmitDocumentForPage(page: BuildPageFacts): boolean {
 }
 
 function isStaticPagePath(pathname: string): boolean {
-  return createStaticPageDocumentOutput(pathname) !== undefined;
+  return createRouteIndexDocumentOutput(pathname) !== undefined;
 }
 
 function createServerPlan(

--- a/packages/ev/tests/build-tools-graph-plan.test.ts
+++ b/packages/ev/tests/build-tools-graph-plan.test.ts
@@ -472,6 +472,8 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
           },
         };
       `,
+      "src/pages/foo/bar/page.tsx":
+        "export default function Nested() { return null; }",
       "index.html": '<main id="app"></main>',
     });
     const spaConfig = await createCanonicalConfig(cwd, "spa");
@@ -491,6 +493,7 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
     expect(spa.graph.pages).toMatchObject({
       index: { render: "csr" },
       about: { render: "csr" },
+      foo_bar: { render: "csr" },
     });
     expect(spa.graph.pages.index).not.toHaveProperty("hydrate");
     expect(spa.graph.pages.about).not.toHaveProperty("hydrate");
@@ -499,13 +502,13 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
     );
     expect(spa.graph.applications.default).toMatchObject({
       routingMode: "spa",
-      pageIds: ["index", "about"],
+      pageIds: ["index", "about", "foo_bar"],
       documentIds: ["index"],
     });
     expect(mpa.graph.applications.default).toMatchObject({
       routingMode: "mpa",
-      pageIds: ["index", "about"],
-      documentIds: ["index", "about"],
+      pageIds: ["index", "about", "foo_bar"],
+      documentIds: ["index", "about", "foo_bar"],
     });
     expect(mpa.graph.pages.about.metadata).toEqual({
       title: "About",
@@ -521,9 +524,14 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
         bootstrap: { kind: "page", pageId: "index" },
       },
       about: {
-        output: "about/index.html",
+        output: "about.html",
         owner: { kind: "page", pageId: "about" },
         bootstrap: { kind: "page", pageId: "about" },
+      },
+      foo_bar: {
+        output: "foo/bar.html",
+        owner: { kind: "page", pageId: "foo_bar" },
+        bootstrap: { kind: "page", pageId: "foo_bar" },
       },
     });
 
@@ -564,6 +572,13 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
         render: "csr",
         hydrate: "load",
       },
+      {
+        name: createPageClientBuildEntryName("foo_bar"),
+        owner: { appId: "default", pageId: "foo_bar" },
+        layers: [{ kind: "layout", module: "./src/pages/layout.tsx" }],
+        render: "csr",
+        hydrate: "load",
+      },
     ]);
     expect(mpaPlan.html).toEqual([
       {
@@ -575,7 +590,7 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
       {
         id: "about",
         template: "./index.html",
-        fileName: "about/index.html",
+        fileName: "about.html",
         owner: { appId: "default", pageId: "about" },
         metadata: {
           title: "About",
@@ -584,6 +599,12 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
             Robots: "index,follow",
           },
         },
+      },
+      {
+        id: "foo_bar",
+        template: "./index.html",
+        fileName: "foo/bar.html",
+        owner: { appId: "default", pageId: "foo_bar" },
       },
     ]);
 
@@ -599,15 +620,20 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
           js: ["about.js"],
           css: ["about.css"],
         },
+        [createPageClientBuildEntryName("foo_bar")]: {
+          js: ["nested.js"],
+          css: [],
+        },
       },
     });
     expect(output.apps).toEqual({});
     expect(output.routes).toEqual([
       { id: "index", path: "/", pageId: "index" },
       { id: "about", path: "/about", pageId: "about" },
+      { id: "foo_bar", path: "/foo/bar", pageId: "foo_bar" },
     ]);
     expect(output.pages.about.document).toEqual({
-      fileName: "about/index.html",
+      fileName: "about.html",
     });
     expect(output.pages.about.metadata).toEqual({
       title: "About",
@@ -624,7 +650,7 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
         "export default function About() { return null; }",
       "src/pages/about/page.config.ts": `
         export default {
-          document: { aliases: ["about.html", "legacy/about.htm"] },
+          document: { aliases: ["legacy/about.html", "legacy/about.htm"] },
         };
       `,
       "index.html": '<main id="app"></main>',
@@ -636,16 +662,16 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
     });
 
     expect(analysis.graph.documents.about).toMatchObject({
-      output: "about/index.html",
-      aliases: ["about.html", "legacy/about.htm"],
+      output: "about.html",
+      aliases: ["legacy/about.html", "legacy/about.htm"],
       owner: { kind: "page", pageId: "about" },
     });
     expect(plan.html).toEqual([
       {
         id: "about",
         template: "./index.html",
-        fileName: "about/index.html",
-        aliases: ["about.html", "legacy/about.htm"],
+        fileName: "about.html",
+        aliases: ["legacy/about.html", "legacy/about.htm"],
         owner: { appId: "default", pageId: "about" },
       },
     ]);
@@ -661,8 +687,8 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
       },
     });
     expect(output.pages.about.document).toEqual({
-      fileName: "about/index.html",
-      aliases: ["about.html", "legacy/about.htm"],
+      fileName: "about.html",
+      aliases: ["legacy/about.html", "legacy/about.htm"],
     });
   });
 
@@ -798,9 +824,9 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
       );
     }
 
-    document.aliases = ["REPORT/INDEX.HTML"];
+    document.aliases = ["REPORT.HTML"];
     expect(() => createBuildPlan(config, analysis.graph)).toThrow(
-      'Duplicate HTML output file "REPORT/INDEX.HTML"',
+      'Duplicate HTML output file "REPORT.HTML"',
     );
 
     document.aliases = [`${originalOutput}/nested.html`];
@@ -819,7 +845,7 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
       "src/pages/about/page.tsx":
         "export default function About() { return null; }",
       "src/pages/about/page.config.ts":
-        'export default { document: { aliases: ["about.html"] } };',
+        'export default { document: { aliases: ["legacy/about.html"] } };',
       "index.html": '<main id="app"></main>',
     });
     const previousConfig = await createCanonicalConfig(cwd, "mpa");
@@ -848,7 +874,7 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
       {
         id: "about",
         template: "./index.html",
-        fileName: "about/index.html",
+        fileName: "about.html",
         owner: { appId: "default", pageId: "about" },
       },
     ]);
@@ -993,7 +1019,7 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
     });
     expect(plan.dev.serverRequestRoutePaths).toEqual([]);
     expect(new Set(plan.dev.serverRenderedPagePaths)).toEqual(
-      new Set(["/ssr", "/rsc", "/ppr"]),
+      new Set(["/ssr.html", "/rsc.html", "/ppr.html"]),
     );
     expect(plan.dev.serverRenderedPagePaths).not.toContain("/ssg");
     expect(plan.entries).toEqual(
@@ -1083,7 +1109,7 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
         documentId: "ppr",
         applicationId: "default",
         template: "./index.html",
-        fileName: "ppr/index.html",
+        fileName: "ppr.html",
         mount: "#app",
       },
       {
@@ -1091,7 +1117,7 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
         documentId: "rsc",
         applicationId: "default",
         template: "./index.html",
-        fileName: "rsc/index.html",
+        fileName: "rsc.html",
         mount: "#app",
       },
       {
@@ -1099,13 +1125,43 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
         documentId: "ssr",
         applicationId: "default",
         template: "./index.html",
-        fileName: "ssr/index.html",
+        fileName: "ssr.html",
         mount: "#app",
       },
     ]);
     expect(
       plan.server.documents?.some((document) => document.pageId === "ssg"),
     ).toBe(false);
+  });
+
+  it("uses MPA Document URLs for server-rendered dev paths without changing SPA routes", async () => {
+    const cwd = await createFixture({
+      "src/pages/page.tsx": "export default function Home() { return null; }",
+      "src/pages/page.config.ts": 'export default { render: "ssr" };',
+      "src/pages/about/page.tsx":
+        "export default function About() { return null; }",
+      "src/pages/about/page.config.ts": 'export default { render: "ssr" };',
+      "index.html": '<main id="app"></main>',
+    });
+    const spaConfig = await createCanonicalConfig(cwd, "spa");
+    const mpaConfig = await createCanonicalConfig(cwd, "mpa");
+    const spa = await createCoreGraph(spaConfig, cwd);
+    const mpa = await createCoreGraph(mpaConfig, cwd);
+    const spaPlan = createBuildPlan(spaConfig, spa.graph, {
+      mode: "development",
+    });
+    const mpaPlan = createBuildPlan(mpaConfig, mpa.graph, {
+      mode: "development",
+    });
+
+    expect(clientRouteProjection(mpa.graph)).toEqual(
+      clientRouteProjection(spa.graph),
+    );
+    expect(spaPlan.dev.serverRenderedPagePaths).toEqual(["/", "/about"]);
+    expect(mpaPlan.dev.serverRenderedPagePaths).toEqual([
+      "/index.html",
+      "/about.html",
+    ]);
   });
 
   it("uses the SPA Application Document as an explicit SSR Page shell without emitting it twice", async () => {
@@ -2493,7 +2549,7 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
       {
         id: "orders",
         template: "./index.html",
-        fileName: "orders/index.html",
+        fileName: "orders.html",
         owner: { appId: "default", pageId: "orders" },
       },
     ]);

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -3361,7 +3361,7 @@ describe("build", () => {
     await build(config("old"), { cwd, bundler });
     const metadataPath = path.join(cwd, "dist/deployment-metadata.json");
     const htmlPaths = ["alpha", "beta"].map((pageId) =>
-      path.join(clientDir, pageId, "index.html"),
+      path.join(clientDir, `${pageId}.html`),
     );
     const previousDist = await readDirectorySnapshot(distDir);
 
@@ -4703,7 +4703,7 @@ describe("build", () => {
     ].join("");
 
     expect(transformedFiles).toEqual([
-      mode === "spa" ? "index.html" : "dashboard/index.html",
+      mode === "spa" ? "index.html" : "dashboard.html",
     ]);
     expect(html).toContain('<html lang="zh-CN"');
     expect(html).toContain('data-template="configured"');
@@ -4910,11 +4910,11 @@ describe("build", () => {
       "utf-8",
     );
     const homeHtml = await fs.promises.readFile(
-      path.join(cwd, "dist/client/home/index.html"),
+      path.join(cwd, "dist/client/home.html"),
       "utf-8",
     );
     const adminHtml = await fs.promises.readFile(
-      path.join(cwd, "dist/client/admin/index.html"),
+      path.join(cwd, "dist/client/admin.html"),
       "utf-8",
     );
 
@@ -5494,10 +5494,7 @@ describe("build", () => {
 
     expect(events).toEqual(["html:product:./src/pages/product/index.html"]);
     await expect(
-      fs.promises.readFile(
-        path.join(cwd, "dist/client/product/index.html"),
-        "utf-8",
-      ),
+      fs.promises.readFile(path.join(cwd, "dist/client/product.html"), "utf-8"),
     ).resolves.toContain('<main id="app">');
   });
 
@@ -5514,7 +5511,7 @@ describe("build", () => {
       `
         export default {
           document: {
-            aliases: ["about.html", "legacy/about.htm"],
+            aliases: ["about-alias.html", "legacy/about.htm"],
           },
         };
       `,
@@ -5574,8 +5571,8 @@ describe("build", () => {
 
     await build(config, { cwd, bundler });
 
-    const primaryPath = path.join(cwd, "dist/client/about/index.html");
-    const aliasPath = path.join(cwd, "dist/client/about.html");
+    const primaryPath = path.join(cwd, "dist/client/about.html");
+    const aliasPath = path.join(cwd, "dist/client/about-alias.html");
     const nestedAliasPath = path.join(cwd, "dist/client/legacy/about.htm");
     const [primary, alias, nestedAlias] = await Promise.all([
       fs.promises.readFile(primaryPath, "utf-8"),
@@ -5586,7 +5583,9 @@ describe("build", () => {
     expect(nestedAlias).toBe(primary);
     expect(primary).toContain("alias-transform");
     expect(transformCalls).toBe(1);
-    expect(frameworkAliases).toEqual([["about.html", "legacy/about.htm"]]);
+    expect(frameworkAliases).toEqual([
+      ["about-alias.html", "legacy/about.htm"],
+    ]);
     const firstDeployment = JSON.parse(
       await fs.promises.readFile(
         path.join(cwd, "dist/deployment-metadata.json"),
@@ -5596,8 +5595,8 @@ describe("build", () => {
     expect(firstDeployment.documents).toContainEqual({
       kind: "page",
       id: "about",
-      fileName: "about/index.html",
-      aliases: ["about.html", "legacy/about.htm"],
+      fileName: "about.html",
+      aliases: ["about-alias.html", "legacy/about.htm"],
       assets: { js: ["page-client-about.js"], css: [] },
     });
 
@@ -5606,7 +5605,7 @@ describe("build", () => {
 
     expect(transformCalls).toBe(2);
     expect(frameworkAliases).toEqual([
-      ["about.html", "legacy/about.htm"],
+      ["about-alias.html", "legacy/about.htm"],
       undefined,
     ]);
     await expect(fs.promises.access(aliasPath)).rejects.toThrow();
@@ -5948,7 +5947,7 @@ describe("build", () => {
     );
 
     const html = fs.readFileSync(
-      path.join(cwd, "dist/client/report/index.html"),
+      path.join(cwd, "dist/client/report.html"),
       "utf-8",
     );
     const transformOutput = JSON.parse(
@@ -5956,7 +5955,7 @@ describe("build", () => {
     );
 
     expect(html).toContain("Prerendered Report");
-    expect(html).toContain("http://evjs.local/report");
+    expect(html).toContain("http://evjs.local/report.html");
     expect(html).not.toMatch(/<script[^>]+src=/);
     expect(html).not.toContain("__EVJS_CLIENT_RUNTIME__");
     expect(html).not.toContain("data-evjs-hydrate");
@@ -5964,7 +5963,7 @@ describe("build", () => {
     expect(transformOutput.documents).toContainEqual({
       kind: "page",
       id: "report",
-      fileName: "report/index.html",
+      fileName: "report.html",
     });
     expect(transformOutput.routes).toEqual([
       {
@@ -6036,7 +6035,7 @@ describe("build", () => {
     );
 
     const html = fs.readFileSync(
-      path.join(cwd, "dist/client/report/index.html"),
+      path.join(cwd, "dist/client/report.html"),
       "utf-8",
     );
     expect(html).toContain(
@@ -6244,8 +6243,8 @@ describe("build", () => {
       { cwd, bundler },
     );
 
-    const reportHtml = path.join(cwd, "dist/client/report/index.html");
-    const archiveHtml = path.join(cwd, "dist/client/archive/index.html");
+    const reportHtml = path.join(cwd, "dist/client/report.html");
+    const archiveHtml = path.join(cwd, "dist/client/archive.html");
     const unrelatedHtml = path.join(cwd, "dist/client/manual.html");
     expect(fs.existsSync(reportHtml)).toBe(true);
     expect(fs.existsSync(archiveHtml)).toBe(true);
@@ -6261,7 +6260,7 @@ describe("build", () => {
     );
     await fs.promises.rm(reportPage);
     await fs.promises.rm(archivePage);
-    bundlerOwnedFile = "report/index.html";
+    bundlerOwnedFile = "report.html";
 
     await build(
       { output: { client: "dist/client" }, routing: { mode: "mpa" } },

--- a/packages/ev/tests/deployment.test.ts
+++ b/packages/ev/tests/deployment.test.ts
@@ -6,7 +6,7 @@ import type { BuildOutput } from "@evjs/shared/manifest";
 import { assertFrameworkManifestShape } from "@evjs/shared/manifest";
 import { afterEach, describe, expect, it } from "vitest";
 import { createBuildResult } from "../src/_internal/build/build-result.js";
-import { createStaticPageDocumentOutput } from "../src/_internal/build/page-document-output.js";
+import { createRouteIndexDocumentOutput } from "../src/_internal/build/page-document-output.js";
 import {
   createLatePluginContext,
   runAfterBuildHooks,
@@ -777,7 +777,7 @@ describe("createDeploymentArtifact", () => {
       throw new Error("Expected the static pricing fixture route.");
     }
     page.path = "/%75sers";
-    const plannedFileName = createStaticPageDocumentOutput(page.path);
+    const plannedFileName = createRouteIndexDocumentOutput(page.path);
     if (!plannedFileName) throw new Error("Expected a static document output.");
     page.document.fileName = plannedFileName;
     expect(page.document.fileName).toBe("%75sers/index.html");

--- a/packages/ev/tests/dev-session.test.ts
+++ b/packages/ev/tests/dev-session.test.ts
@@ -8,7 +8,10 @@ import type {
   BundlerDevController,
 } from "../src/_internal/build/bundler.js";
 import { withActiveBundler } from "../src/_internal/build/bundler-config.js";
-import { startDevSession } from "../src/_internal/build/dev-session.js";
+import {
+  formatDevPageUrls,
+  startDevSession,
+} from "../src/_internal/build/dev-session.js";
 import { createCoreGraph } from "../src/_internal/build/graph/index.js";
 import { createBuildPlan } from "../src/_internal/build/plan/index.js";
 import { resolveConfig } from "../src/config/index.js";
@@ -117,6 +120,38 @@ afterEach(async () => {
 });
 
 describe("immutable dev session", () => {
+  it("formats server-rendered MPA Pages with their Document URLs", async () => {
+    const cwd = await createProject();
+    const controlled = createControlledBundler();
+    const input = await createSessionInput(cwd, controlled.adapter);
+    input.config.routing = {
+      mode: "mpa",
+      html: "./index.html",
+      mount: "#app",
+      routes: [
+        {
+          id: "report",
+          path: "/report",
+          module: "./src/pages/report/page.tsx",
+        },
+      ],
+    };
+    input.plan.server.documents = [
+      {
+        pageId: "report",
+        documentId: "report",
+        applicationId: "default",
+        template: "./index.html",
+        fileName: "report.html",
+        mount: "#app",
+      },
+    ];
+
+    expect(
+      formatDevPageUrls("http://localhost:3000", input.config, input.plan),
+    ).toEqual([{ pageId: "report", url: "http://localhost:3000/report.html" }]);
+  });
+
   it("discards old build facts that arrive after a replacement session starts", async () => {
     const cwd = await createProject();
     const controlled = createControlledBundler();

--- a/packages/server/src/framework-rendering/framework.ts
+++ b/packages/server/src/framework-rendering/framework.ts
@@ -1255,9 +1255,8 @@ export async function handleFrameworkRenderRequest(
   }
 
   const url = new URL(request.url);
-  const routes = getFrameworkRuntimeRoutes(options.runtime);
   const pages = getFrameworkRuntimePages(options.runtime);
-  const route = matchRoute(routes, url.pathname);
+  const route = matchFrameworkPageRoute(options.runtime, url.pathname);
   const pageId = route?.pageId;
   const page = pageId ? pages[pageId] : undefined;
 
@@ -1859,7 +1858,14 @@ function getPprRegionPagePaths(
   const routePaths = getFrameworkRuntimeRoutes(runtime)
     .filter((route) => route.pageId === pageId)
     .map((route) => route.path);
-  return routePaths.length > 0 ? routePaths : page?.path ? [page.path] : [];
+  const paths =
+    routePaths.length > 0 ? routePaths : page?.path ? [page.path] : [];
+  return runtime.routing.kind === "mpa"
+    ? paths.flatMap((path) => {
+        const documentPath = createRouteHtmlDocumentPath(path);
+        return documentPath ? [documentPath] : [];
+      })
+    : paths;
 }
 
 function isStaticPagePath(pathname: string): boolean {
@@ -1973,6 +1979,9 @@ function pageUrlMatchesPage(
   );
 
   if (pageRoutes.length > 0) {
+    if (runtime.routing.kind === "mpa") {
+      return matchFrameworkPageRoute(runtime, pathname)?.pageId === pageId;
+    }
     return pageRoutes.some((route) =>
       pageRoutePathMatches(route.path, pathname),
     );
@@ -2251,6 +2260,34 @@ function matchRoute(
   pathname: string,
 ): FrameworkRouteRuntime | undefined {
   return findBestPageRoute(routes, pathname);
+}
+
+function matchFrameworkPageRoute(
+  runtime: FrameworkRuntime,
+  pathname: string,
+): FrameworkRouteRuntime | undefined {
+  const routes = getFrameworkRuntimeRoutes(runtime);
+  if (runtime.routing.kind === "spa") return matchRoute(routes, pathname);
+  if (!pathname.endsWith(".html")) return undefined;
+
+  const direct = matchRoute(routes, pathname);
+  if (direct) return direct;
+
+  return routes.find((route) => {
+    const documentPath = createRouteHtmlDocumentPath(route.path);
+    return documentPath ? pageRoutePathMatches(documentPath, pathname) : false;
+  });
+}
+
+function createRouteHtmlDocumentPath(pathname: string): string | undefined {
+  if (!isStaticPagePath(pathname)) return undefined;
+  const normalizedPath = normalizeRoutePathname(pathname);
+  if (normalizedPath === "/") return "/index.html";
+
+  const segments = normalizedPath.slice(1).split("/");
+  const last = segments.at(-1);
+  if (!last) return undefined;
+  return `/${[...segments.slice(0, -1), `${last}.html`].join("/")}`;
 }
 
 function matchPprRegion(

--- a/packages/server/tests/app.test.ts
+++ b/packages/server/tests/app.test.ts
@@ -25,6 +25,10 @@ type SpaFrameworkRuntime = FrameworkRuntime & {
   routing: Extract<FrameworkRuntime["routing"], { kind: "spa" }>;
 };
 
+type MpaFrameworkRuntime = FrameworkRuntime & {
+  routing: Extract<FrameworkRuntime["routing"], { kind: "mpa" }>;
+};
+
 describe("createApp", () => {
   let serverFunctions: ServerFunctionRegistry;
 
@@ -1097,6 +1101,64 @@ describe("createApp", () => {
     expect(await res.text()).toBe("<h1>dashboard:ssr</h1>");
   });
 
+  it("routes MPA Document URLs without exposing their semantic Page routes", async () => {
+    const manifest = createMpaManifest();
+    manifest.routing.pages.index = {
+      ...manifest.routing.pages.dashboard,
+      path: "/",
+      routeId: "index",
+    };
+    manifest.routing.pages.about = {
+      ...manifest.routing.pages.dashboard,
+      path: "/about",
+      routeId: "about",
+    };
+    delete manifest.routing.pages.dashboard;
+    manifest.server = {};
+    const app = createApp({
+      framework: {
+        runtime: manifest,
+        render(ctx) {
+          return `<h1>${ctx.pageId}:${ctx.route?.path}</h1>`;
+        },
+      },
+    });
+
+    const rootDocument = await app.request("/index.html");
+    const aboutDocument = await app.request("/about.html");
+    const rootRoute = await app.request("/");
+    const aboutRoute = await app.request("/about");
+
+    expect(rootDocument.status).toBe(200);
+    await expect(rootDocument.text()).resolves.toBe("<h1>index:/</h1>");
+    expect(aboutDocument.status).toBe(200);
+    await expect(aboutDocument.text()).resolves.toBe("<h1>about:/about</h1>");
+    expect(rootRoute.status).toBe(404);
+    expect(aboutRoute.status).toBe(404);
+  });
+
+  it("prefers a real MPA .html semantic route over Document fallback", async () => {
+    const manifest = createMpaManifest();
+    manifest.routing.pages.literal = {
+      ...manifest.routing.pages.dashboard,
+      path: "/dashboard.html",
+      routeId: "literal",
+    };
+    const app = createApp({
+      framework: {
+        runtime: manifest,
+        render(ctx) {
+          return `<h1>${ctx.pageId}</h1>`;
+        },
+      },
+    });
+
+    const response = await app.request("/dashboard.html");
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("<h1>literal</h1>");
+  });
+
   it("matches framework pages without collapsing empty path segments", async () => {
     const manifest = createManifest();
     const render = vi.fn(() => "<h1>dashboard</h1>");
@@ -1837,6 +1899,46 @@ describe("createApp", () => {
       'PPR region request url is required for page "order"',
     );
     expect(renderCount).toBe(2);
+  });
+
+  it("accepts MPA Document URLs for direct PPR region requests", async () => {
+    const spaManifest = createManifest();
+    spaManifest.routing.pages.dashboard.ppr = {
+      delivery: "merge",
+      shell: { js: ["dashboard-ppr-shell.js"], css: [] },
+      regions: {
+        hero: {
+          id: "hero",
+          assets: { js: ["dashboard-hero-ppr-region.js"], css: [] },
+        },
+      },
+    };
+    configurePprRendering(spaManifest);
+    const manifest = createMpaManifest(spaManifest);
+    const app = createApp({
+      framework: {
+        runtime: manifest,
+        render: createModuleRenderCoordinator({
+          renderers: {
+            "dashboard-hero-region": {
+              kind: "ppr-region",
+              owner: { pageId: "dashboard", regionId: "hero" },
+              load: async () => ({
+                default: (ctx: ServerRenderContext) =>
+                  new URL(ctx.pageUrl ?? "https://example.com/").pathname,
+              }),
+            },
+          },
+        }),
+      },
+    });
+
+    const response = await app.request(
+      "/__evjs/ppr/dashboard/hero?url=%2Fdashboard.html",
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("/dashboard.html");
   });
 
   it("leaves PPR page responses with non-html media types unchanged", async () => {
@@ -4628,6 +4730,29 @@ describe("createApp", () => {
     );
   });
 
+  it("accepts MPA Document URLs for RSC Flight page validation", async () => {
+    const spaManifest = createManifest();
+    configureRscManifest(spaManifest);
+    const manifest = createMpaManifest(spaManifest);
+    const app = createApp({
+      framework: {
+        runtime: manifest,
+        rsc(ctx) {
+          return new Response(new URL(ctx.pageUrl ?? "about:blank").pathname, {
+            headers: { "Content-Type": "text/x-component" },
+          });
+        },
+      },
+    });
+
+    const response = await app.request(
+      "/__evjs/rsc?page=dashboard&url=%2Fdashboard.html",
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("/dashboard.html");
+  });
+
   it("accepts RSC Flight page urls that match dynamic page routes", async () => {
     const manifest = createManifest();
     configureRscManifest(manifest);
@@ -4805,6 +4930,32 @@ function createManifest(): SpaFrameworkRuntime {
           assets: { js: ["dashboard-server.js"], css: [] },
         },
       },
+    },
+  };
+}
+
+function createMpaManifest(
+  manifest: SpaFrameworkRuntime = createManifest(),
+): MpaFrameworkRuntime {
+  const pages = Object.fromEntries(
+    Object.entries(manifest.routing.pages).map(([pageId, page]) => {
+      const route = manifest.routing.routes.find(
+        (candidate) => candidate.pageId === pageId,
+      );
+      return [
+        pageId,
+        {
+          ...page,
+          ...(route ? { path: route.path, routeId: route.id } : {}),
+        },
+      ];
+    }),
+  );
+  return {
+    ...manifest,
+    routing: {
+      kind: "mpa",
+      pages,
     },
   };
 }


### PR DESCRIPTION
## Summary

- materialize MPA Page Documents as `index.html`, `about.html`, and nested `foo/bar.html` outputs while preserving semantic routes
- expose SSR/PPR dev paths through the same Document URLs and map them back to canonical Pages in the server runtime
- reuse Document URL matching for PPR/RSC validation while keeping SPA and bundler production behavior unchanged
- adapt dev-session page URL reporting to the immutable-session architecture on current `main`
- document the MPA URL contract in English and Chinese

## Validation

- `npm run lint`
- `npm run check-types`
- documentation build for both locales
- EV focused tests: 245 passed
- server app tests: 112 passed
- Utoopack tests: 98 passed
- Webpack tests: 81 passed
- CLI tests: 53 passed
- `git diff --check`