### PR TITLE
test(bundler-utoopack): remove artifact publish race

### DIFF
--- a/packages/bundler-utoopack/tests/adapter.test.ts
+++ b/packages/bundler-utoopack/tests/adapter.test.ts
@@ -318,7 +318,6 @@ function createFrameworkCallbacks(options: {
         clientEntryAssets: facts.clientEntryAssets,
         serverEntryAssets: facts.serverEntryAssets,
       });
-      await options.onBuildOutput?.(output);
 
       const rootDir = path.join(options.cwd, plan.distDir);
       const clientDir = path.resolve(options.cwd, plan.output.clientDir);
@@ -379,6 +378,7 @@ function createFrameworkCallbacks(options: {
         await fs.promises.mkdir(path.dirname(outPath), { recursive: true });
         await fs.promises.writeFile(outPath, finalHtml, "utf-8");
       }
+      await options.onBuildOutput?.(output);
       return "published" as const;
     },
     onServerBundleReady: options.onServerBundleReady ?? vi.fn(async () => {}),


### PR DESCRIPTION
## Summary

- notify the Utoopack test observer only after deployment metadata and generated HTML files are written
- remove the race that allowed the artifact-retention test to read `dist/client/index.html` before it existed

## Root cause

The test helper invoked `onBuildOutput` immediately after linking the build output, before writing generated artifacts. The affected test treated that callback as the publication boundary and immediately read `index.html`, so slower CI scheduling could produce an intermittent `ENOENT`: 

https://github.com/afx-team/evjs/actions/runs/31471062075/job/93714264699


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build output callbacks now run after deployment metadata and generated HTML files are available, ensuring downstream processes receive complete build results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->