### PR TITLE
feat(ev): allow lower camel case plugin ids

### DIFF
--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -174,17 +174,21 @@ select executable runtime code.
 
 ## Identity and Ordering
 
-Every plugin declares one stable, short, lowercase `id`, such as `analytics` or
-`error-reporting`. The same canonical id identifies dependencies and lifecycle
-state, owns generated IR, and—when the plugin declares a Page contract—keys
-its entry in `page.config.ts#plugins`. It is not a package name and has no
-separate Page alias: the package may be `@company/analytics`, while its plugin
-id is `analytics`. An id must start with a lowercase letter and contain only
-non-empty lowercase alphanumeric segments separated by hyphens. `__proto__`,
+Every plugin declares one stable, short `id` in lower camel case or lowercase
+kebab-case, such as `analytics`, `errorReporting`, or `error-reporting`. The
+same canonical id identifies dependencies and lifecycle state, owns generated
+IR, and—when the plugin declares a Page contract—keys its entry in
+`page.config.ts#plugins`. It is not a package name and has no separate Page
+alias: the package may be `@company/analytics`, while its plugin id is
+`analytics`. An id must start with a lowercase letter and then use either ASCII
+letters and digits without separators, or non-empty lowercase alphanumeric
+segments separated by hyphens. Camel case and kebab-case must not be mixed in
+one id. `__proto__`,
 `constructor`, `prototype`, and Windows device basenames (`con`, `prn`, `aux`,
 `nul`, `com1` through `com9`, and `lpt1` through `lpt9`) are reserved. This
 keeps the unchanged id safe as one generated path segment on every supported
-platform. Plugin ids must be unique in one Application.
+platform. Plugin ids must be unique in one Application after case folding, so
+ids such as `errorReporting` and `errorreporting` cannot be installed together.
 
 `dependencies`, `optionalDependencies`, and `enforce` control hook ordering.
 Unknown descriptor fields and misspelled hooks are rejected.

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugin-authoring.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/plugin-authoring.md
@@ -152,15 +152,18 @@ symbol、bigint、非有限数值、class instance、稀疏数组与循环引用
 
 ## 标识与顺序
 
-每个插件只声明一个稳定、短小写的 `id`，例如 `analytics` 或 `error-reporting`。
+每个插件只声明一个稳定、短小的 `id`，使用小驼峰或全小写 kebab-case，例如
+`analytics`、`errorReporting` 或 `error-reporting`。
 同一个 canonical id 用于依赖与生命周期状态、generated IR；插件声明 Page 合同时，
 它也作为 `page.config.ts#plugins` 中的键。它不是 package name，也没有独立的 Page
 别名：package 可以叫 `@company/analytics`，plugin id 则是 `analytics`。id 必须以
-小写字母开头，只能包含小写字母、数字，以及用单个连字符分隔的 segment；
+小写字母开头，之后可以是不带分隔符的 ASCII 字母和数字，也可以是由连字符分隔的
+非空全小写字母数字 segment；同一个 id 不能混用驼峰与 kebab-case。
 `__proto__`、`constructor`、`prototype`，以及 Windows 设备 basename（`con`、
 `prn`、`aux`、`nul`、`com1` 至 `com9`、`lpt1` 至 `lpt9`）是保留值。这保证原样
 使用的 id 在所有支持平台上都能安全地作为 generated path 的单个 segment。一个
-Application 中的 plugin id 必须唯一。
+Application 中的 plugin id 在忽略大小写后必须唯一，因此 `errorReporting` 与
+`errorreporting` 不能同时安装。
 
 `dependencies`、`optionalDependencies` 与 `enforce` 控制 hook 顺序。未知 descriptor
 字段与拼错的 hook 会被拒绝。

--- a/packages/ev/src/_internal/build/plugin-lifecycle.ts
+++ b/packages/ev/src/_internal/build/plugin-lifecycle.ts
@@ -39,15 +39,19 @@ export function orderPluginsByDependencies<
   TPlugin extends PluginOrderDeclaration,
 >(plugins: TPlugin[]): TPlugin[] {
   const pluginById = new Map<string, TPlugin>();
+  const pluginIdByCaseFoldedId = new Map<string, string>();
   const dependentsById = new Map<string, string[]>();
   const dependencyCountById = new Map<string, number>();
 
   for (const plugin of plugins) {
-    if (pluginById.has(plugin.id)) {
+    const caseFoldedId = plugin.id.toLowerCase();
+    const existingId = pluginIdByCaseFoldedId.get(caseFoldedId);
+    if (existingId !== undefined) {
       throw new Error(
-        `[evjs] Duplicate plugin id "${plugin.id}". Plugin ids must be globally unique.`,
+        `[evjs] Duplicate plugin id "${plugin.id}" conflicts with "${existingId}". Plugin ids must be globally unique, including on case-insensitive filesystems.`,
       );
     }
+    pluginIdByCaseFoldedId.set(caseFoldedId, plugin.id);
     pluginById.set(plugin.id, plugin);
     dependentsById.set(plugin.id, []);
     dependencyCountById.set(plugin.id, 0);

--- a/packages/ev/src/config/index.ts
+++ b/packages/ev/src/config/index.ts
@@ -722,17 +722,19 @@ export function resolvePluginsConfig<TBundlerCfg = unknown>(
   }
   assertConfigArray(plugins, "plugins");
   const resolved: Plugin<TBundlerCfg>[] = [];
-  const ids = new Set<string>();
+  const idsByCaseFoldedId = new Map<string, string>();
   for (let index = 0; index < plugins.length; index++) {
     const plugin = plugins[index];
     if (plugin === false || plugin === null || plugin === undefined) continue;
     const resolvedPlugin = resolvePlugin<TBundlerCfg>(plugin, index);
-    if (ids.has(resolvedPlugin.id)) {
+    const caseFoldedId = resolvedPlugin.id.toLowerCase();
+    const existingId = idsByCaseFoldedId.get(caseFoldedId);
+    if (existingId !== undefined) {
       throw new Error(
-        `[evjs] Duplicate plugin id "${resolvedPlugin.id}". Plugin ids must be globally unique.`,
+        `[evjs] Duplicate plugin id "${resolvedPlugin.id}" conflicts with "${existingId}". Plugin ids must be globally unique, including on case-insensitive filesystems.`,
       );
     }
-    ids.add(resolvedPlugin.id);
+    idsByCaseFoldedId.set(caseFoldedId, resolvedPlugin.id);
     resolved.push(resolvedPlugin);
   }
   return resolved;

--- a/packages/ev/src/plugin/defined.ts
+++ b/packages/ev/src/plugin/defined.ts
@@ -124,8 +124,13 @@ type LowercasePluginIdLetter =
   | "y"
   | "z";
 
+type UppercasePluginIdLetter = Uppercase<LowercasePluginIdLetter>;
 type PluginIdDigit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
-type PluginIdCharacter = LowercasePluginIdLetter | PluginIdDigit;
+type LowerCamelPluginIdCharacter =
+  | LowercasePluginIdLetter
+  | UppercasePluginIdLetter
+  | PluginIdDigit;
+type KebabPluginIdCharacter = LowercasePluginIdLetter | PluginIdDigit;
 
 type ReservedPluginId =
   | "__proto__"
@@ -138,21 +143,30 @@ type ReservedPluginId =
   | "prn"
   | "prototype";
 
-type HasCanonicalPluginIdTail<TValue extends string> = TValue extends ""
+type HasLowerCamelPluginIdTail<TValue extends string> = TValue extends ""
   ? true
-  : TValue extends `${PluginIdCharacter}${infer TRest}`
-    ? HasCanonicalPluginIdTail<TRest>
-    : TValue extends `-${PluginIdCharacter}${infer TRest}`
-      ? HasCanonicalPluginIdTail<TRest>
+  : TValue extends `${LowerCamelPluginIdCharacter}${infer TRest}`
+    ? HasLowerCamelPluginIdTail<TRest>
+    : false;
+
+type HasKebabPluginIdTail<TValue extends string> = TValue extends ""
+  ? true
+  : TValue extends `${KebabPluginIdCharacter}${infer TRest}`
+    ? HasKebabPluginIdTail<TRest>
+    : TValue extends `-${KebabPluginIdCharacter}${infer TRest}`
+      ? HasKebabPluginIdTail<TRest>
       : false;
 
-type CanonicalPluginId<TValue extends string> = TValue extends ReservedPluginId
-  ? never
-  : TValue extends `${LowercasePluginIdLetter}${infer TRest}`
-    ? HasCanonicalPluginIdTail<TRest> extends true
-      ? TValue
-      : never
-    : never;
+type CanonicalPluginId<TValue extends string> =
+  Lowercase<TValue> extends ReservedPluginId
+    ? never
+    : TValue extends `${LowercasePluginIdLetter}${infer TRest}`
+      ? HasLowerCamelPluginIdTail<TRest> extends true
+        ? TValue
+        : HasKebabPluginIdTail<TRest> extends true
+          ? TValue
+          : never
+      : never;
 
 /** @internal Keep only one complete, unbranded string literal. */
 export type DefinitePluginId<TValue extends string> =

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -8234,6 +8234,18 @@ describe("build", () => {
         { cwd, bundler },
       ),
     ).rejects.toThrow('Duplicate plugin id "plugin-a"');
+
+    await expect(
+      build(
+        {
+          output: { client: "dist/client", server: "dist/server" },
+          plugins: [{ id: "errorReporting" }, { id: "errorreporting" }],
+        },
+        { cwd, bundler },
+      ),
+    ).rejects.toThrow(
+      'plugin id "errorreporting" conflicts with "errorReporting"',
+    );
   });
 
   it("fails on invalid plugin declarations before config hooks and bundling", async () => {
@@ -8257,7 +8269,9 @@ describe("build", () => {
         },
         { cwd, bundler },
       ),
-    ).rejects.toThrow('[evjs] plugins[0].id "" must be a lowercase plugin id');
+    ).rejects.toThrow(
+      '[evjs] plugins[0].id "" must be a lower camel case or lowercase kebab-case plugin id',
+    );
 
     expect(events).toEqual([]);
   });

--- a/packages/ev/tests/page-config-module.test.ts
+++ b/packages/ev/tests/page-config-module.test.ts
@@ -933,7 +933,7 @@ describe("page.config modules", () => {
     {
       label: "a legacy namespaced plugin id",
       source: 'export default { plugins: { "@company/feature": true } };',
-      message: /must be a lowercase plugin id/,
+      message: /must be a lower camel case or lowercase kebab-case plugin id/,
     },
     {
       label: "an invalid Page plugin setting",

--- a/packages/ev/tests/plugin-settings.test.ts
+++ b/packages/ev/tests/plugin-settings.test.ts
@@ -112,6 +112,12 @@ describe("plugin settings registry", () => {
     expect(() => collectPluginSettingsRegistry([first(), second()])).toThrow(
       'Duplicate plugin id "shared"',
     );
+
+    const camelCase = definePlugin({ id: "errorReporting" });
+    const caseCollision = definePlugin({ id: "errorreporting" });
+    expect(() =>
+      collectPluginSettingsRegistry([camelCase(), caseCollision()]),
+    ).toThrow('plugin id "errorreporting" conflicts with "errorReporting"');
   });
 
   it("uses the same id for Application settings and the catalog", () => {
@@ -198,7 +204,7 @@ describe("plugin settings registry", () => {
         // @ts-expect-error Scoped package names are not canonical short plugin ids.
         id: "@scope/plugin-auth",
       }),
-    ).toThrow("must be a lowercase plugin id");
+    ).toThrow("must be a lower camel case or lowercase kebab-case plugin id");
     expect(() =>
       definePlugin({
         // @ts-expect-error Windows device basenames are reserved plugin ids.
@@ -209,6 +215,24 @@ describe("plugin settings registry", () => {
 });
 
 describe("definePlugin and pluginOptions", () => {
+  it("accepts a lower camel case plugin id throughout Page settings", () => {
+    const errorReporting = definePlugin({
+      id: "errorReporting",
+      page: pluginOptions({ defaults: { sampleRate: 1 } }),
+    });
+    const state = resolveInstalled(errorReporting());
+
+    expect(state.registry.byId.get("errorReporting")?.id).toBe(
+      "errorReporting",
+    );
+    expect(
+      resolvePagePluginOptions(
+        { errorReporting: { sampleRate: 0.5 } },
+        "Page config plugins",
+      ),
+    ).toEqual({ errorReporting: { sampleRate: 0.5 } });
+  });
+
   it("narrows plugin option context by owner", () => {
     const contract = pluginOptions({
       defaults(context) {
@@ -299,21 +323,21 @@ describe("definePlugin and pluginOptions", () => {
         id: "",
         page: pluginOptions({ defaults: {} }),
       }),
-    ).toThrow("must be a lowercase plugin id");
+    ).toThrow("must be a lower camel case or lowercase kebab-case plugin id");
     expect(() =>
       definePlugin({
         // @ts-expect-error Plugin ids cannot start with whitespace.
         id: " analytics",
         page: pluginOptions({ defaults: {} }),
       }),
-    ).toThrow("must be a lowercase plugin id");
+    ).toThrow("must be a lower camel case or lowercase kebab-case plugin id");
     expect(() =>
       definePlugin({
-        // @ts-expect-error Plugin ids must be lowercase.
+        // @ts-expect-error Plugin ids must start with a lowercase letter.
         id: "Analytics",
         page: pluginOptions({ defaults: {} }),
       }),
-    ).toThrow("must be a lowercase plugin id");
+    ).toThrow("must be a lower camel case or lowercase kebab-case plugin id");
     expect(() =>
       definePlugin({
         id: "analytics",
@@ -412,11 +436,15 @@ describe("definePlugin and pluginOptions", () => {
         id: "analytics--reporting",
       });
       definePlugin({
-        // @ts-expect-error Plugin ids accept lowercase letters, digits, and hyphens only.
+        // @ts-expect-error Camel case and kebab-case cannot be mixed.
+        id: "analytics-reportingPlugin",
+      });
+      definePlugin({
+        // @ts-expect-error Plugin ids accept ASCII letters, digits, or kebab-case hyphens only.
         id: "analytics.reporting",
       });
       definePlugin({
-        // @ts-expect-error Plugin ids accept lowercase letters, digits, and hyphens only.
+        // @ts-expect-error Plugin ids accept ASCII letters, digits, or kebab-case hyphens only.
         id: "analytics_plugin",
       });
       definePlugin({
@@ -438,6 +466,10 @@ describe("definePlugin and pluginOptions", () => {
       definePlugin({
         // @ts-expect-error Windows device basenames are reserved plugin ids.
         id: "con",
+      });
+      definePlugin({
+        // @ts-expect-error Windows device basenames are reserved case-insensitively.
+        id: "cOn",
       });
       definePlugin({
         // @ts-expect-error Windows device basenames are reserved plugin ids.
@@ -469,6 +501,8 @@ describe("definePlugin and pluginOptions", () => {
       definePlugin({ id: "con-tools" });
       definePlugin({ id: "a" });
       definePlugin({ id: "plugin-1" });
+      definePlugin({ id: "errorReporting" });
+      definePlugin({ id: "plugin2FA" });
       definePlugin({
         id: "optional-application",
         // @ts-expect-error Application contract presence must be statically definite.
@@ -1676,7 +1710,7 @@ describe("plugin setting diagnostics", () => {
   it("validates plugin id syntax before installation lookup", () => {
     expect(() =>
       resolvePagePluginOptions({ Analytics: true }, "Page config plugins"),
-    ).toThrow("must be a lowercase plugin id");
+    ).toThrow("must be a lower camel case or lowercase kebab-case plugin id");
   });
 });
 

--- a/packages/shared/src/manifest/core-graph.ts
+++ b/packages/shared/src/manifest/core-graph.ts
@@ -1555,9 +1555,18 @@ function assertPluginCatalog(
 ): Record<string, CorePluginCatalogEntrySnapshot> {
   const catalog = assertObjectShape(value, source, ["entries"]);
   const entries = assertRecord(catalog.entries, `${source}.entries`);
+  const pluginIdByCaseFoldedId = new Map<string, string>();
 
   for (const [pluginId, valueEntry] of Object.entries(entries)) {
     assertPluginId(pluginId, `${source}.entries plugin id`);
+    const caseFoldedId = pluginId.toLowerCase();
+    const existingId = pluginIdByCaseFoldedId.get(caseFoldedId);
+    if (existingId !== undefined) {
+      throw new Error(
+        `[evjs] ${source}.entries plugin id "${pluginId}" conflicts with "${existingId}". Plugin ids must be unique, including on case-insensitive filesystems.`,
+      );
+    }
+    pluginIdByCaseFoldedId.set(caseFoldedId, pluginId);
     const entrySource = `${source}.entries.${pluginId}`;
     const entry = assertObjectShape(
       valueEntry,
@@ -1606,12 +1615,12 @@ export function assertPluginId(
 ): asserts value is string {
   if (
     typeof value !== "string" ||
-    !/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/.test(value) ||
-    RESERVED_PLUGIN_IDS.has(value)
+    !/^(?:[a-z][A-Za-z0-9]*|[a-z][a-z0-9]*(?:-[a-z0-9]+)+)$/.test(value) ||
+    RESERVED_PLUGIN_IDS.has(value.toLowerCase())
   ) {
     const actual = typeof value === "string" ? ` "${value}"` : "";
     throw new Error(
-      `[evjs] ${source}${actual} must be a lowercase plugin id such as "analytics" or "error-reporting" and must not be a reserved object key or Windows device basename.`,
+      `[evjs] ${source}${actual} must be a lower camel case or lowercase kebab-case plugin id such as "errorReporting" or "error-reporting" and must not be a reserved object key or Windows device basename.`,
     );
   }
 }

--- a/packages/shared/tests/core-graph.test.ts
+++ b/packages/shared/tests/core-graph.test.ts
@@ -27,7 +27,9 @@ describe("assertPluginId", () => {
     "com10",
     "com1-tools",
     "con-tools",
+    "errorReporting",
     "error-reporting",
+    "plugin2FA",
     "lpt0",
     "lpt10",
   ])('accepts canonical plugin id "%s"', (id) => {
@@ -39,18 +41,21 @@ describe("assertPluginId", () => {
     "1analytics",
     "-analytics",
     "Analytics",
+    "analytics-reportingPlugin",
     "analytics-",
     "analytics--reporting",
     "analytics.reporting",
     "analytics_plugin",
   ])('rejects non-canonical plugin id "%s"', (id) => {
     expect(() => assertPluginId(id, "plugin.id")).toThrow(
-      "must be a lowercase plugin id",
+      "must be a lower camel case or lowercase kebab-case plugin id",
     );
   });
 
   it.each([
     "__proto__",
+    "cOn",
+    "cOm1",
     "constructor",
     "prototype",
     ...WINDOWS_DEVICE_PLUGIN_IDS,
@@ -126,7 +131,7 @@ describe("assertCoreGraph", () => {
     getDocument(graph).owner = { kind: "plugin", pluginId: "" };
 
     expect(() => assertCoreGraph(graph, "coreGraph")).toThrow(
-      'coreGraph.documents.app:default.owner.pluginId "" must be a lowercase plugin id',
+      'coreGraph.documents.app:default.owner.pluginId "" must be a lower camel case or lowercase kebab-case plugin id',
     );
   });
 
@@ -1052,7 +1057,14 @@ describe("assertCoreGraph", () => {
     entries["invalid.key"] = {};
     invalidIdGraph.plugins.entries = entries as never;
     expect(() => assertCoreGraph(invalidIdGraph, "coreGraph")).toThrow(
-      "must be a lowercase plugin id",
+      "must be a lower camel case or lowercase kebab-case plugin id",
+    );
+
+    const caseCollisionGraph = createValidGraph();
+    caseCollisionGraph.plugins.entries.analytics = {};
+    caseCollisionGraph.plugins.entries.anaLytics = {};
+    expect(() => assertCoreGraph(caseCollisionGraph, "coreGraph")).toThrow(
+      'plugin id "anaLytics" conflicts with "analytics"',
     );
 
     const invalidContractGraph = createValidGraph();


### PR DESCRIPTION
## Summary

- accept lower camel case plugin ids while preserving lowercase kebab-case ids
- reject mixed camel/kebab ids and case-folded collisions that would conflict on case-insensitive filesystems
- update runtime/type validation, tests, and English/Chinese plugin authoring docs

## Testing

- npm run check-types
- npm run lint
- npm test
- npm --workspace evjs-docs run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin IDs now support lowercase kebab-case and lower camel case formats.
  * Added validation guidance and examples for both supported formats.

* **Bug Fixes**
  * Prevented installing or configuring plugins whose IDs differ only by capitalization.
  * Improved validation for mixed naming styles and reserved names.
  * Updated error messages to clearly describe supported ID formats and uniqueness rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->