### PR TITLE
feat(ev): emit CSR fallback HTML for MPA SSR pages

### DIFF
--- a/docs/docs/build.md
+++ b/docs/docs/build.md
@@ -113,9 +113,12 @@ keeps the Application shell separately at `__evjs/<application-id>.html`.
 
 MPA keeps those semantic routes internally but exposes Page Documents as HTML
 URLs: `/` writes and serves `index.html`, `/report` uses `report.html`, and
-`/foo/bar` uses `foo/bar.html`. CSR emits those files; SSR and PPR use the same
-URLs for request-time rendering. Outputs are derived from route segments, not
-Page ids.
+`/foo/bar` uses `foo/bar.html`. CSR emits those files directly. An ordinary MPA
+SSR Page with a Page client entry also emits the same canonical HTML as an
+empty, independently bootable CSR fallback, while its route remains
+server-rendered. PPR and RSC Pages remain request-time-only because they do not
+have an ordinary Page client entry. Outputs are derived from route segments,
+not Page ids.
 
 MPA materializes only static Page routes. `$param` and terminal
 `$...splat` remain valid SPA route identities, but selecting MPA for either
@@ -166,8 +169,12 @@ generated runtime artifact. Plugin `transformHtml` hooks run after
 framework metadata, assets, and structured HTML contributions materialize and
 may explicitly override the result.
 
-For every server-rendered Page, evjs compiles its configured HTML template into
-a request-time document shell during the build. This preserves authored
+Every server-rendered Page receives a request-time document shell during the
+build. For an MPA SSR Page with a CSR fallback, evjs first applies assets,
+structured HTML contributions, and `transformHtml` to the canonical fallback,
+then derives the server shell from that final Document without running the hook
+again. Other server-rendered Pages compile their configured template directly
+into the shell. This preserves authored
 `<html>`, `<head>`, and `<body>` attributes and content while applying the same
 assets, Page metadata, `html.tag` contributions, and `transformHtml` hooks as a
 static Document. The default React renderer inserts the Page HTML and

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
@@ -105,8 +105,10 @@ shell 单独保留在 `__evjs/<application-id>.html`。
 
 MPA 在内部保留这些语义 route，但通过 HTML URL 暴露 Page Document：`/` 写入并
 访问 `index.html`，`/report` 使用 `report.html`，`/foo/bar` 使用
-`foo/bar.html`。CSR 会发射这些文件；SSR 与 PPR 的请求时渲染也使用相同 URL。
-输出由 route segment 推导，不使用 Page id。
+`foo/bar.html`。CSR 会直接发射这些文件。具有 Page client entry 的普通 MPA SSR
+Page 也会把同一 canonical HTML 发射为空 mount、可独立启动的 CSR fallback，同时
+保持其 route 由服务端渲染。PPR 与 RSC Page 没有普通 Page client entry，因此仍只在
+请求时渲染。输出由 route segment 推导，不使用 Page id。
 
 MPA 只物化静态 Page route。`$param` 与终止 `$...splat` 仍是有效的 SPA
 route 身份，但为它们选择 MPA 会在 graph 校验失败，因为一个动态 pattern
@@ -152,8 +154,11 @@ static graph data，除非能力所属插件把它显式投影到 generated runt
 Plugin `transformHtml` hook 在框架元信息、assets 与结构化 HTML contribution
 物化后运行，可以显式覆盖最终结果。
 
-每个 server-rendered Page 都会在构建期把它配置的 HTML 模板编译成
-request-time document shell。模板中手写的 `<html>`、`<head>`、`<body>` 属性和
+每个 server-rendered Page 都会在构建期获得 request-time document shell。对于具有
+CSR fallback 的 MPA SSR Page，evjs 会先在 canonical fallback 上应用 assets、结构化
+HTML contribution 与 `transformHtml`，再从最终 Document 派生 server shell，不会
+再次执行 hook。其他 server-rendered Page 则直接把配置的模板编译成 shell。模板中
+手写的 `<html>`、`<head>`、`<body>` 属性和
 内容会被保留，同时应用与 static Document 相同的 assets、Page metadata、
 `html.tag` contribution 和 `transformHtml` hook。默认 React renderer 在请求时把
 Page HTML 与请求相关的 bootstrap data 插入该 shell。

--- a/packages/client/src/rsc/react.ts
+++ b/packages/client/src/rsc/react.ts
@@ -69,6 +69,7 @@ interface MountedReactRoot {
   root: Root;
 }
 
+const PAGE_HYDRATION_ATTRIBUTE = "data-evjs-hydrate";
 const rootByMountPoint = new WeakMap<Element, MountedReactRoot>();
 
 export function createReactPageModule(
@@ -197,7 +198,7 @@ export function mountReactPage(options: ReactPageRuntimeOptions): void {
 
   const mountPoint = resolveMountPoint(options.mount);
   const mod = createReactPageModule(options);
-  if (shouldHydrate(options)) {
+  if (mountPoint.getAttribute(PAGE_HYDRATION_ATTRIBUTE) === "load") {
     void mod.hydrate?.(mountPoint, {} as AppContext);
     return;
   }

--- a/packages/client/tests/react-runtime.test.ts
+++ b/packages/client/tests/react-runtime.test.ts
@@ -336,6 +336,42 @@ describe("createReactPageModule", () => {
     );
   });
 
+  it("mounts an unmarked SSR fallback with createRoot", () => {
+    calls.length = 0;
+    renderedElements.length = 0;
+    const mountPoint = {
+      getAttribute: vi.fn(() => null),
+    } as unknown as Element;
+
+    mountReactPage({
+      component: Component,
+      mount: mountPoint,
+      render: "ssr",
+      hydrate: "load",
+    });
+
+    expect(calls).toEqual(["createRoot", "render"]);
+  });
+
+  it("hydrates SSR content only when the mount has a server marker", () => {
+    calls.length = 0;
+    renderedElements.length = 0;
+    const mountPoint = {
+      getAttribute: vi.fn((name: string) =>
+        name === "data-evjs-hydrate" ? "load" : null,
+      ),
+    } as unknown as Element;
+
+    mountReactPage({
+      component: Component,
+      mount: mountPoint,
+      render: "ssr",
+      hydrate: "load",
+    });
+
+    expect(calls).toEqual(["hydrateRoot"]);
+  });
+
   it("reports mount selector resolution failures with evjs errors", () => {
     expect(() =>
       mountReactPage({ component: Component, mount: "#app" }),

--- a/packages/ev/src/_internal/build/framework-html-document.ts
+++ b/packages/ev/src/_internal/build/framework-html-document.ts
@@ -17,8 +17,9 @@ export function createFrameworkHtmlDocument<TBundlerCfg>(options: {
   plan: BuildPlan;
   html: HtmlDocumentInfo;
   clientRuntime: ReturnType<typeof createClientRuntime>;
+  purpose: "client-document" | "server-shell";
 }): ReturnType<typeof generateHtml> {
-  const { cwd, config, output, plan, html, clientRuntime } = options;
+  const { cwd, config, output, plan, html, clientRuntime, purpose } = options;
   const doc = generateHtml({
     template: path.resolve(cwd, html.template),
     publicPath: output.publicPath,
@@ -48,7 +49,7 @@ export function createFrameworkHtmlDocument<TBundlerCfg>(options: {
     applyPageMetadataToHtmlDocument(doc, page?.metadata, {
       preserveBaseline: hasSpaApplicationEntry(plan, html.applicationId),
     });
-    markPageHydrationTarget(doc, page);
+    preparePageMount(doc, page, purpose);
   }
   applyHtmlTagContributions(doc, html, plan);
   return doc;
@@ -75,7 +76,21 @@ function withHtmlAssetCrossOrigin(
   }));
 }
 
-function markPageHydrationTarget(
+function preparePageMount(
+  doc: ReturnType<typeof generateHtml>,
+  page: BuildOutput["pages"][string] | undefined,
+  purpose: "client-document" | "server-shell",
+): void {
+  const mount = page ? doc.querySelector(page.mount ?? "#app") : null;
+  if (purpose === "client-document" && page?.render === "ssr") {
+    if (mount) mount.innerHTML = "";
+    return;
+  }
+  markServerPageHydrationTarget(doc, page);
+}
+
+/** Add the server-owned hydration signal to an already generated Document. */
+export function markServerPageHydrationTarget(
   doc: ReturnType<typeof generateHtml>,
   page: BuildOutput["pages"][string] | undefined,
 ): void {

--- a/packages/ev/src/_internal/build/framework-output.ts
+++ b/packages/ev/src/_internal/build/framework-output.ts
@@ -55,7 +55,10 @@ import {
   FRAMEWORK_DEPLOYMENT_METADATA_FILE_NAME,
   portableArtifactPathsConflict,
 } from "./portable-artifact-path.js";
-import { compileServerDocumentShells } from "./server-document-shell.js";
+import {
+  type CanonicalClientPageDocument,
+  compileServerDocumentShells,
+} from "./server-document-shell.js";
 
 const RUNTIME_ONLY_BUNDLER_MANIFEST_FILES = [
   "react-client-manifest.json",
@@ -592,6 +595,103 @@ type PageHtmlDocumentInfo = HtmlDocumentInfo & {
   owner: { kind: "page"; pageId: string };
 };
 
+async function compileFrameworkHtmlDocument<TBundlerCfg>(options: {
+  cwd: string;
+  config: ResolvedConfig<TBundlerCfg>;
+  hooks: PluginHooks<TBundlerCfg>[];
+  pluginCtx: PluginSetupContext<TBundlerCfg>;
+  output: BuildOutput;
+  plan: BuildPlan;
+  html: HtmlDocumentInfo;
+  clientRuntime: ReturnType<typeof createClientRuntime>;
+  isRebuild: boolean;
+  staticPage?: {
+    frameworkRuntime: ReturnType<typeof createFrameworkRuntime>;
+    serverDir: string;
+    loadServerModule?: (asset: string) => Promise<unknown>;
+  };
+}): Promise<string> {
+  const doc = createFrameworkHtmlDocument({
+    cwd: options.cwd,
+    config: options.config,
+    output: options.output,
+    plan: options.plan,
+    html: options.html,
+    clientRuntime: options.clientRuntime,
+    purpose: "client-document",
+  });
+  if (
+    options.staticPage &&
+    shouldPrerenderStaticPage(options.output, options.html)
+  ) {
+    await prerenderStaticPageHtml({
+      doc,
+      output: options.output,
+      html: options.html,
+      frameworkRuntime: options.staticPage.frameworkRuntime,
+      serverDir: options.staticPage.serverDir,
+      loadServerModule: options.staticPage.loadServerModule,
+    });
+  }
+  return buildHtml({
+    doc,
+    hooks: options.hooks,
+    pluginContext: options.pluginCtx,
+    html: options.html,
+    output: options.output,
+    isRebuild: options.isRebuild,
+  });
+}
+
+/**
+ * Compile MPA SSR fallback Documents before request-time shells. Each returned
+ * HTML string is the canonical, fully transformed client Document from which
+ * the corresponding server shell is derived.
+ */
+async function compileCanonicalClientPageDocuments<TBundlerCfg>(options: {
+  cwd: string;
+  config: ResolvedConfig<TBundlerCfg>;
+  hooks: PluginHooks<TBundlerCfg>[];
+  pluginCtx: PluginSetupContext<TBundlerCfg>;
+  output: BuildOutput;
+  plan: BuildPlan;
+  isRebuild: boolean;
+}): Promise<Map<string, CanonicalClientPageDocument>> {
+  const { cwd, config, hooks, pluginCtx, output, plan, isRebuild } = options;
+  const serverPageIds = new Set(
+    plan.server.documents?.map((document) => document.pageId) ?? [],
+  );
+  const documents = new Map<string, CanonicalClientPageDocument>();
+  const clientRuntime = createClientRuntime(output);
+
+  for (const html of plan.html) {
+    const htmlInfo = createHtmlDocumentInfo(html, output);
+    if (
+      htmlInfo?.owner.kind !== "page" ||
+      !serverPageIds.has(htmlInfo.owner.pageId)
+    ) {
+      continue;
+    }
+    const finalHtml = await compileFrameworkHtmlDocument({
+      cwd,
+      config,
+      hooks,
+      pluginCtx,
+      output,
+      plan,
+      html: htmlInfo,
+      clientRuntime,
+      isRebuild,
+    });
+    documents.set(htmlInfo.owner.pageId, {
+      html: finalHtml,
+      fileName: htmlInfo.fileName,
+    });
+  }
+
+  return documents;
+}
+
 async function emitFrameworkHtml<TBundlerCfg>(
   cwd: string,
   config: ResolvedConfig<TBundlerCfg>,
@@ -601,6 +701,7 @@ async function emitFrameworkHtml<TBundlerCfg>(
   plan: BuildPlan,
   frameworkRuntime: ReturnType<typeof createFrameworkRuntime>,
   isRebuild: boolean,
+  canonicalClientDocuments: ReadonlyMap<string, CanonicalClientPageDocument>,
   previousHtmlOutput?: PreviousFrameworkHtmlOutput,
   bundlerClientFiles?: readonly string[],
   loadServerModule?: (asset: string) => Promise<unknown>,
@@ -624,32 +725,26 @@ async function emitFrameworkHtml<TBundlerCfg>(
     const htmlInfo = createHtmlDocumentInfo(html, output);
     if (!htmlInfo) continue;
 
-    const doc = createFrameworkHtmlDocument({
+    const canonicalClientDocument =
+      htmlInfo.owner.kind === "page"
+        ? canonicalClientDocuments.get(htmlInfo.owner.pageId)
+        : undefined;
+    let finalHtml = canonicalClientDocument?.html;
+    finalHtml ??= await compileFrameworkHtmlDocument({
       cwd,
       config,
+      hooks,
+      pluginCtx,
       output,
       plan,
       html: htmlInfo,
       clientRuntime,
-    });
-    if (shouldPrerenderStaticPage(output, htmlInfo)) {
-      await prerenderStaticPageHtml({
-        doc,
-        output,
-        html: htmlInfo,
+      isRebuild,
+      staticPage: {
         frameworkRuntime,
         serverDir,
-        loadServerModule,
-      });
-    }
-
-    const finalHtml = await buildHtml({
-      doc,
-      hooks,
-      pluginContext: pluginCtx,
-      html: htmlInfo,
-      output,
-      isRebuild,
+        ...(loadServerModule ? { loadServerModule } : {}),
+      },
     });
 
     for (const fileName of [html.fileName, ...(html.aliases ?? [])]) {
@@ -943,6 +1038,15 @@ export async function linkAndEmitBuildOutput<TBundlerCfg>(options: {
     assertBuildOutputHookResult,
   );
   assertBuildOutputHookResult();
+  const canonicalClientDocuments = await compileCanonicalClientPageDocuments({
+    cwd: options.cwd,
+    config: options.config,
+    hooks: options.hooks,
+    pluginCtx: options.pluginCtx,
+    output,
+    plan: options.plan,
+    isRebuild: options.isRebuild,
+  });
   const documentShells = await compileServerDocumentShells({
     cwd: options.cwd,
     config: options.config,
@@ -951,6 +1055,7 @@ export async function linkAndEmitBuildOutput<TBundlerCfg>(options: {
     output,
     plan: options.plan,
     isRebuild: options.isRebuild,
+    canonicalClientDocuments,
   });
   const frameworkRuntime = createFrameworkRuntime(output, {
     rscManifests: options.bundlerFacts.rscManifests,
@@ -980,6 +1085,7 @@ export async function linkAndEmitBuildOutput<TBundlerCfg>(options: {
     options.plan,
     buildFrameworkRuntime,
     options.isRebuild,
+    canonicalClientDocuments,
     previousHtmlOutput,
     options.bundlerFacts.emittedFiles?.client,
     options.bundlerFacts.loadServerModule,

--- a/packages/ev/src/_internal/build/html.ts
+++ b/packages/ev/src/_internal/build/html.ts
@@ -125,11 +125,19 @@ export function validateHtmlTemplate(
   return parseHtmlTemplate(options).doc;
 }
 
-function parseHtmlTemplate({
-  template,
-  displayName = template,
-}: ValidateHtmlTemplateOptions): ParsedHtmlTemplate {
-  const templateContent = fs.readFileSync(template, "utf-8");
+/** Parse an already generated HTML Document without reading another template. */
+export function parseHtmlDocument(
+  source: string,
+  displayName = "HTML Document",
+): HtmlDocument {
+  return parseHtmlTemplate({ template: displayName, displayName }, source).doc;
+}
+
+function parseHtmlTemplate(
+  { template, displayName = template }: ValidateHtmlTemplateOptions,
+  source?: string,
+): ParsedHtmlTemplate {
+  const templateContent = source ?? fs.readFileSync(template, "utf-8");
   const doc = parser.parseFromString(
     templateContent,
     "text/html",

--- a/packages/ev/src/_internal/build/plan/index.ts
+++ b/packages/ev/src/_internal/build/plan/index.ts
@@ -1028,9 +1028,14 @@ function shouldEmitDocumentForPage(page: BuildPageFacts): boolean {
     return true;
   }
 
-  // Static SSG Pages emit Page-owned Documents in either mode. CSR Page
-  // Documents are emitted only by canonical MPA materialization.
-  return page.routingMode === "mpa" && page.render === "csr";
+  // Static SSG Pages emit Page-owned Documents in either mode. Canonical MPA
+  // Pages with a browser entry also emit a Page-owned client Document. For
+  // SSR this is an empty CSR fallback alongside the request-time server shell.
+  return (
+    page.routingMode === "mpa" &&
+    (page.render === "csr" ||
+      (page.render === "ssr" && getPageClientEntry(page) !== undefined))
+  );
 }
 
 function isStaticPagePath(pathname: string): boolean {

--- a/packages/ev/src/_internal/build/server-document-shell.ts
+++ b/packages/ev/src/_internal/build/server-document-shell.ts
@@ -12,15 +12,21 @@ import type {
 import {
   CLIENT_RUNTIME_SCRIPT_ID,
   createFrameworkHtmlDocument,
+  markServerPageHydrationTarget,
 } from "./framework-html-document.js";
 import { createClientRuntime } from "./framework-runtime.js";
-import type { generateHtml } from "./html.js";
+import { type generateHtml, parseHtmlDocument } from "./html.js";
 import { buildHtml } from "./html-transform.js";
 
 const PAGE_CONTENT_MARKER = "__EVJS_SERVER_PAGE_CONTENT__";
 const REQUEST_DATA_MARKER = "__EVJS_SERVER_PAGE_DATA__";
 const PAGE_CONTENT_COMMENT = `<!--${PAGE_CONTENT_MARKER}-->`;
 const REQUEST_DATA_COMMENT = `<!--${REQUEST_DATA_MARKER}-->`;
+
+export interface CanonicalClientPageDocument {
+  html: string;
+  fileName: string;
+}
 
 export async function compileServerDocumentShells<TBundlerCfg>(options: {
   cwd: string;
@@ -30,8 +36,18 @@ export async function compileServerDocumentShells<TBundlerCfg>(options: {
   output: BuildOutput;
   plan: BuildPlan;
   isRebuild: boolean;
+  canonicalClientDocuments?: ReadonlyMap<string, CanonicalClientPageDocument>;
 }): Promise<Record<string, ServerDocumentShell>> {
-  const { cwd, config, hooks, pluginCtx, output, plan, isRebuild } = options;
+  const {
+    cwd,
+    config,
+    hooks,
+    pluginCtx,
+    output,
+    plan,
+    isRebuild,
+    canonicalClientDocuments,
+  } = options;
   const shells = Object.create(null) as Record<string, ServerDocumentShell>;
   const clientRuntime = createClientRuntime(output);
 
@@ -55,6 +71,27 @@ export async function compileServerDocumentShells<TBundlerCfg>(options: {
       fileName: serverDocument.fileName,
       assets: page.assets,
     };
+    const canonicalClientDocument = canonicalClientDocuments?.get(
+      serverDocument.pageId,
+    );
+    if (canonicalClientDocument) {
+      const doc = parseHtmlDocument(
+        canonicalClientDocument.html,
+        canonicalClientDocument.fileName,
+      );
+      markServerPageHydrationTarget(doc, page);
+      insertDocumentMarkers(
+        doc,
+        page.mount ?? serverDocument.mount,
+        serverDocument.pageId,
+      );
+      shells[serverDocument.pageId] = splitDocumentShell(
+        doc.toString(),
+        serverDocument.pageId,
+      );
+      continue;
+    }
+
     const doc = createFrameworkHtmlDocument({
       cwd,
       config,
@@ -62,6 +99,7 @@ export async function compileServerDocumentShells<TBundlerCfg>(options: {
       plan,
       html: htmlInfo,
       clientRuntime,
+      purpose: "server-shell",
     });
     insertDocumentMarkers(
       doc,

--- a/packages/ev/tests/build-tools-graph-plan.test.ts
+++ b/packages/ev/tests/build-tools-graph-plan.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   type CoreGraph,
+  createDeploymentMetadata,
   linkBuildOutput,
   PAGE_ANCHOR_PROVIDER_ID,
 } from "@evjs/shared/manifest";
@@ -65,6 +66,87 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
     expect(second.buildId).not.toBe(first.buildId);
     expect(development.buildId).toBe("development");
     expect(explicit.buildId).toBe("release-42");
+  });
+
+  it.each([
+    { mode: "spa", render: "csr", pageDocument: false },
+    { mode: "spa", render: "ssr", pageDocument: false },
+    { mode: "spa", render: "ssg", pageDocument: true },
+    { mode: "mpa", render: "csr", pageDocument: true },
+    { mode: "mpa", render: "ssr", pageDocument: true },
+    { mode: "mpa", render: "ssg", pageDocument: true },
+  ] as const)("plans $mode $render Page Document materialization", async ({
+    mode,
+    render,
+    pageDocument,
+  }) => {
+    const cwd = await createFixture({
+      "src/pages/page.tsx": "export default function Home() { return null; }",
+      "src/pages/page.config.ts": `export default { render: ${JSON.stringify(render)} };`,
+      "index.html": '<main id="app"></main>',
+    });
+    const config = await createCanonicalConfig(cwd, mode);
+    const analysis = await createCoreGraph(config, cwd);
+    const plan = createBuildPlan(config, analysis.graph, {
+      mode: "production",
+    });
+
+    expect(
+      plan.html.some((document) => document.owner.pageId === "index"),
+    ).toBe(pageDocument);
+    expect(
+      plan.server.documents?.some((document) => document.pageId === "index") ??
+        false,
+    ).toBe(render === "ssr");
+  });
+
+  it("links an MPA SSR fallback Document without changing its deployment route", async () => {
+    const cwd = await createFixture({
+      "src/pages/about/page.tsx":
+        "export default function About() { return null; }",
+      "src/pages/about/page.config.ts":
+        'export default { render: "ssr", hydrate: "load" };',
+      "index.html": '<main id="app"></main>',
+    });
+    const config = await createCanonicalConfig(cwd, "mpa");
+    const analysis = await createCoreGraph(config, cwd);
+    const plan = createBuildPlan(config, analysis.graph, {
+      mode: "production",
+    });
+    const clientEntry = createPageClientBuildEntryName("about");
+    const output = linkBuildOutput({
+      graph: analysis.graph,
+      plan,
+      clientEntryAssets: {
+        [clientEntry]: { js: [`${clientEntry}.js`], css: [] },
+      },
+      serverEntryAssets: Object.fromEntries(
+        plan.entries
+          .filter((entry) => entry.environment === "server")
+          .map((entry) => [entry.name, { js: [`${entry.name}.js`], css: [] }]),
+      ),
+    });
+
+    expect(output.pages.about.document).toEqual({ fileName: "about.html" });
+    expect(createDeploymentMetadata(output)).toMatchObject({
+      documents: [
+        {
+          kind: "page",
+          id: "about",
+          fileName: "about.html",
+          assets: { js: [`${clientEntry}.js`], css: [] },
+        },
+      ],
+      routes: [
+        {
+          kind: "server-page",
+          path: "/about",
+          pageId: "about",
+          render: "ssr",
+          methods: ["GET", "HEAD"],
+        },
+      ],
+    });
   });
 
   it("projects server-only build settings", async () => {
@@ -1125,6 +1207,9 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
         .filter((entry) => entry.kind === "page-client")
         .map((entry) => entry.owner?.pageId),
     ).toEqual(["ssr"]);
+    expect(
+      new Set(plan.html.flatMap((document) => document.owner.pageId ?? [])),
+    ).toEqual(new Set(["ssg", "ssr"]));
     expect(plan.server.renderers?.map((renderer) => renderer.kind)).toEqual(
       expect.arrayContaining([
         "page-server",
@@ -2616,7 +2701,7 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
     expect(configUpdate.deliveryChanged).toBe(true);
   });
 
-  it("separates server Document refreshes from server compilation changes", async () => {
+  it("refreshes MPA SSR fallback and server Documents without recompiling", async () => {
     const cwd = await createFixture({
       "src/pages/page.tsx": "export default function Home() { return null; }",
       "src/pages/page.config.ts": 'export default { render: "ssr" };',
@@ -2637,7 +2722,22 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
     const update = diffBuildPlan(previous, next, "route-declaration");
 
     expect(update.entries).toEqual({ added: [], removed: [], changed: [] });
-    expect(update.html).toEqual({ added: [], removed: [], changed: [] });
+    expect(update.html).toEqual({
+      added: [],
+      removed: [],
+      changed: [
+        {
+          id: "index",
+          template: "./index.html",
+          fileName: "index.html",
+          owner: { appId: "default", pageId: "index" },
+          metadata: {
+            title: "Updated home",
+            meta: { description: "Updated description" },
+          },
+        },
+      ],
+    });
     expect(update.serverCompilationChanged).toBe(false);
     expect(update.serverDocumentsChanged).toBe(true);
     expect(update.devRoutingChanged).toBe(false);

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -4763,7 +4763,12 @@ describe("build", () => {
             }
             transformedFiles.push(ctx.fileName);
             doc.documentElement?.setAttribute("data-plugin", mode);
+            doc.documentElement?.setAttribute("data-capr-version", "2026.08");
             doc.body?.setAttribute("data-transformed", "yes");
+            doc.body?.insertAdjacentHTML(
+              "beforeend",
+              '<script id="capr-runtime" src="/capr.js"></script><script id="ppr-snapshot">globalThis.__PPR__ = true;</script>',
+            );
             const title = doc.querySelector("title");
             if (title) title.textContent = "Plugin title";
           },
@@ -4835,6 +4840,7 @@ describe("build", () => {
     expect(html).toContain('<html lang="zh-CN"');
     expect(html).toContain('data-template="configured"');
     expect(html).toContain(`data-plugin="${mode}"`);
+    expect(html).toContain('data-capr-version="2026.08"');
     expect(html).toContain(
       '<body class="template-body" data-transformed="yes">',
     );
@@ -4852,7 +4858,62 @@ describe("build", () => {
     expect(html).toContain("<footer>Template footer</footer>__REQUEST_DATA__");
     expect(html).toContain('id="__EVJS_CLIENT_RUNTIME__"');
     expect(html).toContain(`src="/${clientEntryName}.js"`);
+    expect(html).toContain(
+      '<script id="capr-runtime" src="/capr.js"></script>',
+    );
+    expect(html).toContain('<script id="ppr-snapshot">');
     expect(html).not.toContain("Template fallback");
+
+    if (mode === "mpa") {
+      const fallbackHtml = await fs.promises.readFile(
+        path.join(cwd, "dist/client/dashboard.html"),
+        "utf-8",
+      );
+      const deployment = JSON.parse(
+        await fs.promises.readFile(
+          path.join(cwd, "dist/deployment-metadata.json"),
+          "utf-8",
+        ),
+      );
+
+      expect(fallbackHtml).toContain('data-plugin="mpa"');
+      expect(fallbackHtml).toContain('data-capr-version="2026.08"');
+      expect(fallbackHtml).toContain('data-transformed="yes"');
+      expect(fallbackHtml).toContain(
+        '<meta name="from-contribution" content="mpa">',
+      );
+      expect(fallbackHtml).toContain('<main id="app"></main>');
+      expect(fallbackHtml).not.toContain("data-evjs-hydrate");
+      expect(fallbackHtml).not.toContain("Template fallback");
+      expect(fallbackHtml).toContain('id="__EVJS_CLIENT_RUNTIME__"');
+      expect(fallbackHtml).toContain(`src="/${clientEntryName}.js"`);
+      expect(fallbackHtml).toContain(
+        '<script id="capr-runtime" src="/capr.js"></script>',
+      );
+      expect(fallbackHtml).toContain('<script id="ppr-snapshot">');
+      expect(
+        html
+          .replace(' data-evjs-hydrate="load"', "")
+          .replace("__PAGE_CONTENT__", "")
+          .replace("__REQUEST_DATA__", ""),
+      ).toBe(fallbackHtml);
+      expect(deployment.documents).toContainEqual({
+        kind: "page",
+        id: "dashboard",
+        fileName: "dashboard.html",
+        assets: {
+          js: clientAssets.js,
+          css: [...clientAssets.css, `${pageServerEntryName}.css`],
+        },
+      });
+      expect(deployment.routes).toContainEqual({
+        kind: "server-page",
+        path: "/dashboard",
+        pageId: "dashboard",
+        render: "ssr",
+        methods: ["GET", "HEAD"],
+      });
+    }
   });
 
   it("rejects transformHtml hooks that remove server document markers", async () => {

--- a/packages/ev/tests/config-route.test.ts
+++ b/packages/ev/tests/config-route.test.ts
@@ -764,6 +764,7 @@ describe("explicit SPA route graph", () => {
         assets: output.pages.report.assets,
       },
       clientRuntime: createClientRuntime(output),
+      purpose: "client-document",
     });
 
     expect(doc.querySelector("title")?.textContent).toBe("Report");


### PR DESCRIPTION
## Summary

- emit canonical, independently bootable CSR fallback HTML for hydratable MPA SSR pages
- derive request-time server Document shells from the transformed fallback so HTML hooks run once
- keep fallback mounts empty and unmarked so client startup uses createRoot, while server shells retain hydration markers
- project fallback Documents into BuildOutput and deployment metadata without changing SSR routes from server-page
- document the MPA SSR fallback lifecycle in English and Chinese

## Validation

- npm run check-types
- npm run lint
- npm test
- npm run build in docs
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MPA server-rendered pages with client entries now generate independently bootable HTML fallbacks alongside server-rendered routes.
  * Client-side rendering and hydration now follow the page’s explicit hydration setting, improving compatibility for SSR fallbacks.
  * Generated deployment metadata now includes fallback documents and server-page route details.

* **Documentation**
  * Updated build documentation in English and Simplified Chinese to explain MPA, SSR, PPR, and RSC output behavior.

* **Tests**
  * Added coverage for fallback generation, hydration behavior, metadata, and document ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->