### PR TITLE
docs(changelog): prepare v0.3.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,32 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.7] — 2026-08-10
+
 ### ⚠️ Breaking Changes
 
 - **Immutable bundler development sessions** — Internal bundler adapters now
   return a controller with `origin`, `done`, and idempotent `close()` instead of
   implementing in-place framework plan transitions. Development callbacks are
   scoped to one fixed config, plugin, graph, and plan snapshot.
+
+### ✨ Features
+
+- **Utoopack multi-entry server builds** — Utoopack now forwards named
+  `server-runtime` and `page-server` BuildPlan entries, maps each entry back to
+  its emitted server assets, and preserves shared chunks. Regular server builds
+  are supported while the legacy scalar runtime entry remains compatible.
+- **Plugin-driven development shortcuts** — Interactive `ev dev` terminals can
+  expose plugin-contributed keyboard shortcuts with descriptions, asynchronous
+  actions, and shutdown support. Bindings update safely across configuration
+  replacement and can be disabled with `dev.cliShortcuts` or
+  `ev dev --no-shortcuts`.
+- **Canonical MPA Document URLs** — MPA Pages now materialize as `index.html`,
+  `about.html`, and nested `foo/bar.html` Documents while retaining their
+  semantic routes. Development SSR and PPR requests use the same public URLs
+  and resolve back to their canonical Pages.
 
 ### 🐛 Bug Fixes
 


### PR DESCRIPTION
## Summary
- Prepare the EVJS v0.3.7 stable release notes from the current `main` branch.
- Cover the four changes merged after v0.3.6.

## Changes
- Add a dated v0.3.7 changelog section.
- Document Utoopack multi-entry server builds and plugin-driven development shortcuts.
- Document immutable development sessions and their recovery behavior.
- Document canonical MPA `.html` Document URLs.

## Validation
- `npm run lint`
- `npm --workspace evjs-docs run build`
- `git diff --check`
- PRs #72, #86, #87, and #88 each passed the repository Build & Test workflow before merge.

## Risk / rollout
- Documentation-only change; package versions and internal workspace dependency ranges remain managed by the release workflow.
- Publishing GitHub Release `v0.3.7` after merge will publish all public `@evjs/*` workspaces with the npm `latest` dist-tag.
- No migration, configuration, dependency, auth, security, or privacy changes are introduced by this release-preparation commit.

## Reviewer notes
- Verify that the notes describe only `v0.3.6..main` (PRs #72, #86, #87, and #88).
- The release will target the resulting merge commit on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.3.7.
  * Documented immutable bundler development sessions and multi-entry server builds.
  * Added notes on plugin-driven development shortcuts and canonical MPA document URLs.
  * Clarified the scope of existing breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->