### PR TITLE
docs(changelog): prepare v0.3.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ---
 
+## [0.3.8] — 2026-08-11
+
+### 🐛 Bug Fixes
+
+- **Direct MPA Document development rendering** — MPA `.html` Document requests
+  now enter React framework rendering without the internal development proxy
+  header. SPA requests keep the existing header guard, and extensionless MPA
+  semantic routes remain unavailable.
+
+---
+
 ## [0.3.7] — 2026-08-10
 
 ### ⚠️ Breaking Changes


### PR DESCRIPTION
## Summary
- Prepare the EVJS v0.3.8 stable release notes from the current `main` branch.
- Cover the single change merged after v0.3.7.

## Changes
- Add a dated v0.3.8 changelog section.
- Document direct MPA `.html` Document rendering without the internal development proxy header.
- Clarify that SPA requests retain the header guard and extensionless MPA semantic routes remain unavailable.

## Validation
- `npm run lint`
- `npm --workspace evjs-docs run build`
- `git diff --check`
- PR #90 passed the repository Build & Test workflow before merge.

## Risk / rollout
- Documentation-only change; package versions and internal workspace dependency ranges remain managed by the release workflow.
- Publishing GitHub Release `v0.3.8` after merge will publish all public `@evjs/*` workspaces with the npm `latest` dist-tag.
- No migration, configuration, dependency, auth, security, or privacy changes are introduced by this release-preparation commit.

## Reviewer notes
- Verify that the notes describe only `v0.3.7..main` (PR #90).
- The release will target the resulting merge commit on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed direct `.html` page requests to render correctly using the React framework.
  * Preserved existing behavior for single-page application requests.
  * Extensionless multi-page application routes remain unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->