### PR TITLE
docs(changelog): prepare v0.3.11 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ---
 
+## [0.3.11] — 2026-08-12
+
+### ✨ Features
+
+- **MPA SSR client fallback Documents** — Hydratable MPA SSR Pages now emit an
+  empty, independently bootable CSR fallback HTML Document with their client
+  assets and HTML transforms. Request-time server shells derive from that same
+  transformed Document while preserving server-rendered deployment routes.
+
+---
+
 ## [0.3.10] — 2026-08-12
 
 ### ✨ Features


### PR DESCRIPTION
## Summary

- prepare the changelog for the next stable 0.3 release, v0.3.11
- capture the user-facing MPA SSR CSR fallback behavior merged after v0.3.10

## Changes

- document canonical, independently bootable CSR fallback Documents for hydratable MPA SSR Pages from #99
- document that request-time server shells derive from the same transformed Document
- document that SSR deployment routes remain server-rendered
- update the release date to 2026-08-12
- leave source package versions and internal dependency ranges unchanged; release automation owns publish-time versioning

## Validation

- `npm run lint`
- `npm run check-types` (push hook)
- `npm --workspace evjs-docs run build`
- `git diff --check`

## Risk / rollout

- low risk: this PR changes only release metadata in `CHANGELOG.md`
- publishing occurs separately when the v0.3.11 GitHub Release is created after merge

## Reviewer notes

- verify the v0.3.11 entry matches the complete `v0.3.10...main` commit range
