### PR TITLE
fix(server): allow MPA HTML dev rendering

### DIFF
--- a/packages/server/src/framework-rendering/react.ts
+++ b/packages/server/src/framework-rendering/react.ts
@@ -103,7 +103,7 @@ export function createReactFrameworkServer(
           fallback: options.fallback,
         })
       : undefined,
-    allowPageRenderRequest: createDevPageRenderGuard(),
+    allowPageRenderRequest: createDevPageRenderGuard(runtime),
     rsc,
   };
 }
@@ -171,9 +171,13 @@ function assertOptionalRscCoordinator(value: unknown, source: string): void {
   );
 }
 
-function createDevPageRenderGuard():
-  | FrameworkServerOptions["allowPageRenderRequest"]
-  | undefined {
+function createDevPageRenderGuard(
+  runtime: FrameworkRuntime,
+): FrameworkServerOptions["allowPageRenderRequest"] | undefined {
+  if (runtime.routing.kind === "mpa") {
+    return (request) => new URL(request.url).pathname.endsWith(".html");
+  }
+
   const headerName = globalThis.__EVJS_DEV_PAGE_RENDER_PROXY_HEADER__;
   if (!headerName) return undefined;
 

--- a/packages/server/tests/app.test.ts
+++ b/packages/server/tests/app.test.ts
@@ -4247,6 +4247,42 @@ describe("createApp", () => {
     );
   });
 
+  it("allows MPA Document rendering without a dev proxy header", async () => {
+    const manifest = createMpaManifest();
+    manifest.server = {
+      renderers: {
+        "dashboard-server": {
+          kind: "page-server",
+          owner: { pageId: "dashboard" },
+          assets: { js: ["dashboard-server.js"], css: [] },
+        },
+      },
+    };
+    vi.stubGlobal("__EVJS_FRAMEWORK_RUNTIME__", manifest);
+    vi.stubGlobal(
+      "__EVJS_DEV_PAGE_RENDER_PROXY_HEADER__",
+      "x-evjs-dev-page-render",
+    );
+    vi.stubGlobal("__EVJS_SERVER_MODULE_LOADER__", async () => ({
+      default({ pageId }: { pageId?: string }) {
+        return `Page ${pageId}`;
+      },
+    }));
+
+    const framework = createReactFrameworkServer();
+    if (!framework) throw new Error("Expected framework options");
+    const app = createApp({ framework });
+
+    const document = await app.request("/dashboard.html");
+    const semanticRoute = await app.request("/dashboard");
+
+    expect(document.status).toBe(200);
+    expect(await document.text()).toContain(
+      '<div id="app">Page dashboard</div>',
+    );
+    expect(semanticRoute.status).toBe(404);
+  });
+
   it("mounts RSC flight handling on the framework server path", async () => {
     const manifest = createManifest();
     configureRscManifest(manifest);


### PR DESCRIPTION
## Summary

- allow MPA framework page rendering for `.html` document requests without the internal dev proxy header
- keep the existing header guard unchanged for SPA rendering
- cover both the allowed `.html` document path and rejected extensionless semantic route

## Why

MPA dev URLs are now exposed as `/index.html` and `/about.html`, but the React framework server still required `x-evjs-dev-page-render`. Direct browser requests therefore returned 404/405 unless a proxy injected the internal header. MPA documents already have an unambiguous `.html` request boundary, so the server can recognize them directly.

## Validation

- `npm test`
- `npm run check-types`
- `npm run lint`
- `git diff --check`
- local PPR application with `@utoo/pack@1.5.2`:
  - `/index.html` → 200 without the header
  - `/about.html` → 200 without the header
  - extensionless MPA routes remain unavailable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MPA document URLs now render correctly through the React framework server without requiring a development proxy header.
  * Semantic routes continue to follow the expected availability rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->