### PR TITLE
feat(plugin): expose dev server ready hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+### ✨ Features
+
+- **Dev server ready plugin hook** — Plugins can consume the actual client
+  origin through `devServerReady()` once per immutable development Session,
+  without wrapping or replacing the selected bundler adapter.
+
 ---
 
 ## [0.3.8] — 2026-08-11

--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -262,9 +262,10 @@ contracts.
 
 Public context names follow their stages: `PluginConfigureContext`,
 `PluginSetupContext`, `PluginEmitIRContext`, `ConfigureBundlerContext`,
-`BeforeBuildContext`, `TransformOutputContext`, `TransformHtmlContext`, and
-`DisposeContext`. Contribution code reads the normalized `FrameworkView` from
-`ctx.framework`. Plugin option helpers expose `PluginOptionsContract`,
+`DevServerReadyContext`, `BeforeBuildContext`, `TransformOutputContext`,
+`TransformHtmlContext`, and `DisposeContext`. Contribution code reads the
+normalized `FrameworkView` from `ctx.framework`. Plugin option helpers expose
+`PluginOptionsContract`,
 `PluginOptionsDefinition`, and `PluginOptionsContext`; internal factory
 inference types are not part of the public authoring API.
 
@@ -291,6 +292,7 @@ Required Application options stay required in either available factory form.
 | Declare interactive dev CLI keys and actions | `cliShortcuts()` |
 | Allocate shared state | `setup()` |
 | Run build lifecycle behavior | Hooks returned by `setup()` |
+| Consume the actual client origin after the dev listener starts | `devServerReady()` |
 | Generate modules or attach structured behavior | `emitIR()` or `emitPageIR()` |
 | Compile a custom file type or tune optimization | `configureBundler()` |
 | Rewrite a parsed HTML document | `transformHtml()` |

--- a/docs/docs/plugin-hooks.md
+++ b/docs/docs/plugin-hooks.md
@@ -27,6 +27,7 @@ flowchart TB
   subgraph Build["Bundling and output"]
     BundlerConfig["configureBundler()"]
     Bundler["bundler build"]
+    DevReady["devServerReady()\ndev only"]
     Facts["fresh bundler facts"]
     BuildStart["beforeBuild()"]
     Link["link canonical BuildOutput"]
@@ -38,7 +39,9 @@ flowchart TB
 
   AppOptions --> Config --> Resolve --> Setup --> Graph --> PageSettings --> Contributions --> BuildPlan
   BuildPlan --> IR --> BundlerConfig --> Bundler --> Facts --> BuildStart --> Link
+  Bundler -. client listener ready .-> DevReady
   Link --> BuildOutput --> HTML --> BuildEnd
+  DevReady -. Session close / replacement .-> Dispose
   BuildEnd -. production end / server close / Session replacement .-> Dispose
 
   classDef config fill:#eef6ff,stroke:#8fb5e8,color:#102a43;
@@ -46,7 +49,7 @@ flowchart TB
   classDef build fill:#ecfdf5,stroke:#34d399,color:#064e3b;
   class AppOptions,Config,Resolve,Setup config;
   class Graph,PageSettings,BuildPlan,Contributions,IR plan;
-  class BundlerConfig,Bundler,Facts,BuildStart,Link,BuildOutput,HTML,BuildEnd,Dispose build;
+  class BundlerConfig,Bundler,DevReady,Facts,BuildStart,Link,BuildOutput,HTML,BuildEnd,Dispose build;
 ```
 
 For plugins created with `definePlugin()`, typed values stay flat across these
@@ -57,6 +60,7 @@ and `ctx.pageOptions`.
 | Hook | Purpose |
 |------|---------|
 | `configureBundler(config, ctx)` | Mutate the selected bundler config |
+| `devServerReady({ origin })` | Consume the actual client origin after a development Session starts listening |
 | `beforeBuild(ctx)` | Run after fresh bundler facts arrive and before evjs links or emits canonical output |
 | `transformOutput(output, ctx)` | Adjust linked `AssetGroup` contents or add deployment metadata |
 | `transformHtml(doc, ctx)` | Mutate one HTML document at a time; receives the current manifest result fields |
@@ -86,6 +90,34 @@ state without publishing output, so they trigger neither hook.
 
 `afterBuild()` is deliberately post-publication. If it fails, evjs reports the
 production build failure or fail-stops the owning development Session.
+
+`devServerReady()` runs once after the client bundler listener starts for each
+immutable development Session. Its `origin` is the adapter-reported value, not
+a URL reconstructed from `dev.port`; official adapters return an HTTP(S) URL,
+while custom adapters may return another origin string. Session replacement
+replays the hook with the replacement controller's origin. Ordinary HMR
+rebuilds, production builds, `prepare`, and `inspect` do not run it.
+
+Listener readiness does not imply that the first canonical output or the
+server/API runtime is ready. The first `beforeBuild()` / `afterBuild()` pair may
+finish before, during, or after `devServerReady()`; there is no ordering
+guarantee between them. Keep output-dependent work in `afterBuild()`. A rejected
+`devServerReady()` hook fail-stops the active Session and triggers normal
+controller cleanup and reverse-order plugin disposal. Its `signal` aborts when
+that Session starts closing.
+
+```ts
+const devToolsPlugin = {
+  id: "dev-tools",
+  setup() {
+    return {
+      devServerReady({ origin }) {
+        console.log(`Client dev server: ${origin}`);
+      },
+    };
+  },
+};
+```
 
 `dispose()` runs at most once for each plugin setup, in reverse plugin order,
 when a production build ends, a development Session closes or is replaced, or

--- a/docs/docs/plugin-hooks.md
+++ b/docs/docs/plugin-hooks.md
@@ -60,7 +60,7 @@ and `ctx.pageOptions`.
 | Hook | Purpose |
 |------|---------|
 | `configureBundler(config, ctx)` | Mutate the selected bundler config |
-| `devServerReady({ origin })` | Consume the actual client origin after a development Session starts listening |
+| `devServerReady({ origin, signal })` | Consume the actual client origin after a development Session starts listening, with cooperative cancellation |
 | `beforeBuild(ctx)` | Run after fresh bundler facts arrive and before evjs links or emits canonical output |
 | `transformOutput(output, ctx)` | Adjust linked `AssetGroup` contents or add deployment metadata |
 | `transformHtml(doc, ctx)` | Mutate one HTML document at a time; receives the current manifest result fields |
@@ -102,17 +102,29 @@ Listener readiness does not imply that the first canonical output or the
 server/API runtime is ready. The first `beforeBuild()` / `afterBuild()` pair may
 finish before, during, or after `devServerReady()`; there is no ordering
 guarantee between them. Keep output-dependent work in `afterBuild()`. A rejected
-`devServerReady()` hook fail-stops the active Session and triggers normal
-controller cleanup and reverse-order plugin disposal. Its `signal` aborts when
-that Session starts closing.
+`devServerReady()` hook terminates the entire `ev dev` run while its Session is
+active, and triggers normal controller cleanup and reverse-order plugin
+disposal.
+
+The hook's `signal` aborts when its Session starts closing. Cancellation is
+cooperative: aborting the signal cannot settle the hook's returned Promise, so
+in-flight asynchronous work must observe or forward it and then settle. Session
+shutdown and replacement wait for an in-flight `devServerReady()` hook to settle
+before running plugin `dispose()` hooks. Ignoring the signal can therefore delay
+or block shutdown or replacement.
 
 ```ts
 const devToolsPlugin = {
   id: "dev-tools",
   setup() {
+    let closeDevTools: (() => Promise<void>) | undefined;
     return {
-      devServerReady({ origin }) {
-        console.log(`Client dev server: ${origin}`);
+      async devServerReady({ origin, signal }) {
+        const devTools = await connectDevTools({ origin, signal });
+        closeDevTools = () => devTools.close();
+      },
+      async dispose() {
+        await closeDevTools?.();
       },
     };
   },
@@ -125,8 +137,9 @@ Session construction fails after plugins have initialized. It does not run
 after an ordinary bundler/HMR rebuild inside the same Session.
 
 The `setup()`, `emitIR()`, and `configureBundler()` contexts expose
-`addWatchFile()` for analysis/config dependencies. `BeforeBuildContext`
-deliberately does not; output, HTML, and disposal contexts do not either.
+`addWatchFile()` for analysis/config dependencies. `BeforeBuildContext` and the
+late `DevServerReadyContext` deliberately do not; output, HTML, and disposal
+contexts do not either.
 `emitIR()` dependencies participate in write-free candidate preparation.
 `setup()` and `configureBundler()` dependencies are opaque constructor inputs
 whose content is included in the candidate semantic fingerprint. Read changing
@@ -147,9 +160,12 @@ semantic no-op or candidate-preparation failure keeps the current terminal
 binding. For a replacement, the Supervisor detaches that binding before closing
 the old Session, collects contributions from the replacement Session's
 descriptors, and binds them only after its bundler controller supplies the
-actual client origin. A shortcut action's `PluginDevSession.close()` shuts down
-the whole Supervisor and `ev dev` run, not only its owning immutable Session. See
-[Plugin CLI Shortcuts](./dev#plugin-cli-shortcuts).
+actual client origin. Shortcut binding and `devServerReady()` execution proceed
+independently once the Session is active; neither waits for the other, so a
+shortcut action must not assume that ready hooks have settled. A shortcut
+action's `PluginDevSession.close()` shuts down the whole Supervisor and `ev dev`
+run, not only its owning immutable Session. See [Plugin CLI
+Shortcuts](./dev#plugin-cli-shortcuts).
 
 ## Build Output Ownership
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugin-authoring.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugin-authoring.md
@@ -229,8 +229,9 @@ Setup context 提供 `mode`、`cwd`、resolved `config`、`logger`、
 
 公开 context 名称与阶段一一对应：`PluginConfigureContext`、
 `PluginSetupContext`、`PluginEmitIRContext`、`ConfigureBundlerContext`、
-`BeforeBuildContext`、`TransformOutputContext`、`TransformHtmlContext` 与
-`DisposeContext`。contribution 通过 `ctx.framework` 读取规范化的 `FrameworkView`。
+`DevServerReadyContext`、`BeforeBuildContext`、`TransformOutputContext`、
+`TransformHtmlContext` 与 `DisposeContext`。contribution 通过 `ctx.framework` 读取规范化的
+`FrameworkView`。
 插件 options helper 公开 `PluginOptionsContract`、`PluginOptionsDefinition` 与
 `PluginOptionsContext`；内部 factory 推导类型不属于公开 authoring API。
 
@@ -254,6 +255,7 @@ Setup context 提供 `mode`、`cwd`、resolved `config`、`logger`、
 | 声明交互式 dev CLI key 和 action | `cliShortcuts()` |
 | 初始化共享状态 | `setup()` |
 | 执行 build lifecycle 行为 | `setup()` 返回的 hooks |
+| dev listener 启动后获取实际 client origin | `devServerReady()` |
 | 生成模块或挂载结构化行为 | `emitIR()` 或 `emitPageIR()` |
 | 编译自定义文件类型或调整优化 | `configureBundler()` |
 | 改写已解析的 HTML 文档 | `transformHtml()` |

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugin-hooks.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugin-hooks.md
@@ -59,7 +59,7 @@ flowchart TB
 | Hook | 用途 |
 |------|------|
 | `configureBundler(config, ctx)` | 修改当前 bundler 配置 |
-| `devServerReady({ origin })` | development Session 开始监听后获取实际 client origin |
+| `devServerReady({ origin, signal })` | development Session 开始监听后获取实际 client origin，并支持协作式取消 |
 | `beforeBuild(ctx)` | fresh bundler facts 就绪后、evjs 链接或发射 canonical output 前执行 |
 | `transformOutput(output, ctx)` | 调整已链接的 `AssetGroup` 内容或添加 deployment metadata |
 | `transformHtml(doc, ctx)` | 逐个 HTML 文档修改输出；接收当前 manifest result 字段 |
@@ -95,16 +95,27 @@ HMR rebuild、production build、`prepare` 与 `inspect` 都不会执行它。
 Listener ready 不代表首次 canonical output 或 server/API runtime 已就绪。首次
 `beforeBuild()` / `afterBuild()` 可能在 `devServerReady()` 之前、期间或之后完成，两者没有
 顺序保证。依赖 output 的逻辑仍应放在 `afterBuild()`。如果 `devServerReady()` reject，
-active Session 会 fail-stop，并执行正常的 controller 清理与 plugin 逆序 dispose。该
-Session 开始关闭时，hook context 的 `signal` 会 abort。
+且所属 Session 仍为 active，整个 `ev dev` 运行都会终止，并执行正常的 controller 清理与
+plugin 逆序 dispose。
+
+该 Session 开始关闭时，hook context 的 `signal` 会 abort。取消是协作式的：signal
+abort 不会自动 settle hook 返回的 Promise，进行中的异步工作必须监听或透传 signal，
+随后自行 settle。Session 关闭或 replacement 会等待进行中的 `devServerReady()` hook
+settle，再运行 plugin `dispose()` hook。因此，忽略 signal 可能延迟或阻塞关闭与
+replacement。
 
 ```ts
 const devToolsPlugin = {
   id: "dev-tools",
   setup() {
+    let closeDevTools: (() => Promise<void>) | undefined;
     return {
-      devServerReady({ origin }) {
-        console.log(`Client dev server: ${origin}`);
+      async devServerReady({ origin, signal }) {
+        const devTools = await connectDevTools({ origin, signal });
+        closeDevTools = () => devTools.close();
+      },
+      async dispose() {
+        await closeDevTools?.();
       },
     };
   },
@@ -116,11 +127,11 @@ production build 结束、development Session 关闭或被替换，以及 plugin
 构造失败；同一 Session 内的普通 bundler/HMR rebuild 不会执行它。
 
 `setup()`、`emitIR()` 和 `configureBundler()` context 提供 `addWatchFile()` 来注册
-analysis/config 依赖；`BeforeBuildContext` 明确不提供它，晚期 output、HTML 与 dispose
-context 也不提供。`emitIR()` 依赖参与无写入的候选 preparation；`setup()` 与
-`configureBundler()` 依赖是 opaque constructor input，其内容会进入候选 semantic
-fingerprint。变化的 analysis 数据应在 `emitIR()` 中读取；setup state 在所属 Session
-内保持不变。
+analysis/config 依赖；`BeforeBuildContext` 与晚期 `DevServerReadyContext` 明确不提供它，
+output、HTML 与 dispose context 也不提供。`emitIR()` 依赖参与无写入的候选 preparation；
+`setup()` 与 `configureBundler()` 依赖是 opaque constructor input，其内容会进入候选
+semantic fingerprint。变化的 analysis 数据应在 `emitIR()` 中读取；setup state 在所属
+Session 内保持不变。
 
 真实监听输入发生变化后，长生命周期 Supervisor 会在内存中准备 config、CoreGraph、
 BuildPlan 与 generated IR。Preparation 不执行 build hook；如果失败，当前 Session 仍会
@@ -133,10 +144,11 @@ Descriptor 顶层的 `cliShortcuts()` 遵循相同的 Session 边界，但它不
 也不属于 bundler/HMR cycle。快捷键引擎启用时，semantic no-op 或候选 preparation 失败
 会保留当前 terminal binding。发生 Session replacement 时，Supervisor 会在关闭旧 Session
 前解绑旧集合，从 replacement Session 的 descriptor 收集 contribution，并且只在其
-bundler controller 提供实际 client origin 后绑定新集合。Shortcut action 的
-`PluginDevSession.close()` 会关闭整个 Supervisor 和本次 `ev dev` 运行，而不是只关闭它
-所属的 immutable Session。参见
-[插件 CLI 快捷键](./dev#插件-cli-快捷键)。
+bundler controller 提供实际 client origin 后绑定新集合。Session active 后，快捷键绑定与
+`devServerReady()` 独立执行，双方互不等待，因此 shortcut action 不能假设 ready hook
+已经 settle。Shortcut action 的 `PluginDevSession.close()` 会关闭整个 Supervisor 和本次
+`ev dev` 运行，而不是只关闭它所属的 immutable Session。参见[插件 CLI
+快捷键](./dev#插件-cli-快捷键)。
 
 ## Build Output 所有权
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugin-hooks.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugin-hooks.md
@@ -26,6 +26,7 @@ flowchart TB
   subgraph Build["Bundling 和输出"]
     BundlerConfig["configureBundler()"]
     Bundler["bundler build"]
+    DevReady["devServerReady()\n仅 dev"]
     Facts["fresh bundler facts"]
     BuildStart["beforeBuild()"]
     Link["link canonical BuildOutput"]
@@ -37,7 +38,9 @@ flowchart TB
 
   AppOptions --> Config --> Resolve --> Setup --> Graph --> PageSettings --> Contributions --> BuildPlan
   BuildPlan --> IR --> BundlerConfig --> Bundler --> Facts --> BuildStart --> Link
+  Bundler -. client listener ready .-> DevReady
   Link --> BuildOutput --> HTML --> BuildEnd
+  DevReady -. Session 关闭 / 替换 .-> Dispose
   BuildEnd -. production end / server close / Session replacement .-> Dispose
 
   classDef config fill:#eef6ff,stroke:#8fb5e8,color:#102a43;
@@ -45,7 +48,7 @@ flowchart TB
   classDef build fill:#ecfdf5,stroke:#34d399,color:#064e3b;
   class AppOptions,Config,Resolve,Setup config;
   class Graph,PageSettings,BuildPlan,Contributions,IR plan;
-  class BundlerConfig,Bundler,Facts,BuildStart,Link,BuildOutput,HTML,BuildEnd,Dispose build;
+  class BundlerConfig,Bundler,DevReady,Facts,BuildStart,Link,BuildOutput,HTML,BuildEnd,Dispose build;
 ```
 
 通过 `definePlugin()` 创建插件时，类型安全的值在这些阶段保持扁平：configure 与 setup
@@ -56,6 +59,7 @@ flowchart TB
 | Hook | 用途 |
 |------|------|
 | `configureBundler(config, ctx)` | 修改当前 bundler 配置 |
+| `devServerReady({ origin })` | development Session 开始监听后获取实际 client origin |
 | `beforeBuild(ctx)` | fresh bundler facts 就绪后、evjs 链接或发射 canonical output 前执行 |
 | `transformOutput(output, ctx)` | 调整已链接的 `AssetGroup` 内容或添加 deployment metadata |
 | `transformHtml(doc, ctx)` | 逐个 HTML 文档修改输出；接收当前 manifest result 字段 |
@@ -81,6 +85,31 @@ output transform、HTML 发射或发布失败，`afterBuild()` 不会执行。`p
 
 `afterBuild()` 明确定义在发布之后。若它失败，evjs 会报告 production build 失败，或
 fail-stop 它所属的 development Session。
+
+每个 immutable development Session 的 client bundler listener 开始监听后，
+`devServerReady()` 执行一次。它接收 adapter 实际上报的 `origin`，而不是根据
+`dev.port` 重新拼出的 URL；官方 adapter 返回 HTTP(S) URL，自定义 adapter 也可以返回
+其他 origin 字符串。Session replacement 会用新 controller 的 origin 重放该 hook；普通
+HMR rebuild、production build、`prepare` 与 `inspect` 都不会执行它。
+
+Listener ready 不代表首次 canonical output 或 server/API runtime 已就绪。首次
+`beforeBuild()` / `afterBuild()` 可能在 `devServerReady()` 之前、期间或之后完成，两者没有
+顺序保证。依赖 output 的逻辑仍应放在 `afterBuild()`。如果 `devServerReady()` reject，
+active Session 会 fail-stop，并执行正常的 controller 清理与 plugin 逆序 dispose。该
+Session 开始关闭时，hook context 的 `signal` 会 abort。
+
+```ts
+const devToolsPlugin = {
+  id: "dev-tools",
+  setup() {
+    return {
+      devServerReady({ origin }) {
+        console.log(`Client dev server: ${origin}`);
+      },
+    };
+  },
+};
+```
 
 每次 plugin setup 的 `dispose()` 最多执行一次，并按 plugin 逆序运行。触发场景包括
 production build 结束、development Session 关闭或被替换，以及 plugin 初始化后 Session

--- a/packages/ev/src/_internal/build/dev-session.ts
+++ b/packages/ev/src/_internal/build/dev-session.ts
@@ -32,6 +32,7 @@ import {
   collectPluginHooks,
   rethrowAfterCleanup,
   runAfterBuildHooks,
+  runDevServerReadyHooks,
   runDisposeHooks,
 } from "./plugin-lifecycle.js";
 
@@ -59,6 +60,8 @@ export interface StartDevSessionOptions<TBundlerCfg> {
 export interface DevSession {
   readonly done: Promise<void>;
   readonly origin: string;
+  /** Notify this active Session's plugins that its client listener is ready. */
+  activate(): Promise<void>;
   close(): Promise<void>;
 }
 
@@ -90,6 +93,7 @@ export async function startDevSession<TBundlerCfg>(
   let releaseDistLock: DevRuntimeRelease | undefined;
   let unregisterDistExitCleanup = () => {};
   let pluginContextRetired = false;
+  let activationPromise: Promise<void> | undefined;
 
   const pluginContext: MutablePluginSetupContext<TBundlerCfg> = {
     mode: "development",
@@ -213,6 +217,13 @@ export async function startDevSession<TBundlerCfg>(
       } catch (error) {
         errors.push(error);
       }
+      if (activationPromise) {
+        try {
+          await activationPromise;
+        } catch {
+          // The activation caller owns the authoritative hook failure.
+        }
+      }
       try {
         await releaseDistLock?.();
       } catch (error) {
@@ -335,6 +346,16 @@ export async function startDevSession<TBundlerCfg>(
       },
       get origin() {
         return controller?.origin ?? "";
+      },
+      activate() {
+        if (closing) return activationPromise ?? Promise.resolve();
+        activationPromise ??= runDevServerReadyHooks(
+          hooks,
+          pluginContext,
+          controller?.origin ?? "",
+          abortController.signal,
+        );
+        return activationPromise;
       },
       close,
     };

--- a/packages/ev/src/_internal/build/dev-supervisor.ts
+++ b/packages/ev/src/_internal/build/dev-supervisor.ts
@@ -139,7 +139,7 @@ export async function runDevSupervisor<TBundlerCfg>(
     const customShortcuts = await collectSessionShortcuts(state);
     if (
       stopping ||
-      active !== state ||
+      active?.session !== state.session ||
       shortcutBinding ||
       pendingShortcutActions.size > 0
     ) {
@@ -352,6 +352,19 @@ export async function runDevSupervisor<TBundlerCfg>(
     );
   };
 
+  const activateSession = async (
+    state: ActiveDevState<TBundlerCfg>,
+  ): Promise<void> => {
+    try {
+      await state.session.activate();
+      if (!stopping && active?.session === state.session) {
+        await refreshCLIShortcutsSafely();
+      }
+    } catch (error) {
+      if (!stopping && active?.session === state.session) fail(error);
+    }
+  };
+
   const switchSession = async (
     prepared: PreparedDevRevision<TBundlerCfg>,
   ): Promise<void> => {
@@ -400,7 +413,7 @@ export async function runDevSupervisor<TBundlerCfg>(
     retainedFailedDependencies.clear();
     refreshWatcher(currentDependencySet());
     monitorSession(nextState);
-    await refreshCLIShortcutsSafely();
+    void activateSession(nextState);
   };
 
   const reconcileAttemptChanged = (

--- a/packages/ev/src/_internal/build/dev-supervisor.ts
+++ b/packages/ev/src/_internal/build/dev-supervisor.ts
@@ -104,7 +104,7 @@ export async function runDevSupervisor<TBundlerCfg>(
   let stopPromise: Promise<void> | undefined;
   let fatalError: unknown;
   let shortcutBinding: ActiveShortcutBinding | undefined;
-  let shortcutRefreshQueue = Promise.resolve();
+  let shortcutOwnerSession: DevSession | undefined;
   const pendingShortcutActions = new Set<Promise<void>>();
   const shortcutContributions = new WeakMap<
     DevSession,
@@ -132,14 +132,20 @@ export async function runDevSupervisor<TBundlerCfg>(
     return contribution;
   };
 
-  const bindActiveCLIShortcuts = async (): Promise<void> => {
+  const refreshCLIShortcuts = async (): Promise<void> => {
     if (stopping || shortcutBinding || pendingShortcutActions.size > 0) return;
     const state = active;
-    if (!state?.revision.config.dev.cliShortcuts) return;
+    if (
+      !state?.revision.config.dev.cliShortcuts ||
+      shortcutOwnerSession !== state.session
+    ) {
+      return;
+    }
     const customShortcuts = await collectSessionShortcuts(state);
     if (
       stopping ||
       active?.session !== state.session ||
+      shortcutOwnerSession !== state.session ||
       shortcutBinding ||
       pendingShortcutActions.size > 0
     ) {
@@ -155,15 +161,6 @@ export async function runDevSupervisor<TBundlerCfg>(
     shortcutBinding = {
       unbind: bindCLIShortcuts(pluginSession, { customShortcuts }),
     };
-  };
-
-  const refreshCLIShortcuts = (): Promise<void> => {
-    const refresh = shortcutRefreshQueue.then(
-      bindActiveCLIShortcuts,
-      bindActiveCLIShortcuts,
-    );
-    shortcutRefreshQueue = refresh.catch(() => {});
-    return refresh;
   };
 
   const refreshCLIShortcutsSafely = async (): Promise<void> => {
@@ -357,9 +354,6 @@ export async function runDevSupervisor<TBundlerCfg>(
   ): Promise<void> => {
     try {
       await state.session.activate();
-      if (!stopping && active?.session === state.session) {
-        await refreshCLIShortcutsSafely();
-      }
     } catch (error) {
       if (!stopping && active?.session === state.session) fail(error);
     }
@@ -369,6 +363,9 @@ export async function runDevSupervisor<TBundlerCfg>(
     prepared: PreparedDevRevision<TBundlerCfg>,
   ): Promise<void> => {
     const previous = active;
+    // Revoke eligibility before the asynchronous detach so a late contribution
+    // cannot rebind shortcuts for the Session being retired.
+    shortcutOwnerSession = undefined;
     await detachCLIShortcuts(DEV_CLI_SHORTCUT_ACTION_DRAIN_TIMEOUT_MS);
     // Detach identity before close so an intentional controller.done settle is
     // never classified as an unexpected active-session failure.
@@ -410,10 +407,12 @@ export async function runDevSupervisor<TBundlerCfg>(
       sessionWatchFiles,
     };
     active = nextState;
+    shortcutOwnerSession = session;
     retainedFailedDependencies.clear();
     refreshWatcher(currentDependencySet());
     monitorSession(nextState);
     void activateSession(nextState);
+    void refreshCLIShortcutsSafely();
   };
 
   const reconcileAttemptChanged = (

--- a/packages/ev/src/_internal/build/plugin-lifecycle.ts
+++ b/packages/ev/src/_internal/build/plugin-lifecycle.ts
@@ -13,6 +13,7 @@ import type {
   BeforeBuildContext,
   BuildResult,
   CliFlags,
+  DevServerReadyContext,
   Plugin,
   PluginCliShortcut,
   PluginConfigureContext,
@@ -509,6 +510,24 @@ export async function runBeforeBuildHooks<TBundlerCfg>(
       isRebuild,
     }) as BeforeBuildContext<TBundlerCfg>;
     await hook.beforeBuild(beforeBuildContext);
+  }
+}
+
+export async function runDevServerReadyHooks<TBundlerCfg>(
+  hooks: PluginHooks<TBundlerCfg>[],
+  ctx: PluginSetupContext<TBundlerCfg>,
+  origin: string,
+  signal: AbortSignal,
+): Promise<void> {
+  for (const hook of hooks) {
+    if (signal.aborted) return;
+    if (!hook.devServerReady) continue;
+    const readyContext = Object.freeze({
+      ...createLatePluginContext(ctx),
+      origin,
+      signal,
+    }) as DevServerReadyContext<TBundlerCfg>;
+    await hook.devServerReady(readyContext);
   }
 }
 

--- a/packages/ev/src/plugin/hook-names.ts
+++ b/packages/ev/src/plugin/hook-names.ts
@@ -1,5 +1,6 @@
 export const PLUGIN_HOOK_NAMES = [
   "configureBundler",
+  "devServerReady",
   "beforeBuild",
   "transformOutput",
   "transformHtml",

--- a/packages/ev/src/plugin/index.ts
+++ b/packages/ev/src/plugin/index.ts
@@ -705,6 +705,16 @@ export interface BeforeBuildContext<TBundlerCfg = unknown>
   readonly isRebuild: boolean;
 }
 
+/** Context passed after the client dev server starts listening. */
+export interface DevServerReadyContext<TBundlerCfg = unknown>
+  extends PluginBaseContext<TBundlerCfg> {
+  readonly mode: "development";
+  /** Actual client dev server origin reported by the bundler adapter. */
+  readonly origin: string;
+  /** Aborted when the owning immutable development Session is closing. */
+  readonly signal: AbortSignal;
+}
+
 export interface TransformOutputContext<TBundlerCfg = unknown>
   extends PluginBaseContext<TBundlerCfg> {}
 
@@ -715,6 +725,12 @@ type BeforeBuildHook<TBundlerCfg> = <
   TActualBundlerCfg extends TBundlerCfg = TBundlerCfg,
 >(
   ctx: BeforeBuildContext<TActualBundlerCfg>,
+) => void | Promise<void>;
+
+type DevServerReadyHook<TBundlerCfg> = <
+  TActualBundlerCfg extends TBundlerCfg = TBundlerCfg,
+>(
+  ctx: DevServerReadyContext<TActualBundlerCfg>,
 ) => void | Promise<void>;
 
 type TransformOutputHook<TBundlerCfg> = <
@@ -761,6 +777,13 @@ export interface PluginHooks<TBundlerCfg = unknown> {
    * adapter or pass a concrete config type for adapter-specific changes.
    */
   configureBundler?: ConfigureBundlerHook<TBundlerCfg>;
+
+  /**
+   * Called once after this immutable development Session's client server is
+   * listening. The actual adapter-reported origin is available on the context.
+   * Ordinary bundler/HMR rebuilds do not call this hook again.
+   */
+  devServerReady?: DevServerReadyHook<TBundlerCfg>;
 
   /**
    * Called after fresh bundler facts are available and before evjs links and

--- a/packages/ev/src/plugin/index.ts
+++ b/packages/ev/src/plugin/index.ts
@@ -705,13 +705,20 @@ export interface BeforeBuildContext<TBundlerCfg = unknown>
   readonly isRebuild: boolean;
 }
 
-/** Context passed after the client dev server starts listening. */
+/**
+ * Late lifecycle context passed after the client dev server starts listening.
+ * Analysis watch registration is intentionally unavailable at this stage.
+ */
 export interface DevServerReadyContext<TBundlerCfg = unknown>
   extends PluginBaseContext<TBundlerCfg> {
   readonly mode: "development";
   /** Actual client dev server origin reported by the bundler adapter. */
   readonly origin: string;
-  /** Aborted when the owning immutable development Session is closing. */
+  /**
+   * Cooperative cancellation signal aborted when the owning immutable
+   * development Session starts closing. Aborting the signal does not settle
+   * the hook's Promise automatically; asynchronous work must observe it.
+   */
   readonly signal: AbortSignal;
 }
 
@@ -782,6 +789,12 @@ export interface PluginHooks<TBundlerCfg = unknown> {
    * Called once after this immutable development Session's client server is
    * listening. The actual adapter-reported origin is available on the context.
    * Ordinary bundler/HMR rebuilds do not call this hook again.
+   *
+   * Rejecting this hook while its Session is active terminates the whole
+   * development run. Session shutdown or replacement aborts the context signal
+   * and waits for an in-flight hook to settle before running dispose hooks. CLI
+   * shortcut binding proceeds independently and does not wait for this hook to
+   * settle.
    */
   devServerReady?: DevServerReadyHook<TBundlerCfg>;
 

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -93,6 +93,33 @@ function createTestDevController(
   };
 }
 
+function createBlockingReadyPlugin(
+  events: string[],
+): Plugin<Record<string, never>> {
+  return {
+    id: "blocking-dev-server-ready",
+    setup() {
+      events.push("setup");
+      return {
+        devServerReady({ signal }) {
+          events.push("ready");
+          return new Promise<void>((resolve) => {
+            const onAbort = () => {
+              events.push("ready:aborted");
+              resolve();
+            };
+            if (signal.aborted) onAbort();
+            else signal.addEventListener("abort", onAbort, { once: true });
+          });
+        },
+        dispose() {
+          events.push("dispose");
+        },
+      };
+    },
+  };
+}
+
 interface EmbeddedClientRuntime {
   runtime: {
     server?: Record<string, unknown>;
@@ -834,6 +861,106 @@ describe("prepareFrameworkBuild", () => {
       "dispose:candidate:initial",
     ]);
     expect(flags.feature).toEqual(["initial", "caller-mutation"]);
+  });
+
+  it("aborts an active devServerReady hook during SIGINT shutdown", async () => {
+    const cwd = await createSpaProject();
+    const events: string[] = [];
+    const bundler: BundlerAdapter<Record<string, never>> = {
+      name: "ready-sigint",
+      capabilities: fullBundlerCapabilities,
+      async build() {
+        return {};
+      },
+      async dev() {
+        events.push("bundler.dev");
+        return createTestDevController(() => events.push("controller.close"));
+      },
+    };
+    const running = dev(
+      {
+        routing: { mode: "spa" },
+        plugins: [createBlockingReadyPlugin(events)],
+      },
+      { cwd, bundler },
+    );
+    let settled = false;
+    void running.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    try {
+      await vi.waitFor(() => expect(events).toContain("ready"));
+      process.emit("SIGINT");
+      await running;
+    } finally {
+      if (!settled) {
+        process.emit("SIGINT");
+        await running.catch(() => {});
+      }
+    }
+
+    expect(events).toEqual([
+      "setup",
+      "bundler.dev",
+      "ready",
+      "ready:aborted",
+      "controller.close",
+      "dispose",
+    ]);
+  });
+
+  it("closes a pending devServerReady hook when the controller fails", async () => {
+    const cwd = await createSpaProject();
+    const events: string[] = [];
+    let rejectController!: (error: unknown) => void;
+    const controllerDone = new Promise<void>((_resolve, reject) => {
+      rejectController = reject;
+    });
+    const bundler: BundlerAdapter<Record<string, never>> = {
+      name: "ready-controller-failure",
+      capabilities: fullBundlerCapabilities,
+      async build() {
+        return {};
+      },
+      async dev() {
+        events.push("bundler.dev");
+        return {
+          origin: "http://localhost:4123",
+          done: controllerDone,
+          async close() {
+            events.push("controller.close");
+          },
+        };
+      },
+    };
+    const running = dev(
+      {
+        routing: { mode: "spa" },
+        plugins: [createBlockingReadyPlugin(events)],
+      },
+      { cwd, bundler },
+    );
+
+    await vi.waitFor(() => expect(events).toContain("ready"));
+    rejectController(new Error("controller failed during ready hook"));
+
+    await expect(running).rejects.toThrow(
+      "controller failed during ready hook",
+    );
+    expect(events).toEqual([
+      "setup",
+      "bundler.dev",
+      "ready",
+      "ready:aborted",
+      "controller.close",
+      "dispose",
+    ]);
   });
 
   it("isolates one plugin instance across concurrent project preparations", async () => {

--- a/packages/ev/tests/config.test.ts
+++ b/packages/ev/tests/config.test.ts
@@ -1215,6 +1215,16 @@ describe("resolveConfig", () => {
       resolveConfig({
         plugins: [
           {
+            id: "misplaced-dev-server-ready",
+            devServerReady() {},
+          } as never,
+        ],
+      }),
+    ).toThrow("Return the hook from plugins[0].setup() instead");
+    expect(() =>
+      resolveConfig({
+        plugins: [
+          {
             id: "legacy-shortcuts-hook",
             configureShortcuts() {},
           } as never,

--- a/packages/ev/tests/dev-session.test.ts
+++ b/packages/ev/tests/dev-session.test.ts
@@ -248,12 +248,16 @@ describe("immutable dev session", () => {
     const cwd = await createProject();
     const base = createControlledBundler(["http://localhost:4314"]);
     const events: string[] = [];
+    let initialFactsPublished!: Promise<"discarded" | "published">;
     const controlled: ControlledBundler = {
       ...base,
       adapter: {
         ...base.adapter,
-        async dev(context) {
-          await context.callbacks.onBuildFacts({}, { isRebuild: false });
+        dev(context) {
+          initialFactsPublished = context.callbacks.onBuildFacts(
+            {},
+            { isRebuild: false },
+          );
           return base.adapter.dev(context);
         },
       },
@@ -276,10 +280,60 @@ describe("immutable dev session", () => {
     };
 
     const session = await start(cwd, controlled, [plugin]);
+    await expect(initialFactsPublished).resolves.toBe("published");
+    expect(events).toEqual(["beforeBuild", "afterBuild"]);
     await session.activate();
     await session.close();
 
     expect(events).toEqual(["beforeBuild", "afterBuild", "devServerReady"]);
+  });
+
+  it("aborts and waits for an active devServerReady hook before disposal", async () => {
+    const cwd = await createProject();
+    const controlled = createControlledBundler(["http://localhost:4315"]);
+    const events: string[] = [];
+    let readySignal: AbortSignal | undefined;
+    let settleReady!: () => void;
+    const readySettled = new Promise<void>((resolve) => {
+      settleReady = resolve;
+    });
+    const plugin: Plugin<Record<string, never>> = {
+      id: "pending-dev-server-ready",
+      setup() {
+        return {
+          async devServerReady({ signal }) {
+            readySignal = signal;
+            events.push("ready");
+            await readySettled;
+            events.push("ready:settled");
+          },
+          dispose() {
+            events.push("dispose");
+          },
+        };
+      },
+    };
+
+    const session = await start(cwd, controlled, [plugin]);
+    const activation = session.activate();
+    expect(events).toEqual(["ready"]);
+
+    let closeSettled = false;
+    const closing = session.close().then(() => {
+      closeSettled = true;
+    });
+    await Promise.resolve();
+
+    expect(readySignal?.aborted).toBe(true);
+    expect(closeSettled).toBe(false);
+    expect(events).toEqual(["ready"]);
+
+    settleReady();
+    await activation;
+    await closing;
+
+    expect(controlled.events).toEqual(["start:1", "close:1"]);
+    expect(events).toEqual(["ready", "ready:settled", "dispose"]);
   });
 
   it("closes the controller and disposes plugins when devServerReady fails", async () => {

--- a/packages/ev/tests/dev-session.test.ts
+++ b/packages/ev/tests/dev-session.test.ts
@@ -30,7 +30,9 @@ interface ControlledBundler {
 const temporaryProjects = new Set<string>();
 let buildId = 0;
 
-function createControlledBundler(): ControlledBundler {
+function createControlledBundler(
+  origins: readonly string[] = [],
+): ControlledBundler {
   const contexts: BundlerDevContext<Record<string, never>>[] = [];
   const events: string[] = [];
   const adapter: BundlerAdapter<Record<string, never>> = {
@@ -49,7 +51,8 @@ function createControlledBundler(): ControlledBundler {
         resolveDone = resolve;
       });
       return {
-        origin: `http://localhost:${context.config.dev.port}`,
+        origin:
+          origins[index - 1] ?? `http://localhost:${context.config.dev.port}`,
         done,
         async close() {
           if (closed) return;
@@ -193,5 +196,116 @@ describe("immutable dev session", () => {
     await second.close();
 
     expect(events).toEqual(["setup", "dispose", "setup", "dispose"]);
+  });
+
+  it("reports the actual client origin once for each immutable session", async () => {
+    const cwd = await createProject();
+    const controlled = createControlledBundler([
+      "dev-server-one",
+      "https://localhost:4312",
+    ]);
+    const events: string[] = [];
+    const plugin: Plugin<Record<string, never>> = {
+      id: "dev-server-ready",
+      setup() {
+        events.push("setup");
+        return {
+          devServerReady(ctx) {
+            events.push(`ready:${ctx.origin}`);
+          },
+          dispose() {
+            events.push("dispose");
+          },
+        };
+      },
+    };
+
+    const first = await start(cwd, controlled, [plugin]);
+    await first.activate();
+    await expect(
+      controlled.contexts[0]?.callbacks.onBuildFacts({}, { isRebuild: false }),
+    ).resolves.toBe("published");
+    await expect(
+      controlled.contexts[0]?.callbacks.onBuildFacts({}, { isRebuild: true }),
+    ).resolves.toBe("published");
+    await first.close();
+
+    const second = await start(cwd, controlled, [plugin]);
+    await second.activate();
+    await second.close();
+
+    expect(events).toEqual([
+      "setup",
+      "ready:dev-server-one",
+      "dispose",
+      "setup",
+      "ready:https://localhost:4312",
+      "dispose",
+    ]);
+  });
+
+  it("does not order devServerReady before the initial output hooks", async () => {
+    const cwd = await createProject();
+    const base = createControlledBundler(["http://localhost:4314"]);
+    const events: string[] = [];
+    const controlled: ControlledBundler = {
+      ...base,
+      adapter: {
+        ...base.adapter,
+        async dev(context) {
+          await context.callbacks.onBuildFacts({}, { isRebuild: false });
+          return base.adapter.dev(context);
+        },
+      },
+    };
+    const plugin: Plugin<Record<string, never>> = {
+      id: "ready-build-order",
+      setup() {
+        return {
+          beforeBuild() {
+            events.push("beforeBuild");
+          },
+          afterBuild() {
+            events.push("afterBuild");
+          },
+          devServerReady() {
+            events.push("devServerReady");
+          },
+        };
+      },
+    };
+
+    const session = await start(cwd, controlled, [plugin]);
+    await session.activate();
+    await session.close();
+
+    expect(events).toEqual(["beforeBuild", "afterBuild", "devServerReady"]);
+  });
+
+  it("closes the controller and disposes plugins when devServerReady fails", async () => {
+    const cwd = await createProject();
+    const controlled = createControlledBundler(["http://localhost:4313"]);
+    const events: string[] = [];
+    const plugin: Plugin<Record<string, never>> = {
+      id: "failing-dev-server-ready",
+      setup() {
+        return {
+          devServerReady() {
+            events.push("ready");
+            throw new Error("ready failed");
+          },
+          dispose() {
+            events.push("dispose");
+          },
+        };
+      },
+    };
+
+    const session = await start(cwd, controlled, [plugin]);
+    await expect(session.activate()).rejects.toThrow("ready failed");
+    await session.close();
+
+    expect(controlled.events).toEqual(["start:1", "close:1"]);
+    expect(events).toEqual(["ready", "dispose"]);
   });
 });

--- a/packages/ev/tests/dev-supervisor.test.ts
+++ b/packages/ev/tests/dev-supervisor.test.ts
@@ -10,7 +10,7 @@ import type {
 } from "../src/_internal/build/bundler.js";
 import { type DevOptions, dev } from "../src/_internal/build/commands.js";
 import type { Config } from "../src/config/index.js";
-import type { Plugin } from "../src/plugin/index.js";
+import type { Plugin, PluginCliShortcut } from "../src/plugin/index.js";
 
 const capabilities = {
   build: { server: true, rsc: true, ppr: true },
@@ -202,6 +202,165 @@ describe("immutable dev supervisor", { timeout: 15_000 }, () => {
     } finally {
       if (controlled.active > 0) await stopDev(run).catch(() => {});
       fakeStdin.restore();
+    }
+  });
+
+  it("binds shortcuts while devServerReady is pending and aborts it on shortcut close", async () => {
+    const cwd = await createProject();
+    const controlled = createControlledBundler();
+    const fakeStdin = installFakeTTYStdin();
+    const initialDataListeners = fakeStdin.input.listenerCount("data");
+    const events: string[] = [];
+    const plugin: Plugin<Record<string, never>> = {
+      id: "pending-ready-shortcut",
+      cliShortcuts() {
+        events.push("contribute");
+        return [
+          {
+            key: "q",
+            description: "close pending ready session",
+            async action(session) {
+              events.push("shortcut:close");
+              await session.close();
+              events.push("shortcut:closed");
+            },
+          },
+        ];
+      },
+      setup() {
+        events.push("setup");
+        return {
+          devServerReady({ signal }) {
+            events.push("ready");
+            return new Promise<void>((resolve) => {
+              const onAbort = () => {
+                events.push("ready:aborted");
+                resolve();
+              };
+              if (signal.aborted) onAbort();
+              else signal.addEventListener("abort", onAbort, { once: true });
+            });
+          },
+          dispose() {
+            events.push("dispose");
+          },
+        };
+      },
+    };
+    const run = dev(
+      { plugins: [plugin] },
+      { cwd, bundler: controlled.adapter },
+    );
+
+    try {
+      await vi.waitFor(() => {
+        expect(events).toContain("ready");
+        expect(events).toContain("contribute");
+        expect(fakeStdin.input.listenerCount("data")).toBeGreaterThan(
+          initialDataListeners,
+        );
+      });
+      fakeStdin.input.write("q\n");
+      await run;
+
+      expect(events).toContain("shortcut:closed");
+      expect(events.indexOf("ready:aborted")).toBeGreaterThan(
+        events.indexOf("shortcut:close"),
+      );
+      expect(events.indexOf("dispose")).toBeGreaterThan(
+        events.indexOf("ready:aborted"),
+      );
+      expect(controlled.events).toEqual(["start:1", "close:1"]);
+    } finally {
+      if (controlled.active > 0) await stopDev(run).catch(() => {});
+      fakeStdin.restore();
+    }
+  });
+
+  it("replays devServerReady only when the Supervisor replaces a Session", async () => {
+    const cwd = await createProject();
+    const configFile = path.join(cwd, "dev-config.ts");
+    const packageFile = path.join(cwd, "package.json");
+    await fs.writeFile(configFile, "v1\n");
+    const controlled = createControlledBundler();
+    const events: string[] = [];
+    let loads = 0;
+    const createPlugin = (label: "v1" | "v2"): Plugin => ({
+      id: "session-ready",
+      setup() {
+        events.push(`setup:${label}`);
+        return {
+          async devServerReady({ signal }) {
+            events.push(`ready:${label}`);
+            if (label !== "v1") return;
+            await new Promise<void>((resolve) => {
+              const onAbort = () => {
+                events.push("abort:v1");
+                resolve();
+              };
+              if (signal.aborted) onAbort();
+              else signal.addEventListener("abort", onAbort, { once: true });
+            });
+            events.push("settled:v1");
+          },
+          dispose() {
+            events.push(`dispose:${label}`);
+          },
+        };
+      },
+    });
+    let currentConfig: Config = { plugins: [createPlugin("v1")] };
+    const run = dev(undefined, {
+      cwd,
+      bundler: controlled.adapter,
+      reloadInitialConfig: true,
+      loadConfig(_cwd, context) {
+        loads += 1;
+        context?.onDependency(configFile);
+        return currentConfig;
+      },
+    });
+
+    try {
+      await vi.waitFor(() => expect(events).toContain("ready:v1"));
+
+      const packageSource = await fs.readFile(packageFile, "utf-8");
+      await fs.writeFile(packageFile, `${packageSource.trim()}\n\n`);
+      await vi.waitFor(() => expect(loads).toBe(2));
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(controlled.starts).toHaveLength(1);
+      expect(events.filter((event) => event === "ready:v1")).toHaveLength(1);
+
+      currentConfig = {
+        dev: {
+          proxy: [{ context: ["/api"], target: "https://v2.example" }],
+        },
+        plugins: [createPlugin("v2")],
+      };
+      await fs.writeFile(configFile, "v2\n");
+      await vi.waitFor(() => expect(events).toContain("ready:v2"));
+
+      expect(controlled.events.slice(0, 3)).toEqual([
+        "start:1",
+        "close:1",
+        "start:2",
+      ]);
+      expect(events.filter((event) => event === "ready:v1")).toHaveLength(1);
+      expect(events.filter((event) => event === "ready:v2")).toHaveLength(1);
+      expect(events.indexOf("settled:v1")).toBeGreaterThan(
+        events.indexOf("abort:v1"),
+      );
+      expect(events.indexOf("dispose:v1")).toBeGreaterThan(
+        events.indexOf("settled:v1"),
+      );
+      expect(events.indexOf("ready:v2")).toBeGreaterThan(
+        events.indexOf("dispose:v1"),
+      );
+
+      await stopDev(run);
+      expect(events).toContain("dispose:v2");
+    } finally {
+      if (controlled.active > 0) await stopDev(run).catch(() => {});
     }
   });
 
@@ -406,6 +565,97 @@ describe("immutable dev supervisor", { timeout: 15_000 }, () => {
       await stopDev(run);
     } finally {
       finishAction();
+      if (controlled.active > 0) await stopDev(run).catch(() => {});
+      fakeStdin.restore();
+    }
+  });
+
+  it("binds replacement shortcuts without waiting for a stale contribution", async () => {
+    const cwd = await createProject();
+    const configFile = path.join(cwd, "dev-config.ts");
+    await fs.writeFile(configFile, "v1\n");
+    const controlled = createControlledBundler();
+    const fakeStdin = installFakeTTYStdin();
+    const initialDataListeners = fakeStdin.input.listenerCount("data");
+    const events: string[] = [];
+    const shortcutsFor = (label: "v1" | "v2"): readonly PluginCliShortcut[] => [
+      {
+        key: "t",
+        description: label,
+        action() {
+          events.push(`shortcut:${label}`);
+        },
+      },
+    ];
+    let initialContributionReleased = false;
+    let releaseInitialContribution!: () => void;
+    const initialContribution = new Promise<readonly PluginCliShortcut[]>(
+      (resolve) => {
+        releaseInitialContribution = () => {
+          if (initialContributionReleased) return;
+          initialContributionReleased = true;
+          events.push("resolve:v1");
+          resolve(shortcutsFor("v1"));
+        };
+      },
+    );
+    const createPlugin = (
+      label: "v1" | "v2",
+    ): Plugin<Record<string, never>> => ({
+      id: "pending-shortcut-contribution",
+      cliShortcuts() {
+        events.push(`contribute:${label}`);
+        return label === "v1" ? initialContribution : shortcutsFor(label);
+      },
+    });
+    let currentConfig: Config<Record<string, never>> = {
+      plugins: [createPlugin("v1")],
+    };
+    const run = dev(undefined, {
+      cwd,
+      bundler: controlled.adapter,
+      reloadInitialConfig: true,
+      loadConfig(_cwd, context) {
+        context?.onDependency(configFile);
+        return currentConfig;
+      },
+    });
+
+    try {
+      await vi.waitFor(() => expect(events).toContain("contribute:v1"));
+      expect(fakeStdin.input.listenerCount("data")).toBe(initialDataListeners);
+
+      currentConfig = {
+        dev: {
+          proxy: [{ context: ["/api"], target: "https://v2.example" }],
+        },
+        plugins: [createPlugin("v2")],
+      };
+      await fs.writeFile(configFile, "v2\n");
+      await vi.waitFor(() => {
+        expect(controlled.starts).toHaveLength(2);
+        expect(events).toContain("contribute:v2");
+        expect(fakeStdin.input.listenerCount("data")).toBeGreaterThan(
+          initialDataListeners,
+        );
+      });
+
+      fakeStdin.input.write("t\n");
+      await vi.waitFor(() => expect(events).toContain("shortcut:v2"));
+
+      releaseInitialContribution();
+      await initialContribution;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      fakeStdin.input.write("t\n");
+      await vi.waitFor(() => {
+        expect(events.filter((event) => event === "shortcut:v2")).toHaveLength(
+          2,
+        );
+      });
+      expect(events).not.toContain("shortcut:v1");
+      await stopDev(run);
+    } finally {
+      releaseInitialContribution();
       if (controlled.active > 0) await stopDev(run).catch(() => {});
       fakeStdin.restore();
     }
@@ -669,6 +919,52 @@ describe("immutable dev supervisor", { timeout: 15_000 }, () => {
 
     expect(controlled.starts).toHaveLength(1);
     expect(controlled.events).toEqual(["start:1", "close:1"]);
+  });
+
+  it("fail-stops public dev and reverses disposal when devServerReady rejects", async () => {
+    const cwd = await createProject();
+    const controlled = createControlledBundler();
+    const events = controlled.events;
+    const createPlugin = (
+      label: "first" | "second",
+      rejectReady = false,
+    ): Plugin<Record<string, never>> => ({
+      id: `ready-${label}`,
+      setup() {
+        events.push(`setup:${label}`);
+        return {
+          devServerReady() {
+            events.push(`ready:${label}`);
+            if (rejectReady) throw new Error("dev server ready failed");
+          },
+          dispose() {
+            events.push(`dispose:${label}`);
+          },
+        };
+      },
+    });
+    const run = dev(
+      {
+        plugins: [createPlugin("first"), createPlugin("second", true)],
+      },
+      { cwd, bundler: controlled.adapter },
+    );
+
+    try {
+      await expect(run).rejects.toThrow("dev server ready failed");
+      expect(events).toEqual([
+        "setup:first",
+        "setup:second",
+        "start:1",
+        "ready:first",
+        "ready:second",
+        "close:1",
+        "dispose:second",
+        "dispose:first",
+      ]);
+    } finally {
+      if (controlled.active > 0) await stopDev(run).catch(() => {});
+    }
   });
 
   it("discards a stale preparation and starts only the latest saved config", async () => {

--- a/packages/ev/tests/plugin-lifecycle.test.ts
+++ b/packages/ev/tests/plugin-lifecycle.test.ts
@@ -594,6 +594,40 @@ describe("runDevServerReadyHooks", () => {
     expect(observedReceivers).toEqual([first, second]);
   });
 
+  it("does not start later hooks after the Session signal aborts", async () => {
+    const abortController = new AbortController();
+    const events: string[] = [];
+    const context = {
+      mode: "development",
+      cwd: "/project",
+      config: resolveConfig(),
+      logger: {} as PluginSetupContext["logger"],
+      addWatchFile() {},
+    } satisfies PluginSetupContext;
+
+    await runDevServerReadyHooks(
+      [
+        {
+          devServerReady({ signal }) {
+            events.push("first");
+            abortController.abort();
+            expect(signal.aborted).toBe(true);
+          },
+        },
+        {
+          devServerReady() {
+            events.push("second");
+          },
+        },
+      ],
+      context,
+      "dev-server",
+      abortController.signal,
+    );
+
+    expect(events).toEqual(["first"]);
+  });
+
   it("suggests the supported casing for devServerReady", async () => {
     const context = {
       mode: "development",

--- a/packages/ev/tests/plugin-lifecycle.test.ts
+++ b/packages/ev/tests/plugin-lifecycle.test.ts
@@ -6,6 +6,7 @@ import {
   createPluginConfigView,
   runAfterBuildHooks,
   runBeforeBuildHooks,
+  runDevServerReadyHooks,
 } from "../src/_internal/build/plugin-lifecycle.js";
 import { resolveConfig } from "../src/config/index.js";
 import {
@@ -538,6 +539,81 @@ describe("collectPluginCliShortcuts", () => {
     ).rejects.toThrow(
       'Plugin "throwing-shortcuts" cliShortcuts contribution failed: contribution failed',
     );
+  });
+});
+
+describe("runDevServerReadyHooks", () => {
+  it("awaits hooks in order with isolated frozen contexts", async () => {
+    const abortController = new AbortController();
+    const events: string[] = [];
+    const contexts: object[] = [];
+    const observedReceivers: unknown[] = [];
+    const first: PluginHooks = {
+      async devServerReady(ctx) {
+        observedReceivers.push(this);
+        contexts.push(ctx);
+        events.push(`first:${ctx.origin}`);
+        expect(ctx.mode).toBe("development");
+        expect(ctx.signal).toBe(abortController.signal);
+        expect(Object.isFrozen(ctx)).toBe(true);
+        expect(() => {
+          (ctx as { origin: string }).origin = "mutated";
+        }).toThrow(TypeError);
+        await Promise.resolve();
+        events.push("first:done");
+      },
+    };
+    const second: PluginHooks = {
+      devServerReady(ctx) {
+        observedReceivers.push(this);
+        contexts.push(ctx);
+        events.push(`second:${ctx.origin}`);
+      },
+    };
+    const context = {
+      mode: "development",
+      cwd: "/project",
+      config: resolveConfig(),
+      logger: {} as PluginSetupContext["logger"],
+      addWatchFile() {},
+    } satisfies PluginSetupContext;
+
+    await runDevServerReadyHooks(
+      [first, second],
+      context,
+      "dev-server",
+      abortController.signal,
+    );
+
+    expect(events).toEqual([
+      "first:dev-server",
+      "first:done",
+      "second:dev-server",
+    ]);
+    expect(contexts[0]).not.toBe(contexts[1]);
+    expect(observedReceivers).toEqual([first, second]);
+  });
+
+  it("suggests the supported casing for devServerReady", async () => {
+    const context = {
+      mode: "development",
+      cwd: "/project",
+      config: resolveConfig(),
+      logger: {} as PluginSetupContext["logger"],
+      addWatchFile() {},
+    } satisfies PluginSetupContext;
+
+    await expect(
+      collectPluginHooks(
+        [
+          {
+            id: "ready-casing",
+            setup: () => ({ devserverready() {} }) as never,
+          },
+        ],
+        context,
+      ),
+    ).rejects.toThrow('Use "devServerReady" instead');
   });
 });
 

--- a/packages/ev/tests/plugin-settings.test.ts
+++ b/packages/ev/tests/plugin-settings.test.ts
@@ -241,6 +241,16 @@ describe("definePlugin and pluginOptions", () => {
             // @ts-expect-error The framework config view stays read-only here.
             bundlerCtx.config.server.basePath = "/other";
           },
+          devServerReady(readyCtx) {
+            const mode: "development" = readyCtx.mode;
+            const origin: string = readyCtx.origin;
+            const signal: AbortSignal = readyCtx.signal;
+            // @ts-expect-error Ready hooks cannot add analysis watches.
+            readyCtx.addWatchFile("late.txt");
+            void mode;
+            void origin;
+            void signal;
+          },
           transformOutput(_output, outputCtx) {
             // @ts-expect-error Late output hooks cannot add analysis watches.
             outputCtx.addWatchFile("late.txt");


### PR DESCRIPTION
## Summary
- Expose the actual adapter-reported client dev origin to plugins without wrapping or replacing the selected bundler adapter.
- Notify plugins once for each active immutable development Session.
- Keep plugin CLI shortcuts responsive and isolated while ready hooks or stale Session contributions are pending.

## Changes
- Add the public `DevServerReadyContext` and `PluginHooks.devServerReady()` lifecycle API with `origin` and a Session-scoped `AbortSignal`.
- Activate ready hooks only after the Supervisor installs the Session and monitors `controller.done`; shutdown and controller failure abort pending hook work before disposal.
- Replay the hook on Session replacement, while ordinary bundler/HMR rebuilds and semantic no-ops do not trigger it again.
- Bind CLI shortcuts independently from ready-hook completion and collect contributions per Session, so a stale pending contribution cannot block or rebind over its replacement.
- Preserve the existing independent timing of listener readiness and initial `beforeBuild()` / `afterBuild()`, and document that no ordering is guaranteed.
- Document cooperative cancellation: close and replacement abort the signal and wait for in-flight ready work to settle before disposal.
- Add lifecycle, Session, Supervisor cleanup/replacement/concurrency, validation, type-contract, and bilingual documentation coverage.

## Validation
- `npm run check-types`
- `npm run lint`
- `npm test`
- `npm --workspace evjs-docs run build`
- `git diff --check`

## Risk / rollout
- Additive plugin API; existing plugins and bundler adapters are unchanged.
- Development-only behavior; production build paths do not invoke the hook.
- Plugins adopting the hook must require an EVJS version that includes it.
- A ready hook that rejects while its Session is active fail-stops the development run and runs normal controller cleanup and reverse-order plugin disposal.
- Cancellation is cooperative; a hook that ignores `signal` can delay Session replacement or shutdown.

## Reviewer notes
- Please focus on Supervisor activation/teardown ordering, Session ownership of asynchronous shortcut contributions, and the explicit lack of ordering between listener readiness and the first output cycle.
- After this lands, facade integrations can remove adapter proxies, `_internal/build` imports, and bundler config recomposition used only to discover the actual origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `devServerReady()` plugin lifecycle hook.
  * Plugins can receive the development server’s actual origin after the client listener starts.
  * Hooks support cooperative cancellation and run once per development session.
  * Development session shutdown and replacement now safely handle pending readiness hooks and failures.

* **Documentation**
  * Added lifecycle diagrams, API reference details, usage examples, and localized documentation for the new hook and context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->