### PR TITLE
fix(bundler-utoopack): map server resolve aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 - **Utoopack server alias isolation** — Mixed client/server builds now map
   `server.resolve.alias` to Utoopack's server-scoped resolver instead of
   rejecting the configuration, allowing matching client and server aliases to
-  resolve to different targets.
+  resolve to different targets while preserving project-relative alias
+  replacements for Utoopack 1.5.4.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- **Utoopack server alias isolation** — Mixed client/server builds now map
+  `server.resolve.alias` to Utoopack's server-scoped resolver instead of
+  rejecting the configuration, allowing matching client and server aliases to
+  resolve to different targets.
+
 ---
 
 ## [0.3.9] — 2026-08-11

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -289,11 +289,10 @@ whose project-relative replacements resolve from the application root.
 without leading or trailing whitespace. Config resolution normalizes these
 entries into `plan.server.externals` as a server-build-specific string map.
 
-The Webpack adapter supports both settings in mixed client/server builds.
-Utoopack 1.5.3 supports independent `server.externals`; its current resolver
-does not expose a server-scoped resolve object, so `server.resolve` is supported
-only for server-only Utoopack plans and fails fast for mixed plans instead of
-leaking the override into client resolution.
+The Webpack and Utoopack adapters support both settings in mixed client/server
+builds. Utoopack maps `server.resolve.alias` to its server-scoped resolver so a
+matching specifier can resolve differently for client and server entries;
+other top-level aliases remain shared.
 
 `server.basePath` owns server-function, PPR, and RSC runtime paths. It must be
 an absolute pathname using non-empty ASCII URL-safe segments containing only

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/config.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/config.md
@@ -269,10 +269,10 @@ replacement 从应用根目录解析。`server.externals` 把 module specifier �
 空白的非空字符串。配置解析会将它们作为 server build 专用的字符串映射放入
 `plan.server.externals`。
 
-Webpack adapter 在 client/server 混合构建中完整支持这两个配置。Utoopack 1.5.3
-支持独立的 `server.externals`；当前 resolver 尚未暴露 server-scoped resolve
-对象，因此 `server.resolve` 只支持 server-only Utoopack plan。混合 plan 会快速
-失败，避免把 server override 泄漏到 client resolution。
+Webpack 和 Utoopack adapter 在 client/server 混合构建中都支持这两个配置。
+Utoopack 会将 `server.resolve.alias` 映射到 server-scoped resolver，因此同名的
+specifier 可以在 client 和 server entry 中解析到不同目标；其他顶层 alias 仍然
+由两类 entry 共享。
 
 `server.basePath` 统一控制 server function、PPR 和 RSC runtime 路径。它必须是
 absolute pathname，由非空 ASCII URL-safe segment 组成；每个 segment 只能包含

--- a/package-lock.json
+++ b/package-lock.json
@@ -8838,9 +8838,9 @@
       }
     },
     "node_modules/@utoo/pack-darwin-arm64": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-darwin-arm64/-/pack-darwin-arm64-1.5.3.tgz",
-      "integrity": "sha512-xmapboRiKB7TSZsvevaAGk/t/T7G5bh0W2igSmmoQrj71mnEFEvsCaiG/LiXvExOgB3nJPk0MzUXYms4DAwVPg==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-darwin-arm64/-/pack-darwin-arm64-1.5.4.tgz",
+      "integrity": "sha512-5VEpaFn+MVBXoC+6C4rsK94UycEVINTMZ6XsbRU9C/geN7uw73WvnJENS0ITMk0PFiAQxUIhzzlPy0aV5J/96g==",
       "cpu": [
         "arm64"
       ],
@@ -8854,9 +8854,9 @@
       }
     },
     "node_modules/@utoo/pack-darwin-x64": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-darwin-x64/-/pack-darwin-x64-1.5.3.tgz",
-      "integrity": "sha512-A70FPoyf8If7UCgfHPPtMJkEkVwbPSRUXTYHz0nj3cifqEPsYg2wT85rHqw51a99HFykYmBYI8Pci24lAmOp0g==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-darwin-x64/-/pack-darwin-x64-1.5.4.tgz",
+      "integrity": "sha512-F023kpSx+xBYjVVnGIJOvR0kY/kDkFxuSI+uVtqS+5DtnJwMcHzMdegU8zEwjFzYUNLgwXkMAs1myCl7Ezgzjw==",
       "cpu": [
         "x64"
       ],
@@ -8870,9 +8870,9 @@
       }
     },
     "node_modules/@utoo/pack-linux-arm64-gnu": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-arm64-gnu/-/pack-linux-arm64-gnu-1.5.3.tgz",
-      "integrity": "sha512-sQDEroVN+mHHuqkF0nffdVDbM7lVonhW6DrHqmkmLzD/h0dudum6UsjoWNZ8taTqIcvybLiWVzJH1xf3oxB/qA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-arm64-gnu/-/pack-linux-arm64-gnu-1.5.4.tgz",
+      "integrity": "sha512-EAdDVjTsMXaIR1DX83RQXWEVMy3NyaFbp3V16ptErYt/rreG4ZbrnMTAaBYuEVs9sZ3x2wEPZEKtlQKErkgAXg==",
       "cpu": [
         "arm64"
       ],
@@ -8886,9 +8886,9 @@
       }
     },
     "node_modules/@utoo/pack-linux-arm64-musl": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-arm64-musl/-/pack-linux-arm64-musl-1.5.3.tgz",
-      "integrity": "sha512-U6exeeZHYSpMYx1gK1LVYDa8tV9E3RRPd9VFJZtlslxjTiofGCvVVjEP3ZqxNJipThnqPv5OEXgZ43GpX2CAUQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-arm64-musl/-/pack-linux-arm64-musl-1.5.4.tgz",
+      "integrity": "sha512-X2DuZs8ZqJ01YqBI8HdSBxD2zjQXqGs1gJ97v2Nmver/e1l9wf94tmcgrZAgJWm2WBUQF6ZzkMTW986Pdg7wLA==",
       "cpu": [
         "arm64"
       ],
@@ -8902,9 +8902,9 @@
       }
     },
     "node_modules/@utoo/pack-linux-x64-gnu": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-x64-gnu/-/pack-linux-x64-gnu-1.5.3.tgz",
-      "integrity": "sha512-6xeXNYelhFo79GIOSn0d6v2QYLktjgKGPW78oNN/UmlSmWO25mvyLMyVHM6qGUFI785R4KouAMVqe0xIt6M8kw==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-x64-gnu/-/pack-linux-x64-gnu-1.5.4.tgz",
+      "integrity": "sha512-ky1j/kdkQ1lxGqN9VmUIizbf/IWWpWLLQO2aCU3XkAdF/vjKG/lODa4zRCYlSg/Fby0W0XMCANfKCuS8DCRD1w==",
       "cpu": [
         "x64"
       ],
@@ -8918,9 +8918,9 @@
       }
     },
     "node_modules/@utoo/pack-linux-x64-musl": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-x64-musl/-/pack-linux-x64-musl-1.5.3.tgz",
-      "integrity": "sha512-mDulBCwNe/nOa8G/WjN9PfPEgwGzRPyBA+yh6LzHUdlOH/WeBL5eKiPv6RoifuAPJpzGKcYNFqUAnc2ppHPjfA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-linux-x64-musl/-/pack-linux-x64-musl-1.5.4.tgz",
+      "integrity": "sha512-dmfEtDaVIp5mllWMEeshekzfdkQr0uIQITCoCvk4NDt3fWaPNtJmgmOfM7LYo1+5+/Sl5nW6o5zvnfE6Y9bbmA==",
       "cpu": [
         "x64"
       ],
@@ -8934,9 +8934,9 @@
       }
     },
     "node_modules/@utoo/pack-shared": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-shared/-/pack-shared-1.5.3.tgz",
-      "integrity": "sha512-w4rNZGRWAX4VTzz6dfXYuLK5KLwKeUUh1TlD1xfswasQWuXdd681VwB3VMMFVVcYcdQv+1/5S8v2pvrk1CJH0Q==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-shared/-/pack-shared-1.5.4.tgz",
+      "integrity": "sha512-LGI3kcj42v56UpTVeq6yITzKeMwVZiVTnL+hlS8muA/1goYDF6a6O7+Ujn5xtdChHhSfgw2dBh+BGfqZP/fEZQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "7.22.5",
@@ -8959,9 +8959,9 @@
       }
     },
     "node_modules/@utoo/pack-win32-x64-msvc": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@utoo/pack-win32-x64-msvc/-/pack-win32-x64-msvc-1.5.3.tgz",
-      "integrity": "sha512-al2EtNZ5Bqj3dJgTS6VhF0ljOtrB2n1Zq7xGOjA/o+vulgoPeXAHRrakb7EKqB9lcv99HM1LWQ7uzUxHunuEgA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@utoo/pack-win32-x64-msvc/-/pack-win32-x64-msvc-1.5.4.tgz",
+      "integrity": "sha512-XbAtFBEK6pmA7D1Iai43EpR1I67bbScqoZmjIIaClKfOIXth/z/tqZiz2s8DN+d9UD1U+Sr2PmcRTre3Ri0KdA==",
       "cpu": [
         "x64"
       ],
@@ -24545,7 +24545,7 @@
         "@evjs/ev": "*",
         "@evjs/shared": "*",
         "@logtape/logtape": "^2.0.4",
-        "@utoo/pack": "^1.5.3",
+        "@utoo/pack": "^1.5.4",
         "chokidar": "^3.6.0",
         "fast-glob": "^3.3.3",
         "less": "4.1.3",
@@ -24578,16 +24578,16 @@
       }
     },
     "packages/bundler-utoopack/node_modules/@utoo/pack": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@utoo/pack/-/pack-1.5.3.tgz",
-      "integrity": "sha512-sRRK4YyoDHTmvi2r+97u6n1PqcdisOeFZA+Wzwp5lgApCNA56KIl2EoH+ppwgsYv9XT0jJ3qwe2HAF95Q7YbfQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@utoo/pack/-/pack-1.5.4.tgz",
+      "integrity": "sha512-Q+mWtY/qe0A1pmpe1POipaRj8IBrHa8x+W07RY6EHKXC6pQc2fyJNERUdemPuYe4Yt3pvy5SKDwAOPMmXbOfSw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "7.22.5",
         "@hono/node-server": "^1.19.11",
         "@hono/node-ws": "^1.3.0",
         "@swc/helpers": "0.5.15",
-        "@utoo/pack-shared": "1.5.3",
+        "@utoo/pack-shared": "1.5.4",
         "domparser-rs": "^0.0.7",
         "find-up": "4.1.0",
         "get-port": "5.1.1",
@@ -24602,13 +24602,13 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@utoo/pack-darwin-arm64": "1.5.3",
-        "@utoo/pack-darwin-x64": "1.5.3",
-        "@utoo/pack-linux-arm64-gnu": "1.5.3",
-        "@utoo/pack-linux-arm64-musl": "1.5.3",
-        "@utoo/pack-linux-x64-gnu": "1.5.3",
-        "@utoo/pack-linux-x64-musl": "1.5.3",
-        "@utoo/pack-win32-x64-msvc": "1.5.3"
+        "@utoo/pack-darwin-arm64": "1.5.4",
+        "@utoo/pack-darwin-x64": "1.5.4",
+        "@utoo/pack-linux-arm64-gnu": "1.5.4",
+        "@utoo/pack-linux-arm64-musl": "1.5.4",
+        "@utoo/pack-linux-x64-gnu": "1.5.4",
+        "@utoo/pack-linux-x64-musl": "1.5.4",
+        "@utoo/pack-win32-x64-msvc": "1.5.4"
       },
       "peerDependencies": {
         "less": "^4.0.0",

--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -35,7 +35,7 @@
     "@evjs/ev": "*",
     "@evjs/shared": "*",
     "@logtape/logtape": "^2.0.4",
-    "@utoo/pack": "^1.5.3",
+    "@utoo/pack": "^1.5.4",
     "chokidar": "^3.6.0",
     "fast-glob": "^3.3.3",
     "less": "4.1.3",

--- a/packages/bundler-utoopack/src/adapter/create-config.ts
+++ b/packages/bundler-utoopack/src/adapter/create-config.ts
@@ -110,10 +110,7 @@ export async function createUtoopackConfig(
 
   const finalServerEntry = resolveServerEntries(plan);
   const expectedServerEntry = snapshotUtoopackServerEntry(finalServerEntry);
-  const resolveEnvironment: ResolveEnvironment =
-    finalServerEntry !== undefined && !hasClientEntries(plan)
-      ? "server"
-      : "client";
+  const serverResolve = createServerResolve(cwd, plan);
 
   const outputPaths = resolveBuildOutputPaths(cwd, plan);
   await assertSafeBuildOutputPaths(cwd, outputPaths);
@@ -139,7 +136,7 @@ export async function createUtoopackConfig(
       clean: true,
     },
     resolve: {
-      alias: createResolveAlias(cwd, plan, resolveEnvironment),
+      alias: createResolveAlias(cwd, plan.resolve?.alias),
       extensions: [".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs"],
     },
     externals: createResolveExternals(plan, "client"),
@@ -178,6 +175,7 @@ export async function createUtoopackConfig(
           // Server functions config — utoopack handles "use server" natively.
           server: {
             entry: finalServerEntry,
+            ...(serverResolve ? { resolve: serverResolve } : {}),
             externals: createResolveExternals(plan, "server") ?? {},
             output: {
               path: outputPaths.serverDir,
@@ -196,7 +194,7 @@ export async function createUtoopackConfig(
               clientProxy: SERVER_FUNCTION_TRANSFORM_RUNTIME.clientModule,
               serverRegister: SERVER_FUNCTION_TRANSFORM_RUNTIME.serverModule,
             },
-          },
+          } satisfies UtoopackServerConfig,
         }
       : {}),
 
@@ -530,15 +528,31 @@ function missingFrameworkWatchCollector(file: string): never {
 
 function createResolveAlias(
   cwd: string,
-  plan: BuildPlan,
-  environment: ResolveEnvironment,
+  alias: Record<string, string> | undefined,
 ): NonNullable<ConfigComplete["resolve"]>["alias"] {
   return Object.fromEntries(
-    Object.entries({
-      ...(plan.resolve?.alias ?? {}),
-      ...(environment === "server" ? plan.server.resolve?.alias : undefined),
-    }).map(([name, target]) => [name, resolveAliasTarget(cwd, target)]),
+    Object.entries(alias ?? {}).map(([name, target]) => [
+      name,
+      resolveAliasTarget(cwd, target),
+    ]),
   );
+}
+
+type UtoopackServerConfig = NonNullable<ConfigComplete["server"]> & {
+  // Available in Utoopack after https://github.com/utooland/utoo/pull/3296.
+  resolve?: NonNullable<ConfigComplete["resolve"]>;
+};
+
+function createServerResolve(
+  cwd: string,
+  plan: BuildPlan,
+): NonNullable<UtoopackServerConfig["resolve"]> | undefined {
+  const alias = plan.server.resolve?.alias;
+  if (alias === undefined) return undefined;
+
+  return {
+    alias: createResolveAlias(cwd, alias),
+  };
 }
 
 function resolveAliasTarget(cwd: string, target: string): string {
@@ -564,30 +578,11 @@ function createResolveExternals(
   return Object.keys(external).length > 0 ? external : undefined;
 }
 
-function assertSupportedServerResolve(plan: BuildPlan): void {
-  if (!hasClientEntries(plan) || !hasServerEntries(plan)) return;
-  if (Object.keys(plan.server.resolve?.alias ?? {}).length === 0) {
-    return;
-  }
-  throw new Error(
-    "[evjs] The Utoopack adapter cannot apply server.resolve independently while client entries are present. Use the Webpack adapter or remove the server-only resolve override.",
-  );
-}
-
 function hasAppClientEntry(plan: BuildPlan): boolean {
   return plan.entries.some((entry) => entry.kind === "app-client");
 }
 
-function hasClientEntries(plan: BuildPlan): boolean {
-  return plan.entries.some((entry) => entry.environment === "client");
-}
-
-function hasServerEntries(plan: BuildPlan): boolean {
-  return plan.entries.some((entry) => entry.environment === "server");
-}
-
 function validateUtoopackPlanSupport(plan: BuildPlan): void {
-  assertSupportedServerResolve(plan);
   const serverRuntimeEntries = plan.entries.filter(
     (entry) =>
       entry.environment === "server" && entry.kind === "server-runtime",

--- a/packages/bundler-utoopack/src/adapter/create-config.ts
+++ b/packages/bundler-utoopack/src/adapter/create-config.ts
@@ -110,7 +110,6 @@ export async function createUtoopackConfig(
 
   const finalServerEntry = resolveServerEntries(plan);
   const expectedServerEntry = snapshotUtoopackServerEntry(finalServerEntry);
-  const serverResolve = createServerResolve(cwd, plan);
 
   const outputPaths = resolveBuildOutputPaths(cwd, plan);
   await assertSafeBuildOutputPaths(cwd, outputPaths);
@@ -136,7 +135,7 @@ export async function createUtoopackConfig(
       clean: true,
     },
     resolve: {
-      alias: createResolveAlias(cwd, plan.resolve?.alias),
+      alias: { ...plan.resolve?.alias },
       extensions: [".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs"],
     },
     externals: createResolveExternals(plan, "client"),
@@ -175,7 +174,13 @@ export async function createUtoopackConfig(
           // Server functions config — utoopack handles "use server" natively.
           server: {
             entry: finalServerEntry,
-            ...(serverResolve ? { resolve: serverResolve } : {}),
+            ...(plan.server.resolve?.alias !== undefined
+              ? {
+                  resolve: {
+                    alias: { ...plan.server.resolve.alias },
+                  },
+                }
+              : {}),
             externals: createResolveExternals(plan, "server") ?? {},
             output: {
               path: outputPaths.serverDir,
@@ -194,7 +199,7 @@ export async function createUtoopackConfig(
               clientProxy: SERVER_FUNCTION_TRANSFORM_RUNTIME.clientModule,
               serverRegister: SERVER_FUNCTION_TRANSFORM_RUNTIME.serverModule,
             },
-          } satisfies UtoopackServerConfig,
+          },
         }
       : {}),
 
@@ -524,40 +529,6 @@ function missingFrameworkWatchCollector(file: string): never {
   throw new Error(
     `[evjs] Cannot watch plugin dependency "${file}" because the Utoopack config was created without a framework watch collector.`,
   );
-}
-
-function createResolveAlias(
-  cwd: string,
-  alias: Record<string, string> | undefined,
-): NonNullable<ConfigComplete["resolve"]>["alias"] {
-  return Object.fromEntries(
-    Object.entries(alias ?? {}).map(([name, target]) => [
-      name,
-      resolveAliasTarget(cwd, target),
-    ]),
-  );
-}
-
-type UtoopackServerConfig = NonNullable<ConfigComplete["server"]> & {
-  // Available in Utoopack after https://github.com/utooland/utoo/pull/3296.
-  resolve?: NonNullable<ConfigComplete["resolve"]>;
-};
-
-function createServerResolve(
-  cwd: string,
-  plan: BuildPlan,
-): NonNullable<UtoopackServerConfig["resolve"]> | undefined {
-  const alias = plan.server.resolve?.alias;
-  if (alias === undefined) return undefined;
-
-  return {
-    alias: createResolveAlias(cwd, alias),
-  };
-}
-
-function resolveAliasTarget(cwd: string, target: string): string {
-  if (path.isAbsolute(target)) return target;
-  return target.startsWith(".") ? path.resolve(cwd, target) : target;
 }
 
 type ResolveEnvironment = "client" | "server";

--- a/packages/bundler-utoopack/tests/create-config.test.ts
+++ b/packages/bundler-utoopack/tests/create-config.test.ts
@@ -343,7 +343,7 @@ describe("createUtoopackConfig", () => {
     });
   });
 
-  it("rejects server.resolve for mixed Utoopack plans", async () => {
+  it("maps server.resolve to the Utoopack server build", async () => {
     const config = createResolvedConfig();
     config.server.resolve = {
       alias: { "server-sdk": "./src/server/sdk.ts" },
@@ -358,32 +358,13 @@ describe("createUtoopackConfig", () => {
         },
       ],
     });
-
-    await expect(
-      createUtoopackConfig(config, plan, process.cwd(), []),
-    ).rejects.toThrow(
-      "cannot apply server.resolve independently while client entries are present",
-    );
-  });
-
-  it("maps server.resolve for server-only Utoopack plans", async () => {
-    const config = createResolvedConfig();
-    config.server.resolve = {
-      alias: { "server-sdk": "./src/server/sdk.ts" },
+    plan.resolve = {
+      ...plan.resolve,
+      alias: {
+        ...plan.resolve?.alias,
+        "server-sdk": "./src/client/sdk.ts",
+      },
     };
-    const plan = await createPlan(config, {
-      serverRoutes: [
-        {
-          id: "src/apis/health/api.ts:/health:GET",
-          module: "src/apis/health/api.ts",
-          path: "/health",
-          methods: ["GET"],
-        },
-      ],
-    });
-    plan.entries = plan.entries.filter(
-      (entry) => entry.environment === "server",
-    );
 
     const utoopackConfig = await createUtoopackConfig(
       config,
@@ -392,9 +373,20 @@ describe("createUtoopackConfig", () => {
       [],
     );
 
-    expect(utoopackConfig.resolve?.alias?.["server-sdk"]).toBe(
-      path.resolve(process.cwd(), "src/server/sdk.ts"),
-    );
+    expect(utoopackConfig).toMatchObject({
+      resolve: {
+        alias: {
+          "server-sdk": path.resolve(process.cwd(), "src/client/sdk.ts"),
+        },
+      },
+      server: {
+        resolve: {
+          alias: {
+            "server-sdk": path.resolve(process.cwd(), "src/server/sdk.ts"),
+          },
+        },
+      },
+    });
   });
 
   it("uses configured client and server output directories", async () => {

--- a/packages/bundler-utoopack/tests/create-config.test.ts
+++ b/packages/bundler-utoopack/tests/create-config.test.ts
@@ -82,9 +82,7 @@ describe("createUtoopackConfig", () => {
     ]);
     expect(utoopackConfig.output?.publicPath).toBe("auto");
     expect(utoopackConfig.output?.crossOriginLoading).toBe("anonymous");
-    expect(utoopackConfig.resolve?.alias?.["@"]).toBe(
-      path.resolve(process.cwd(), "src"),
-    );
+    expect(utoopackConfig.resolve?.alias?.["@"]).toBe("./src");
     expect(utoopackConfig.define).toMatchObject({
       "process.env.EVJS_FUNCTION_ENDPOINT": JSON.stringify("__evjs/fn"),
       __EVJS_FUNCTION_ENDPOINT__: JSON.stringify("__evjs/fn"),
@@ -270,7 +268,7 @@ describe("createUtoopackConfig", () => {
     );
     expect(plan.resolve?.alias?.["@generated/config"]).toBe(module?.file);
     expect(utoopackConfig.resolve?.alias?.["@generated/config"]).toBe(
-      path.resolve(process.cwd(), module?.file ?? ""),
+      module?.file,
     );
   });
 
@@ -376,13 +374,13 @@ describe("createUtoopackConfig", () => {
     expect(utoopackConfig).toMatchObject({
       resolve: {
         alias: {
-          "server-sdk": path.resolve(process.cwd(), "src/client/sdk.ts"),
+          "server-sdk": "./src/client/sdk.ts",
         },
       },
       server: {
         resolve: {
           alias: {
-            "server-sdk": path.resolve(process.cwd(), "src/server/sdk.ts"),
+            "server-sdk": "./src/server/sdk.ts",
           },
         },
       },

--- a/packages/bundler-utoopack/tests/multi-server-entry.test.ts
+++ b/packages/bundler-utoopack/tests/multi-server-entry.test.ts
@@ -45,6 +45,12 @@ describe("Utoopack multi-server entries", () => {
         import: "./src/detail.server.ts",
       },
     ]);
+    expect(config.resolve?.alias?.["platform-alias"]).toBe(
+      "./src/client-value.ts",
+    );
+    expect(config.server?.resolve?.alias?.["platform-alias"]).toBe(
+      "./src/server-value.ts",
+    );
 
     await runUtoopackBuild({ build: utoopackBuild }, config, cwd);
     await fs.promises.writeFile(
@@ -53,6 +59,10 @@ describe("Utoopack multi-server entries", () => {
     );
 
     const facts = await new UtoopackManifestGenerator(cwd, plan).build();
+    const [clientOutput, serverOutput] = await Promise.all([
+      readJavaScriptOutput(path.join(cwd, "dist/client")),
+      readJavaScriptOutput(path.join(cwd, "dist/server")),
+    ]);
     const stats = JSON.parse(
       await fs.promises.readFile(
         path.join(cwd, "dist/server/stats.json"),
@@ -72,6 +82,10 @@ describe("Utoopack multi-server entries", () => {
       "page-server-detail",
       "server",
     ]);
+    expect(clientOutput).toContain("client alias");
+    expect(clientOutput).not.toContain("server alias");
+    expect(serverOutput).toContain("server alias");
+    expect(serverOutput).not.toContain("client alias");
 
     const assetReferenceCounts = new Map<string, number>();
     for (const entrypoint of Object.values(stats.entrypoints)) {
@@ -194,6 +208,12 @@ function createPlan(): BuildPlan {
     server: {
       entry: "./src/server.ts",
       renderers,
+      resolve: {
+        alias: { "platform-alias": "./src/server-value.ts" },
+      },
+    },
+    resolve: {
+      alias: { "platform-alias": "./src/client-value.ts" },
     },
     dev: {
       clientRoutes: [],
@@ -217,7 +237,15 @@ async function writeFixture(cwd: string): Promise<void> {
   await Promise.all([
     fs.promises.writeFile(
       path.join(sourceDir, "client.ts"),
-      'console.log("client");\n',
+      'import { value } from "platform-alias";\nconsole.log(value);\n',
+    ),
+    fs.promises.writeFile(
+      path.join(sourceDir, "client-value.ts"),
+      'export const value = "client alias";\n',
+    ),
+    fs.promises.writeFile(
+      path.join(sourceDir, "server-value.ts"),
+      'export const value = "server alias";\n',
     ),
     fs.promises.writeFile(
       path.join(sourceDir, "shared-all.ts"),
@@ -229,7 +257,7 @@ async function writeFixture(cwd: string): Promise<void> {
     ),
     fs.promises.writeFile(
       path.join(sourceDir, "server.ts"),
-      'import { sharedPrimary } from "./shared-primary";\nexport const serverEntry = sharedPrimary;\n',
+      'import { value } from "platform-alias";\nimport { sharedPrimary } from "./shared-primary";\nexport const serverEntry = value + " " + sharedPrimary;\n',
     ),
     fs.promises.writeFile(
       path.join(sourceDir, "dashboard.server.ts"),
@@ -240,4 +268,15 @@ async function writeFixture(cwd: string): Promise<void> {
       'import { sharedAll } from "./shared-all";\nexport const detailEntry = sharedAll;\n',
     ),
   ]);
+}
+
+async function readJavaScriptOutput(dir: string): Promise<string> {
+  const files = (await fs.promises.readdir(dir, { recursive: true })).filter(
+    (file) => file.endsWith(".js"),
+  );
+  return (
+    await Promise.all(
+      files.map((file) => fs.promises.readFile(path.join(dir, file), "utf-8")),
+    )
+  ).join("\n");
 }


### PR DESCRIPTION
## Summary

- require `@utoo/pack` 1.5.4 and map `BuildPlan.server.resolve.alias` to its official `server.resolve.alias` input
- keep shared aliases in top-level `resolve.alias`, allowing matching client/server specifiers to resolve differently
- preserve project-relative alias replacements because Utoopack 1.5.4 does not resolve the adapter's previous absolute replacement form
- remove the obsolete mixed-plan rejection and temporary compatibility type
- update English/Chinese config docs and the Unreleased changelog entry

Upstream support: https://github.com/utooland/utoo/pull/3296

## Validation

- real Utoopack 1.5.4 mixed client/server build verifies the same specifier resolves to separate client and server modules
- `npm run check-types`
- `npm run lint`
- `npm test`
- `npm --workspace evjs-docs run build`
- `git diff --check`

## Changelog

A changelog update is included because this changes user-visible behavior: mixed Utoopack builds no longer reject `server.resolve.alias`, and project-relative aliases remain resolvable with Utoopack 1.5.4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed mixed client/server builds so server-specific aliases resolve independently from client aliases.
  - Preserved project-relative alias paths and allowed the same alias to target different implementations in client and server output.
  - Removed the previous failure when using server-specific resolution settings.

- **Documentation**
  - Updated configuration documentation in English and Chinese to describe server-scoped aliases and related server settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->