### PR TITLE
docs(changelog): prepare v0.3.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,26 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.10] — 2026-08-12
+
+### ✨ Features
+
+- **Server-specific build configuration** — Applications can declare
+  `server.resolve.alias` and `server.externals` without changing client
+  resolution. Webpack and Utoopack keep both settings isolated in mixed builds.
+- **Lower camel case plugin ids** — Plugin ids can use lower camel case as well
+  as lowercase kebab-case. Mixed camel/kebab ids and case-folded collisions
+  remain invalid so generated paths and settings stay portable across
+  case-sensitive and case-insensitive filesystems.
+
 ### 🐛 Bug Fixes
 
 - **Utoopack server alias isolation** — Mixed client/server builds now map
-  `server.resolve.alias` to Utoopack's server-scoped resolver instead of
-  rejecting the configuration, allowing matching client and server aliases to
-  resolve to different targets while preserving project-relative alias
-  replacements for Utoopack 1.5.4.
+  `server.resolve.alias` to Utoopack's server-scoped resolver, allowing matching
+  client and server aliases to resolve to different targets while preserving
+  project-relative alias replacements for Utoopack 1.5.4.
 
 ---
 


### PR DESCRIPTION
## Summary

- prepare the changelog for the next stable 0.3 release, v0.3.10
- capture the user-facing features and bug fix merged after v0.3.9

## Changes

- document lower camel case plugin ids from #94
- document server-specific resolve aliases and externals from #96
- document Utoopack mixed client/server alias isolation and 1.5.4 compatibility from #98
- update the release date to 2026-08-12
- leave source package versions and internal dependency ranges unchanged; release automation owns publish-time versioning
- omit #95 because it changes test synchronization only and has no user-facing runtime behavior

## Validation

- `npm run lint`
- `npm run check-types` (push hook)
- `npm --workspace evjs-docs run build`
- `git diff --check`

## Risk / rollout

- low risk: this PR changes only release metadata in `CHANGELOG.md`
- publishing occurs separately when the v0.3.10 GitHub Release is created after merge

## Reviewer notes

- verify the v0.3.10 entry matches the complete `v0.3.9...main` commit range
