### PR TITLE
docs(changelog): prepare v0.3.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.9] — 2026-08-11
+
 ### ✨ Features
 
 - **Dev server ready plugin hook** — Plugins can consume the actual client


### PR DESCRIPTION
## Summary
- Prepare the changelog for the next stable 0.3 release, v0.3.9.
- Capture the single feature merged after v0.3.8.

## Changes
- Leave the Unreleased section empty for future changes.
- Add a dated v0.3.9 section for the dev server ready plugin hook from #92.
- Keep source package versions and internal dependency ranges unchanged; release automation owns publish-time versioning.

## Validation
- `npm run lint`
- `npm --workspace evjs-docs run build`
- `git diff --check`

## Risk / rollout
- Low risk: this PR changes only release metadata in `CHANGELOG.md`.
- Publishing occurs separately when the v0.3.9 GitHub Release is created after merge.

## Reviewer notes
- Verify the v0.3.9 entry matches the complete v0.3.8...main commit range.