### PR TITLE
feat(ev): support server build config

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -271,9 +271,29 @@ export default defineConfig({
   routing: { mode: "spa" },
   server: {
     basePath: "/__evjs",
+    resolve: {
+      alias: { "server-sdk": "./src/server/sdk.ts" },
+    },
+    externals: {
+      "native-addon": "commonjs native-addon",
+    },
   },
 });
 ```
+
+`server.resolve` and `server.externals` apply only to server build entries;
+they never modify the client compiler. `server.resolve.alias` is a string map
+whose project-relative replacements resolve from the application root.
+`server.externals` maps module specifiers to external requests such as
+`"commonjs native-addon"`. All keys and values must be non-empty strings
+without leading or trailing whitespace. Config resolution normalizes these
+entries into `plan.server.externals` as a server-build-specific string map.
+
+The Webpack adapter supports both settings in mixed client/server builds.
+Utoopack 1.5.3 supports independent `server.externals`; its current resolver
+does not expose a server-scoped resolve object, so `server.resolve` is supported
+only for server-only Utoopack plans and fails fast for mixed plans instead of
+leaking the override into client resolution.
 
 `server.basePath` owns server-function, PPR, and RSC runtime paths. It must be
 an absolute pathname using non-empty ASCII URL-safe segments containing only

--- a/docs/docs/generated-contributions.md
+++ b/docs/docs/generated-contributions.md
@@ -295,9 +295,12 @@ input must normalize to the same
 Application/Page/Document ownership before using these semantics.
 
 `resolve.external` accepts `runtime: "client" | "server" | "all"`. The
-Webpack adapter applies that filter per target. The current Utoopack adapter
-only exposes a top-level externals config, so client/all externals are mapped
-there and server-only externals fail fast when client entries are present.
+Webpack adapter applies that filter per target. Utoopack maps client/all
+externals to its top-level config and server/all externals to its independent
+`server.externals` config, so server-only contributions remain isolated in
+mixed builds. Plugin contributions remain under `plan.resolve.external`;
+authored `server.externals` is a separate server-build override applied after
+those contributions.
 
 ## Boundaries
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/config.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/config.md
@@ -252,9 +252,27 @@ export default defineConfig({
   routing: { mode: "spa" },
   server: {
     basePath: "/__evjs",
+    resolve: {
+      alias: { "server-sdk": "./src/server/sdk.ts" },
+    },
+    externals: {
+      "native-addon": "commonjs native-addon",
+    },
   },
 });
 ```
+
+`server.resolve` 与 `server.externals` 只作用于 server build entry，不会修改
+client compiler。`server.resolve.alias` 是字符串映射，其中 project-relative
+replacement 从应用根目录解析。`server.externals` 把 module specifier 映射为
+`"commonjs native-addon"` 这类 external request。所有 key 与 value 都必须是无首尾
+空白的非空字符串。配置解析会将它们作为 server build 专用的字符串映射放入
+`plan.server.externals`。
+
+Webpack adapter 在 client/server 混合构建中完整支持这两个配置。Utoopack 1.5.3
+支持独立的 `server.externals`；当前 resolver 尚未暴露 server-scoped resolve
+对象，因此 `server.resolve` 只支持 server-only Utoopack plan。混合 plan 会快速
+失败，避免把 server override 泄漏到 client resolution。
 
 `server.basePath` 统一控制 server function、PPR 和 RSC runtime 路径。它必须是
 absolute pathname，由非空 ASCII URL-safe segment 组成；每个 segment 只能包含

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/generated-contributions.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/generated-contributions.md
@@ -275,9 +275,11 @@ Application/Page target 可以同时用于 SPA 与 MPA。展开结果记录在 g
 route-tree 输入必须先 normalize 到相同 Application/Page/Document ownership。
 
 `resolve.external` 支持 `runtime: "client" | "server" | "all"`。Webpack adapter
-会按 target 应用 filter。当前 Utoopack adapter 只暴露 top-level externals config，
-因此会映射 client/all external；当存在 client entries 时，server-only external 会
-快速失败。
+会按 target 应用 filter。Utoopack 会把 client/all external 映射到 top-level config，
+并把 server/all external 映射到独立的 `server.externals` config，因此混合构建中的
+server-only contribution 仍保持隔离。插件 contribution 仍保留在
+`plan.resolve.external`；用户声明的 `server.externals` 是独立的 server build override，
+并在这些 contribution 之后应用。
 
 ## 边界
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8838,9 +8838,9 @@
       }
     },
     "node_modules/@utoo/pack-darwin-arm64": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-darwin-arm64/-/pack-darwin-arm64-1.5.0.tgz",
-      "integrity": "sha512-bymMwDKlAJYRDN4aL8PV3cykB/82eKrpmqvgvJg0t1aAJ/7ym6BoAzuTAUV4DG9ZP5sSlyKRJTUbup/Iu2QWTQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-darwin-arm64/-/pack-darwin-arm64-1.5.3.tgz",
+      "integrity": "sha512-xmapboRiKB7TSZsvevaAGk/t/T7G5bh0W2igSmmoQrj71mnEFEvsCaiG/LiXvExOgB3nJPk0MzUXYms4DAwVPg==",
       "cpu": [
         "arm64"
       ],
@@ -8854,9 +8854,9 @@
       }
     },
     "node_modules/@utoo/pack-darwin-x64": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-darwin-x64/-/pack-darwin-x64-1.5.0.tgz",
-      "integrity": "sha512-qH8/Y0cl47SMsQr6EcwsJPsjcB/ycBAeuDx4sdC5y8ZhYL5kJWNIzKENtPK7fWMCoFRcICMF+nK8ujvRWZll7Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-darwin-x64/-/pack-darwin-x64-1.5.3.tgz",
+      "integrity": "sha512-A70FPoyf8If7UCgfHPPtMJkEkVwbPSRUXTYHz0nj3cifqEPsYg2wT85rHqw51a99HFykYmBYI8Pci24lAmOp0g==",
       "cpu": [
         "x64"
       ],
@@ -8870,9 +8870,9 @@
       }
     },
     "node_modules/@utoo/pack-linux-arm64-gnu": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-arm64-gnu/-/pack-linux-arm64-gnu-1.5.0.tgz",
-      "integrity": "sha512-06kznzqnv5yscFWJALr1KZQ6PsoNua/wkk3CygWFvS468lJM6eUDie3smSRkpbadnDkpWUGJMCGo0duYULmGng==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-arm64-gnu/-/pack-linux-arm64-gnu-1.5.3.tgz",
+      "integrity": "sha512-sQDEroVN+mHHuqkF0nffdVDbM7lVonhW6DrHqmkmLzD/h0dudum6UsjoWNZ8taTqIcvybLiWVzJH1xf3oxB/qA==",
       "cpu": [
         "arm64"
       ],
@@ -8886,9 +8886,9 @@
       }
     },
     "node_modules/@utoo/pack-linux-arm64-musl": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-arm64-musl/-/pack-linux-arm64-musl-1.5.0.tgz",
-      "integrity": "sha512-ENu7j6pwb/AIkPN0cgumbtlSAAhg5iZHh+3G7Fm3ZR0OIGpMBjhCEhUd5C9myM5sKtYcTNz66H725wuifuujyA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-arm64-musl/-/pack-linux-arm64-musl-1.5.3.tgz",
+      "integrity": "sha512-U6exeeZHYSpMYx1gK1LVYDa8tV9E3RRPd9VFJZtlslxjTiofGCvVVjEP3ZqxNJipThnqPv5OEXgZ43GpX2CAUQ==",
       "cpu": [
         "arm64"
       ],
@@ -8902,9 +8902,9 @@
       }
     },
     "node_modules/@utoo/pack-linux-x64-gnu": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-x64-gnu/-/pack-linux-x64-gnu-1.5.0.tgz",
-      "integrity": "sha512-dys9SrvU4L0RBPAQ+i8P9QbBGHKHAlUcXBdlBORrJeH5XIX47bbM8Kt26ORpvySNmV4aTvJ5d6mtkayR0Yz2GA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-x64-gnu/-/pack-linux-x64-gnu-1.5.3.tgz",
+      "integrity": "sha512-6xeXNYelhFo79GIOSn0d6v2QYLktjgKGPW78oNN/UmlSmWO25mvyLMyVHM6qGUFI785R4KouAMVqe0xIt6M8kw==",
       "cpu": [
         "x64"
       ],
@@ -8918,9 +8918,9 @@
       }
     },
     "node_modules/@utoo/pack-linux-x64-musl": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-x64-musl/-/pack-linux-x64-musl-1.5.0.tgz",
-      "integrity": "sha512-LpR5lO+ebZhYI2liyXsFCEL6u54rl42voMnKxS+MlEf/FJMreeQ5XPUSWObx+YCPDdRaBjh9JkiSnaOFGMTD+A==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-x64-musl/-/pack-linux-x64-musl-1.5.3.tgz",
+      "integrity": "sha512-mDulBCwNe/nOa8G/WjN9PfPEgwGzRPyBA+yh6LzHUdlOH/WeBL5eKiPv6RoifuAPJpzGKcYNFqUAnc2ppHPjfA==",
       "cpu": [
         "x64"
       ],
@@ -8934,9 +8934,9 @@
       }
     },
     "node_modules/@utoo/pack-shared": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-shared/-/pack-shared-1.5.0.tgz",
-      "integrity": "sha512-0kbGUf82T7GCaTqHzsvR8d6l2F25VZ552kZdp4+8zz0qAXydjRMW3mQrzfj6UUIFDoN1M8g+O297XO3mMJ7kGw==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-shared/-/pack-shared-1.5.3.tgz",
+      "integrity": "sha512-w4rNZGRWAX4VTzz6dfXYuLK5KLwKeUUh1TlD1xfswasQWuXdd681VwB3VMMFVVcYcdQv+1/5S8v2pvrk1CJH0Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "7.22.5",
@@ -8959,9 +8959,9 @@
       }
     },
     "node_modules/@utoo/pack-win32-x64-msvc": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-win32-x64-msvc/-/pack-win32-x64-msvc-1.5.0.tgz",
-      "integrity": "sha512-YQ8IpsQUAlVtey+6jwv2zmm+FBg9NgdidpR+Mx1o86fMY3T20o2ZWybQjVa7xwU2Sz/XqGH5e6sKKjZXSsVvZQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-win32-x64-msvc/-/pack-win32-x64-msvc-1.5.3.tgz",
+      "integrity": "sha512-al2EtNZ5Bqj3dJgTS6VhF0ljOtrB2n1Zq7xGOjA/o+vulgoPeXAHRrakb7EKqB9lcv99HM1LWQ7uzUxHunuEgA==",
       "cpu": [
         "x64"
       ],
@@ -24545,7 +24545,7 @@
         "@evjs/ev": "*",
         "@evjs/shared": "*",
         "@logtape/logtape": "^2.0.4",
-        "@utoo/pack": "^1.5.0",
+        "@utoo/pack": "^1.5.3",
         "chokidar": "^3.6.0",
         "fast-glob": "^3.3.3",
         "less": "4.1.3",
@@ -24578,16 +24578,16 @@
       }
     },
     "packages/bundler-utoopack/node_modules/@utoo/pack": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@utoo/pack/-/pack-1.5.0.tgz",
-      "integrity": "sha512-1hLRitEju/parkZdI8LUauz7tccVoNf6Dp8X63l5pJuYUlBG1xnBekryAoTMf4dbLPO4FaOEPkuAQxaLOgH1AQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@utoo/pack/-/pack-1.5.3.tgz",
+      "integrity": "sha512-sRRK4YyoDHTmvi2r+97u6n1PqcdisOeFZA+Wzwp5lgApCNA56KIl2EoH+ppwgsYv9XT0jJ3qwe2HAF95Q7YbfQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "7.22.5",
         "@hono/node-server": "^1.19.11",
         "@hono/node-ws": "^1.3.0",
         "@swc/helpers": "0.5.15",
-        "@utoo/pack-shared": "1.5.0",
+        "@utoo/pack-shared": "1.5.3",
         "domparser-rs": "^0.0.7",
         "find-up": "4.1.0",
         "get-port": "5.1.1",
@@ -24602,13 +24602,13 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@utoo/pack-darwin-arm64": "1.5.0",
-        "@utoo/pack-darwin-x64": "1.5.0",
-        "@utoo/pack-linux-arm64-gnu": "1.5.0",
-        "@utoo/pack-linux-arm64-musl": "1.5.0",
-        "@utoo/pack-linux-x64-gnu": "1.5.0",
-        "@utoo/pack-linux-x64-musl": "1.5.0",
-        "@utoo/pack-win32-x64-msvc": "1.5.0"
+        "@utoo/pack-darwin-arm64": "1.5.3",
+        "@utoo/pack-darwin-x64": "1.5.3",
+        "@utoo/pack-linux-arm64-gnu": "1.5.3",
+        "@utoo/pack-linux-arm64-musl": "1.5.3",
+        "@utoo/pack-linux-x64-gnu": "1.5.3",
+        "@utoo/pack-linux-x64-musl": "1.5.3",
+        "@utoo/pack-win32-x64-msvc": "1.5.3"
       },
       "peerDependencies": {
         "less": "^4.0.0",

--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -35,7 +35,7 @@
     "@evjs/ev": "*",
     "@evjs/shared": "*",
     "@logtape/logtape": "^2.0.4",
-    "@utoo/pack": "^1.5.0",
+    "@utoo/pack": "^1.5.3",
     "chokidar": "^3.6.0",
     "fast-glob": "^3.3.3",
     "less": "4.1.3",

--- a/packages/bundler-utoopack/src/adapter/create-config.ts
+++ b/packages/bundler-utoopack/src/adapter/create-config.ts
@@ -110,6 +110,10 @@ export async function createUtoopackConfig(
 
   const finalServerEntry = resolveServerEntries(plan);
   const expectedServerEntry = snapshotUtoopackServerEntry(finalServerEntry);
+  const resolveEnvironment: ResolveEnvironment =
+    finalServerEntry !== undefined && !hasClientEntries(plan)
+      ? "server"
+      : "client";
 
   const outputPaths = resolveBuildOutputPaths(cwd, plan);
   await assertSafeBuildOutputPaths(cwd, outputPaths);
@@ -135,10 +139,10 @@ export async function createUtoopackConfig(
       clean: true,
     },
     resolve: {
-      alias: createResolveAlias(cwd, plan),
+      alias: createResolveAlias(cwd, plan, resolveEnvironment),
       extensions: [".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs"],
     },
-    externals: createResolveExternals(plan),
+    externals: createResolveExternals(plan, "client"),
     sourceMaps: !isProduction,
     stats: true,
     ...(isProduction
@@ -174,6 +178,7 @@ export async function createUtoopackConfig(
           // Server functions config — utoopack handles "use server" natively.
           server: {
             entry: finalServerEntry,
+            externals: createResolveExternals(plan, "server") ?? {},
             output: {
               path: outputPaths.serverDir,
               filename: isProduction
@@ -526,12 +531,13 @@ function missingFrameworkWatchCollector(file: string): never {
 function createResolveAlias(
   cwd: string,
   plan: BuildPlan,
+  environment: ResolveEnvironment,
 ): NonNullable<ConfigComplete["resolve"]>["alias"] {
   return Object.fromEntries(
-    Object.entries(plan.resolve?.alias ?? {}).map(([name, target]) => [
-      name,
-      resolveAliasTarget(cwd, target),
-    ]),
+    Object.entries({
+      ...(plan.resolve?.alias ?? {}),
+      ...(environment === "server" ? plan.server.resolve?.alias : undefined),
+    }).map(([name, target]) => [name, resolveAliasTarget(cwd, target)]),
   );
 }
 
@@ -540,28 +546,31 @@ function resolveAliasTarget(cwd: string, target: string): string {
   return target.startsWith(".") ? path.resolve(cwd, target) : target;
 }
 
+type ResolveEnvironment = "client" | "server";
+
 function createResolveExternals(
   plan: BuildPlan,
+  environment: ResolveEnvironment,
 ): Record<string, ExternalConfig> | undefined {
-  assertSupportedResolveExternals(plan);
+  const excludedEnvironment = environment === "client" ? "server" : "client";
   const external = Object.fromEntries(
     Object.entries(plan.resolve?.external ?? {})
-      .filter(([, value]) => value.runtime !== "server")
+      .filter(([, value]) => value.runtime !== excludedEnvironment)
       .map(([specifier, value]) => [specifier, value.source ?? specifier]),
   );
+  if (environment === "server") {
+    Object.assign(external, plan.server.externals);
+  }
   return Object.keys(external).length > 0 ? external : undefined;
 }
 
-function assertSupportedResolveExternals(plan: BuildPlan): void {
-  if (!hasClientEntries(plan)) return;
-
-  const serverOnly = Object.entries(plan.resolve?.external ?? {})
-    .filter(([, value]) => value.runtime === "server")
-    .map(([specifier]) => specifier);
-  if (serverOnly.length === 0) return;
-
+function assertSupportedServerResolve(plan: BuildPlan): void {
+  if (!hasClientEntries(plan) || !hasServerEntries(plan)) return;
+  if (Object.keys(plan.server.resolve?.alias ?? {}).length === 0) {
+    return;
+  }
   throw new Error(
-    `[evjs] The Utoopack adapter cannot map server-only resolve.external contributions while client entries are present: ${serverOnly.join(", ")}. Use runtime "client" or "all", switch to a bundler with server-scoped externals, or configure the lower-level bundler directly.`,
+    "[evjs] The Utoopack adapter cannot apply server.resolve independently while client entries are present. Use the Webpack adapter or remove the server-only resolve override.",
   );
 }
 
@@ -573,7 +582,12 @@ function hasClientEntries(plan: BuildPlan): boolean {
   return plan.entries.some((entry) => entry.environment === "client");
 }
 
+function hasServerEntries(plan: BuildPlan): boolean {
+  return plan.entries.some((entry) => entry.environment === "server");
+}
+
 function validateUtoopackPlanSupport(plan: BuildPlan): void {
+  assertSupportedServerResolve(plan);
   const serverRuntimeEntries = plan.entries.filter(
     (entry) =>
       entry.environment === "server" && entry.kind === "server-runtime",

--- a/packages/bundler-utoopack/tests/create-config.test.ts
+++ b/packages/bundler-utoopack/tests/create-config.test.ts
@@ -298,8 +298,11 @@ describe("createUtoopackConfig", () => {
     });
   });
 
-  it("rejects server-only resolve.external contributions for mixed Utoopack plans", async () => {
+  it("maps server-only externals to the Utoopack server build", async () => {
     const config = createResolvedConfig();
+    config.server.externals = {
+      "shared-lib": "commonjs configured-shared-lib",
+    };
     const plan = await createPlan(config, {
       serverRoutes: [
         {
@@ -314,16 +317,83 @@ describe("createUtoopackConfig", () => {
       ...plan.resolve,
       external: {
         "server-only-lib": {
-          source: "server-only-lib",
+          source: "commonjs server-only-lib",
           runtime: "server",
+        },
+        "shared-lib": {
+          source: "SharedLib",
+          runtime: "all",
         },
       },
     };
 
+    const utoopackConfig = await createUtoopackConfig(
+      config,
+      plan,
+      process.cwd(),
+      [],
+    );
+
+    expect(utoopackConfig.externals).toEqual({
+      "shared-lib": "SharedLib",
+    });
+    expect(utoopackConfig.server?.externals).toEqual({
+      "server-only-lib": "commonjs server-only-lib",
+      "shared-lib": "commonjs configured-shared-lib",
+    });
+  });
+
+  it("rejects server.resolve for mixed Utoopack plans", async () => {
+    const config = createResolvedConfig();
+    config.server.resolve = {
+      alias: { "server-sdk": "./src/server/sdk.ts" },
+    };
+    const plan = await createPlan(config, {
+      serverRoutes: [
+        {
+          id: "src/apis/health/api.ts:/health:GET",
+          module: "src/apis/health/api.ts",
+          path: "/health",
+          methods: ["GET"],
+        },
+      ],
+    });
+
     await expect(
       createUtoopackConfig(config, plan, process.cwd(), []),
     ).rejects.toThrow(
-      "cannot map server-only resolve.external contributions while client entries are present: server-only-lib",
+      "cannot apply server.resolve independently while client entries are present",
+    );
+  });
+
+  it("maps server.resolve for server-only Utoopack plans", async () => {
+    const config = createResolvedConfig();
+    config.server.resolve = {
+      alias: { "server-sdk": "./src/server/sdk.ts" },
+    };
+    const plan = await createPlan(config, {
+      serverRoutes: [
+        {
+          id: "src/apis/health/api.ts:/health:GET",
+          module: "src/apis/health/api.ts",
+          path: "/health",
+          methods: ["GET"],
+        },
+      ],
+    });
+    plan.entries = plan.entries.filter(
+      (entry) => entry.environment === "server",
+    );
+
+    const utoopackConfig = await createUtoopackConfig(
+      config,
+      plan,
+      process.cwd(),
+      [],
+    );
+
+    expect(utoopackConfig.resolve?.alias?.["server-sdk"]).toBe(
+      path.resolve(process.cwd(), "src/server/sdk.ts"),
     );
   });
 

--- a/packages/bundler-webpack/src/adapter/create-config.ts
+++ b/packages/bundler-webpack/src/adapter/create-config.ts
@@ -127,6 +127,8 @@ export async function createWebpackConfigs(
         publicPath: plan.runtime.publicPath,
         resolveAlias: plan.resolve?.alias,
         resolveExternal: plan.resolve?.external,
+        serverResolveAlias: plan.server.resolve?.alias,
+        serverExternals: plan.server.externals,
         functionEndpoint: plan.runtime.server.fn,
         crossOriginLoading: undefined,
         rscClientReferences: getRscClientReferenceModules(
@@ -152,6 +154,8 @@ export async function createWebpackConfigs(
         publicPath: plan.runtime.publicPath,
         resolveAlias: plan.resolve?.alias,
         resolveExternal: plan.resolve?.external,
+        serverResolveAlias: plan.server.resolve?.alias,
+        serverExternals: plan.server.externals,
         functionEndpoint: plan.runtime.server.fn,
         crossOriginLoading: undefined,
         rscClientReferences: getRscClientReferenceModules(
@@ -177,6 +181,8 @@ export async function createWebpackConfigs(
         publicPath: plan.runtime.publicPath,
         resolveAlias: plan.resolve?.alias,
         resolveExternal: plan.resolve?.external,
+        serverResolveAlias: plan.server.resolve?.alias,
+        serverExternals: plan.server.externals,
         functionEndpoint: plan.runtime.server.fn,
         crossOriginLoading: undefined,
         rscClientReferences: getRscClientReferenceModules(
@@ -862,6 +868,8 @@ function createWebpackConfig(options: {
   publicPath: PublicPathOutput;
   resolveAlias?: NonNullable<BuildPlan["resolve"]>["alias"];
   resolveExternal?: NonNullable<BuildPlan["resolve"]>["external"];
+  serverResolveAlias?: NonNullable<BuildPlan["server"]["resolve"]>["alias"];
+  serverExternals?: BuildPlan["server"]["externals"];
   functionEndpoint: string;
   crossOriginLoading:
     | ResolvedConfig["output"]["crossOriginLoading"]
@@ -913,6 +921,7 @@ function createWebpackConfig(options: {
       extensions: [".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs", ".json"],
       alias: createResolveAlias(options.cwd, {
         ...(options.resolveAlias ?? {}),
+        ...(options.serverResolveAlias ?? {}),
         ...(options.reactServerConditions
           ? {
               "@evjs/client$": clientRscPageContextEntry,
@@ -1034,6 +1043,7 @@ function createWebpackExternals(options: {
   target: "web" | "node";
   reactServerConditions: boolean;
   resolveExternal?: NonNullable<BuildPlan["resolve"]>["external"];
+  serverExternals?: BuildPlan["server"]["externals"];
 }): Configuration["externals"] {
   const contributed = Object.fromEntries(
     Object.entries(options.resolveExternal ?? {})
@@ -1047,6 +1057,9 @@ function createWebpackExternals(options: {
         external.source ?? specifier,
       ]),
   );
+  if (options.target === "node") {
+    Object.assign(contributed, options.serverExternals);
+  }
   const hasContributed = Object.keys(contributed).length > 0;
   const defaultNodeExternals =
     options.target === "node" && !options.reactServerConditions

--- a/packages/bundler-webpack/tests/create-config.test.ts
+++ b/packages/bundler-webpack/tests/create-config.test.ts
@@ -908,9 +908,15 @@ describe("createWebpackConfigs", () => {
     });
   });
 
-  it("filters resolve.external contributions by webpack target runtime", async () => {
+  it("applies resolve contributions and server overrides by webpack target", async () => {
     const config: ResolvedConfig<WebpackConfigs> = {
       ...createResolvedConfig(),
+    };
+    config.server.resolve = {
+      alias: { "server-sdk": "./src/server/sdk.ts" },
+    };
+    config.server.externals = {
+      "shared-lib": "commonjs configured-shared-lib",
     };
     const graph = createGraph(config, {
       pages: [
@@ -955,11 +961,15 @@ describe("createWebpackConfigs", () => {
       expect.arrayContaining([
         expect.objectContaining({
           "server-only-lib": "commonjs server-only-lib",
-          "shared-lib": "SharedLib",
+          "shared-lib": "commonjs configured-shared-lib",
         }),
       ]),
     );
     expect(serverExternalsText).not.toContain("ClientOnlyLib");
+    expect(clientConfig?.resolve?.alias).not.toHaveProperty("server-sdk");
+    expect(serverConfig?.resolve?.alias).toMatchObject({
+      "server-sdk": path.resolve(process.cwd(), "src/server/sdk.ts"),
+    });
   });
 
   it("uses a generated server entry for framework-managed server routes", async () => {

--- a/packages/ev/src/_internal/build/plan/index.ts
+++ b/packages/ev/src/_internal/build/plan/index.ts
@@ -131,6 +131,8 @@ export interface BuildPlanConfig {
       ppr?: string;
       rsc?: string;
     };
+    resolve?: ServerBuildPlan["resolve"];
+    externals?: ServerBuildPlan["externals"];
   };
 }
 
@@ -566,10 +568,14 @@ export function diffBuildPlan(
   const previousServerCompilation = {
     entry: previous.server.entry,
     renderers: previous.server.renderers,
+    resolve: previous.server.resolve,
+    externals: previous.server.externals,
   };
   const nextServerCompilation = {
     entry: next.server.entry,
     renderers: next.server.renderers,
+    resolve: next.server.resolve,
+    externals: next.server.externals,
   };
   return {
     reason,
@@ -1038,9 +1044,22 @@ function createServerPlan(
 ): ServerBuildPlan {
   const entry = createServerRuntimeEntry(config, graph, renderers)?.import;
   const documents = createServerDocumentPlans(graph);
+  const serverResolveAlias = config.server.resolve?.alias;
   return {
     ...(entry ? { entry } : {}),
     ...(renderers.length > 0 ? { renderers } : {}),
+    ...(serverResolveAlias !== undefined
+      ? {
+          resolve: {
+            alias: { ...serverResolveAlias },
+          },
+        }
+      : {}),
+    ...(config.server.externals !== undefined
+      ? {
+          externals: { ...config.server.externals },
+        }
+      : {}),
     ...(documents.length > 0 ? { documents } : {}),
   };
 }

--- a/packages/ev/src/config/index.ts
+++ b/packages/ev/src/config/index.ts
@@ -16,6 +16,7 @@ import {
   type PageRouteNode,
   type PrerenderConfig,
   type RenderMode,
+  type ResolvePlan,
   type ServerMiddlewareNode,
   type ServerRouteNode,
 } from "@evjs/shared/manifest";
@@ -98,7 +99,15 @@ export interface ResolvedServerConfig {
   conventions?: ResolvedServerConventionsConfig;
   /** Server dev options. */
   dev: ResolvedServerDevConfig;
+  /** Module resolution overrides applied only to server build entries. */
+  resolve?: ResolvedServerResolveConfig;
+  /** External modules applied only to server build entries. */
+  externals?: ResolvedServerExternalsConfig;
 }
+
+export type ResolvedServerResolveConfig = ServerResolveConfig;
+
+export type ResolvedServerExternalsConfig = ServerExternalsConfig;
 
 export interface ResolvedServerRuntimeConfig {
   basePath: string;
@@ -243,9 +252,17 @@ export interface ServerConfig {
    * RSC is enabled by a Page's `page.config.ts`, not by server config.
    */
   rsc?: ServerRscConfig;
+  /** Module resolution overrides applied only to server build entries. */
+  resolve?: ServerResolveConfig;
+  /** External modules applied only to server build entries. */
+  externals?: ServerExternalsConfig;
   /** Server dev options. */
   dev?: ServerDevConfig;
 }
+
+export type ServerResolveConfig = Pick<ResolvePlan, "alias">;
+
+export type ServerExternalsConfig = Record<string, string>;
 
 export interface ServerRscConfig {
   /** RSC Flight endpoint path override. */
@@ -531,7 +548,14 @@ const PUBLIC_DEV_CONFIG_KEYS = new Set([
   "proxy",
   "cliShortcuts",
 ]);
-const PUBLIC_SERVER_CONFIG_KEYS = new Set(["basePath", "rsc", "dev"]);
+const PUBLIC_SERVER_CONFIG_KEYS = new Set([
+  "basePath",
+  "rsc",
+  "resolve",
+  "externals",
+  "dev",
+]);
+const PUBLIC_SERVER_RESOLVE_CONFIG_KEYS = new Set(["alias"]);
 const PUBLIC_SERVER_DEV_CONFIG_KEYS = new Set(["port", "https"]);
 const PUBLIC_SERVER_RSC_CONFIG_KEYS = new Set(["endpoint"]);
 const PUBLIC_TRANSPORT_CONFIG_KEYS = new Set(["baseUrl"]);
@@ -610,6 +634,11 @@ export function resolveConfig<TBundlerCfg = unknown>(
   );
   validateServerConfigKeys(serverConfig);
   const serverRscConfig = resolveServerRscConfig(serverConfig.rsc);
+  const serverResolveConfig = resolveServerResolveConfig(serverConfig.resolve);
+  const serverExternalsConfig = resolveExternalsConfig(
+    serverConfig.externals,
+    "server.externals",
+  );
   const serverDevConfig = resolveOptionalConfigRecord<ServerDevConfig>(
     serverConfig.dev,
     "server.dev",
@@ -687,6 +716,12 @@ export function resolveConfig<TBundlerCfg = unknown>(
       rsc: rscEndpoint ? { endpoint: rscEndpoint } : undefined,
       routes: conventions ? [] : undefined,
       conventions: resolvedServerConventions,
+      ...(serverResolveConfig !== undefined
+        ? { resolve: serverResolveConfig }
+        : {}),
+      ...(serverExternalsConfig !== undefined
+        ? { externals: serverExternalsConfig }
+        : {}),
       dev: {
         port: serverPort,
         https: serverHttps,
@@ -1531,7 +1566,52 @@ function validateServerConfigKeys(server: ServerConfig): void {
     server,
     PUBLIC_SERVER_CONFIG_KEYS,
     "server",
-    "basePath, rsc, or dev",
+    "basePath, rsc, resolve, externals, or dev",
+  );
+}
+
+function resolveServerResolveConfig(
+  value: unknown,
+): ResolvedServerResolveConfig | undefined {
+  if (value === undefined) return undefined;
+  const resolve = assertPlainConfigRecord(
+    value,
+    "server.resolve",
+    "a server resolve object",
+  );
+  assertKnownConfigKeys(
+    resolve,
+    PUBLIC_SERVER_RESOLVE_CONFIG_KEYS,
+    "server.resolve",
+    "alias",
+  );
+
+  return {
+    ...(resolve.alias === undefined
+      ? {}
+      : {
+          alias: resolveStringRecord(resolve.alias, "server.resolve.alias"),
+        }),
+  };
+}
+
+function resolveExternalsConfig(
+  value: unknown,
+  path: string,
+): ResolvedServerExternalsConfig | undefined {
+  return value === undefined ? undefined : resolveStringRecord(value, path);
+}
+
+function resolveStringRecord(
+  value: unknown,
+  path: string,
+): Record<string, string> {
+  const record = assertPlainConfigRecord(value, path, "a string map");
+  return Object.fromEntries(
+    Object.entries(record).map(([key, rawValue]) => [
+      assertTrimmedNonEmptyString(key, `${path} key`),
+      assertTrimmedNonEmptyString(rawValue, `${path}[${JSON.stringify(key)}]`),
+    ]),
   );
 }
 

--- a/packages/ev/tests/build-tools-graph-plan.test.ts
+++ b/packages/ev/tests/build-tools-graph-plan.test.ts
@@ -67,6 +67,36 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
     expect(explicit.buildId).toBe("release-42");
   });
 
+  it("projects server-only build settings", async () => {
+    const cwd = await createFixture({
+      "src/pages/page.tsx": "export default function Home() { return null; }",
+      "index.html": '<main id="app"></main>',
+    });
+    const config = await createCanonicalConfig(cwd, "spa");
+    config.server.resolve = {
+      alias: { "server-sdk": "./src/server/sdk.ts" },
+    };
+    config.server.externals = {
+      "native-addon": "commonjs native-addon",
+    };
+    const analysis = await createCoreGraph(config, cwd);
+    const plan = createBuildPlan(config, analysis.graph);
+
+    expect(plan.server.resolve).toEqual({
+      alias: config.server.resolve.alias,
+    });
+    expect(plan.server.externals).toEqual(config.server.externals);
+    expect(plan.server.resolve?.alias).not.toBe(config.server.resolve.alias);
+    expect(plan.server.externals).not.toBe(config.server.externals);
+
+    const next = structuredClone(plan);
+    delete next.server.resolve;
+    delete next.server.externals;
+    expect(diffBuildPlan(plan, next, "config").serverCompilationChanged).toBe(
+      true,
+    );
+  });
+
   it("keeps recursively cleaned outputs inside the BuildPlan distDir", async () => {
     const cwd = await createFixture({
       "src/pages/page.tsx": "export default function Home() { return null; }",

--- a/packages/ev/tests/config.test.ts
+++ b/packages/ev/tests/config.test.ts
@@ -982,6 +982,12 @@ describe("resolveConfig", () => {
       },
       server: {
         basePath: "/_ev",
+        resolve: {
+          alias: { "server-sdk": "./src/server/sdk.ts" },
+        },
+        externals: {
+          "native-addon": "commonjs native-addon",
+        },
         dev: {
           port: 4200,
           https: { key: "server.key", cert: "server.cert" },
@@ -1013,11 +1019,35 @@ describe("resolveConfig", () => {
       ppr: "_ev/ppr",
     });
     expect(resolved.server.routes).toEqual([]);
+    expect(resolved.server.resolve).toEqual({
+      alias: { "server-sdk": "./src/server/sdk.ts" },
+    });
+    expect(resolved.server.externals).toEqual({
+      "native-addon": "commonjs native-addon",
+    });
     expect(resolved.server.dev).toEqual({
       port: 4200,
       https: { key: "server.key", cert: "server.cert" },
     });
     expect(resolved.transport.baseUrl).toBe("https://runtime.example.com");
+  });
+
+  it("strictly validates server-only build settings", () => {
+    expect(() =>
+      resolveConfig({
+        server: { resolve: { extensions: [".ts"] } },
+      } as never),
+    ).toThrow("server.resolve.extensions is not supported");
+    expect(() =>
+      resolveConfig({
+        server: { resolve: { alias: { sdk: " " } } },
+      }),
+    ).toThrow('server.resolve.alias["sdk"] must be a non-empty string');
+    expect(() =>
+      resolveConfig({
+        server: { externals: { native: false } },
+      } as never),
+    ).toThrow('server.externals["native"] must be a non-empty string');
   });
 
   it("rejects output directories that can escape or alias the project root", () => {

--- a/packages/shared/src/manifest/index.ts
+++ b/packages/shared/src/manifest/index.ts
@@ -309,6 +309,10 @@ export interface HtmlPlan {
 export interface ServerBuildPlan {
   entry?: string;
   renderers?: ServerRenderPlan[];
+  /** Module resolution overrides applied only to server build entries. */
+  resolve?: ServerResolvePlan;
+  /** External modules applied only to server build entries. */
+  externals?: Record<string, string>;
   /**
    * HTML templates compiled into request-time document shells for Pages that
    * are rendered by the deployment server.
@@ -319,6 +323,8 @@ export interface ServerBuildPlan {
    */
   documents?: ServerDocumentPlan[];
 }
+
+export type ServerResolvePlan = Pick<ResolvePlan, "alias">;
 
 export interface ServerDocumentPlan {
   /** Page whose request-time HTML is inserted into this document. */


### PR DESCRIPTION
## Summary

- add validated `server.resolve.alias` and `server.externals` config projected into server BuildPlan fields
- apply server-only aliases and external overrides in Webpack and Utoopack while preserving existing `resolve.external` contributions
- upgrade Utoopack to 1.5.3 for scoped server externals and document mixed-build resolver limitations

## Testing

- `npm run check-types`
- `npm run lint`
- `npm test`
- `npm --workspace evjs-docs run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-specific module aliases and external module mappings.
  * Server settings now apply only to server builds, keeping client resolution isolated.
  * Webpack supports both options; Utoopack supports server externals and server-only aliases.
* **Bug Fixes**
  * Improved mixed-build handling for server-only external contributions.
  * Added validation for empty or whitespace-only alias and external entries.
* **Documentation**
  * Documented the new configuration options and contribution behavior in English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->