### PR TITLE
feat(ev): add configurable client compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+### ✨ Features
+
+- **Low-end browser compatibility** — Applications can opt into Android 5 and
+  iOS 8 or newer targets with ES5 syntax by configuring numeric Android/iOS
+  versions, which bundle `core-js/stable` by default. An absolute
+  `polyfill.coreJs` UMD URL overrides the bundled source. Server targets are
+  unchanged.
+
 ---
 
 ## [0.3.10] — 2026-08-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 ### ✨ Features
 
 - **Low-end browser compatibility** — Applications can opt into Android 5 and
-  iOS 8 or newer targets with ES5 syntax by configuring numeric Android/iOS
-  versions, which bundle `core-js/stable` by default. An absolute
-  `polyfill.coreJs` UMD URL overrides the bundled source. Server targets are
-  unchanged.
+  iOS 8 or newer production targets with ES5 syntax by configuring numeric
+  Android/iOS versions, which bundle `core-js/stable` by default. An absolute
+  `polyfill.coreJs` UMD URL overrides the bundled source. Development and server
+  targets are unchanged.
 
 ---
 

--- a/docs/docs/build.md
+++ b/docs/docs/build.md
@@ -98,23 +98,23 @@ or edit deployment metadata.
 
 Browser compatibility is enabled with a browser target such as
 `target: { android: 5, ios: 8 }`. The configured Android/iOS versions become
-the Browserslist target, and
-their JavaScript syntax output is ES5 in development and production. Webpack
-transpiles both application code and client-side framework/third-party
-dependencies to that syntax baseline; semantic server-function and RSC loaders
-remain scoped to project source. Utoopack receives the same Android/iOS target.
-When `target` is omitted, adapters retain their existing client targets and
-dependency transpilation scope and no core-js is injected.
+the production Browserslist target, and production JavaScript syntax output is
+ES5. Webpack transpiles both application code and client-side framework/third-party
+dependencies to that syntax baseline in production; semantic server-function
+and RSC loaders remain scoped to project source. Utoopack receives the same
+Android/iOS production target. Development retains each adapter's existing
+client target and dependency transpilation scope and does not inject core-js.
+When `target` is omitted, production also retains that existing behavior.
 
 The compatibility target is framework-owned: a plugin `configureBundler()`
 hook cannot replace it. Node, build-time, server-function, and server-renderer
 compilations retain their existing Node target.
 
-Targeted client entries bundle `core-js/stable` by default. Setting an external
-`polyfill.coreJs` UMD URL removes that import and adds a blocking script before
-EVJS runtime data and deferred client bundles in every Document with client
-JavaScript. See [Polyfills](./config#polyfills) for configuration, loading order,
-scope, and bundle-size details.
+Targeted production client entries bundle `core-js/stable` by default. Setting
+an external `polyfill.coreJs` UMD URL removes that import and adds a blocking
+script before EVJS runtime data and deferred client bundles in every production
+Document with client JavaScript. See [Polyfills](./config#polyfills) for
+configuration, loading order, scope, and bundle-size details.
 
 ## SPA And MPA Output
 

--- a/docs/docs/build.md
+++ b/docs/docs/build.md
@@ -94,6 +94,28 @@ Generated HTML embeds the `ClientRuntime` required by browser bootstrap.
 the complete `BuildOutput` remains in memory. Application code must not import
 or edit deployment metadata.
 
+## Browser Compatibility
+
+Browser compatibility is enabled with a browser target such as
+`target: { android: 5, ios: 8 }`. The configured Android/iOS versions become
+the Browserslist target, and
+their JavaScript syntax output is ES5 in development and production. Webpack
+transpiles both application code and client-side framework/third-party
+dependencies to that syntax baseline; semantic server-function and RSC loaders
+remain scoped to project source. Utoopack receives the same Android/iOS target.
+When `target` is omitted, adapters retain their existing client targets and
+dependency transpilation scope and no core-js is injected.
+
+The compatibility target is framework-owned: a plugin `configureBundler()`
+hook cannot replace it. Node, build-time, server-function, and server-renderer
+compilations retain their existing Node target.
+
+Targeted client entries bundle `core-js/stable` by default. Setting an external
+`polyfill.coreJs` UMD URL removes that import and adds a blocking script before
+EVJS runtime data and deferred client bundles in every Document with client
+JavaScript. See [Polyfills](./config#polyfills) for configuration, loading order,
+scope, and bundle-size details.
+
 ## SPA And MPA Output
 
 `routing.mode` controls route and Document materialization:

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -261,6 +261,53 @@ configuration.
 
 ## Other Configuration
 
+### Polyfills
+
+Browser compatibility is opt-in and controlled by `target`. When `target` is
+omitted, evjs does not inject core-js or replace the adapters' existing client
+targets.
+
+Use a target object to select supported Android and iOS versions, emit ES5 syntax, and
+bundle the framework-owned `core-js/stable` bridge. Every generated client facade
+imports the bridge before plugin `polyfill` entry contributions and the application
+entry. This covers ECMAScript built-in features and increases the client bundle size.
+
+```ts
+export default defineConfig({
+  target: { android: 5, ios: 8 },
+});
+```
+
+Applications can raise either baseline, for example to
+`target: { android: 6, ios: 10 }`. Android 5 and iOS 8 are the minimum accepted
+values. Both fields are required and must be finite numbers.
+
+To load a separately hosted core-js UMD bundle instead, configure one absolute
+HTTP(S) URL alongside the target:
+
+```ts
+export default defineConfig({
+  target: { android: 6, ios: 10 },
+  polyfill: {
+    coreJs: "https://cdn.example.com/core-js-bundle.min.js",
+  },
+});
+```
+
+External mode removes the bundled core-js import. Every SPA, MPA, SSR, and SSG
+Document that contains client JavaScript receives a normal blocking
+`<script src="...">` before the embedded EVJS client runtime data and deferred
+application scripts. The configured URL is preserved exactly and is not joined
+with `publicPath`. Documents without client JavaScript do not receive the tag.
+
+`polyfill` is valid only with `target`; this prevents core-js from being
+loaded while JavaScript syntax remains untransformed. `polyfill.coreJs` accepts
+only an absolute `http:` or `https:` URL. Relative
+paths, other URL schemes, non-string values, and unknown `polyfill` fields are
+rejected during configuration resolution. This setting does not add Web API
+polyfills such as `fetch`, `AbortController`, or Streams, and does not change
+Node, build-time, or server compilation targets.
+
 ### Server
 
 When file conventions are enabled, positive `api.*` server request-route

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -263,14 +263,16 @@ configuration.
 
 ### Polyfills
 
-Browser compatibility is opt-in and controlled by `target`. When `target` is
-omitted, evjs does not inject core-js or replace the adapters' existing client
-targets.
+Production browser compatibility is opt-in and controlled by `target`. In
+development, evjs keeps the adapters' existing client targets and transpilation
+scope and does not inject core-js. When `target` is omitted, production also
+keeps that existing behavior.
 
-Use a target object to select supported Android and iOS versions, emit ES5 syntax, and
-bundle the framework-owned `core-js/stable` bridge. Every generated client facade
-imports the bridge before plugin `polyfill` entry contributions and the application
-entry. This covers ECMAScript built-in features and increases the client bundle size.
+Use a target object to select supported Android and iOS versions for production,
+emit ES5 syntax, and bundle the framework-owned `core-js/stable` bridge. Every
+production generated client facade imports the bridge before plugin `polyfill`
+entry contributions and the application entry. This covers ECMAScript built-in
+features and increases the production client bundle size.
 
 ```ts
 export default defineConfig({
@@ -294,8 +296,8 @@ export default defineConfig({
 });
 ```
 
-External mode removes the bundled core-js import. Every SPA, MPA, SSR, and SSG
-Document that contains client JavaScript receives a normal blocking
+External mode removes the bundled core-js import. Every production SPA, MPA,
+SSR, and SSG Document that contains client JavaScript receives a normal blocking
 `<script src="...">` before the embedded EVJS client runtime data and deferred
 application scripts. The configured URL is preserved exactly and is not joined
 with `publicPath`. Documents without client JavaScript do not receive the tag.

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
@@ -86,6 +86,24 @@ Bundler server fact 使用 `serverEntryAssets`，并以每个 server BuildPlan e
 完整 `BuildOutput` 只存在于内存中。应用代码不得 import 或编辑 deployment
 metadata。
 
+## 浏览器兼容性
+
+配置如 `target: { android: 5, ios: 8 }` 的浏览器目标时会启用低端浏览器兼容。
+配置的 Android/iOS 版本会成为 client 与 mixed build 的 Browserslist target，
+并在开发和生产模式下都输出 ES5
+JavaScript 语法。Webpack 会把应用代码、客户端 framework 代码和第三方依赖一起
+降级到该语法基线；server-function 与 RSC 语义 loader 仍只处理项目源码。
+Utoopack 接收相同的 Android/iOS target。省略 `target` 时，适配器保留现有的
+客户端 target 和依赖转译范围，也不注入 core-js。
+
+该兼容 target 由框架持有，plugin `configureBundler()` hook 不能覆盖。Node、
+构建期、server-function 与 server-renderer 编译继续使用现有 Node target。
+
+配置 target 的客户端 entry 默认打包 `core-js/stable`。配置外部
+`polyfill.coreJs` UMD URL 后会移除该 import，并在每个包含客户端 JavaScript 的
+Document 中，把阻塞式脚本放到 EVJS runtime 数据和带 `defer` 的 client bundle
+之前。配置、加载顺序、能力范围与体积影响详见 [Polyfill](./config#polyfill)。
+
 ## SPA 与 MPA 输出
 
 `routing.mode` 控制 Route/Document materialization：

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/build.md
@@ -89,20 +89,21 @@ metadata。
 ## 浏览器兼容性
 
 配置如 `target: { android: 5, ios: 8 }` 的浏览器目标时会启用低端浏览器兼容。
-配置的 Android/iOS 版本会成为 client 与 mixed build 的 Browserslist target，
-并在开发和生产模式下都输出 ES5
-JavaScript 语法。Webpack 会把应用代码、客户端 framework 代码和第三方依赖一起
-降级到该语法基线；server-function 与 RSC 语义 loader 仍只处理项目源码。
-Utoopack 接收相同的 Android/iOS target。省略 `target` 时，适配器保留现有的
-客户端 target 和依赖转译范围，也不注入 core-js。
+配置的 Android/iOS 版本会成为生产 client 与 mixed build 的 Browserslist
+target，并在生产模式下输出 ES5 JavaScript 语法。Webpack 会在生产构建中把应用
+代码、客户端 framework 代码和第三方依赖一起降级到该语法基线；server-function
+与 RSC 语义 loader 仍只处理项目源码。Utoopack 接收相同的 Android/iOS 生产
+target。开发模式保留适配器现有的客户端 target 和依赖转译范围，也不注入
+core-js；省略 `target` 时，生产构建也保留该默认行为。
 
 该兼容 target 由框架持有，plugin `configureBundler()` hook 不能覆盖。Node、
 构建期、server-function 与 server-renderer 编译继续使用现有 Node target。
 
-配置 target 的客户端 entry 默认打包 `core-js/stable`。配置外部
+配置 target 的生产客户端 entry 默认打包 `core-js/stable`。配置外部
 `polyfill.coreJs` UMD URL 后会移除该 import，并在每个包含客户端 JavaScript 的
-Document 中，把阻塞式脚本放到 EVJS runtime 数据和带 `defer` 的 client bundle
-之前。配置、加载顺序、能力范围与体积影响详见 [Polyfill](./config#polyfill)。
+生产 Document 中，把阻塞式脚本放到 EVJS runtime 数据和带 `defer` 的 client
+bundle 之前。配置、加载顺序、能力范围与体积影响详见
+[Polyfill](./config#polyfill)。
 
 ## SPA 与 MPA 输出
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/config.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/config.md
@@ -244,13 +244,14 @@ projection。插件根据 normalized Page 派生 Route 或 Document 行为，不
 
 ### Polyfill
 
-低端浏览器兼容由 `target` 显式控制。省略 `target` 时，evjs 不会注入 core-js，
-也不会替换适配器现有的客户端 target。
+生产环境的低端浏览器兼容由 `target` 显式控制。开发模式保留适配器现有的客户端
+target 和依赖转译范围，也不注入 core-js；省略 `target` 时，生产构建也保留该
+默认行为。
 
-配置 target 对象会选择支持的 Android 与 iOS 版本、输出 ES5 语法，并打包
-framework-owned `core-js/stable` 桥接模块。每个生成的客户端 facade 都会先 import
-该模块，再执行插件的 `polyfill` entry contribution 和应用入口。这会补齐
-ECMAScript 内建能力，同时增大客户端 bundle 体积。
+配置 target 对象会为生产构建选择支持的 Android 与 iOS 版本、输出 ES5 语法，
+并打包 framework-owned `core-js/stable` 桥接模块。每个生产客户端 facade 都会先
+import 该模块，再执行插件的 `polyfill` entry contribution 和应用入口。这会补齐
+ECMAScript 内建能力，同时增大生产客户端 bundle 体积。
 
 ```ts
 export default defineConfig({
@@ -272,10 +273,11 @@ export default defineConfig({
 });
 ```
 
-外部模式会移除 bundled core-js import。所有包含客户端 JavaScript 的 SPA、MPA、
-SSR 与 SSG Document 都会在 EVJS client runtime 内嵌数据和带 `defer` 的应用脚本
-之前插入普通阻塞式 `<script src="...">`。配置 URL 会原样保留，不与
-`publicPath` 拼接；不包含客户端 JavaScript 的 Document 不会插入该标签。
+外部模式会移除 bundled core-js import。所有包含客户端 JavaScript 的生产 SPA、
+MPA、SSR 与 SSG Document 都会在 EVJS client runtime 内嵌数据和带 `defer` 的
+应用脚本之前插入普通阻塞式 `<script src="...">`。配置 URL 会原样保留，不与
+`publicPath` 拼接；开发 Document 和不包含客户端 JavaScript 的 Document 不会插入
+该标签。
 
 `polyfill` 只能与 `target` 一起配置，避免只加载 core-js、却没有降级
 JavaScript 语法。`polyfill.coreJs` 只接受绝对 `http:` 或 `https:` URL。相对路径、其他 URL

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/config.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/config.md
@@ -242,6 +242,47 @@ projection。插件根据 normalized Page 派生 Route 或 Document 行为，不
 
 ## 其他配置
 
+### Polyfill
+
+低端浏览器兼容由 `target` 显式控制。省略 `target` 时，evjs 不会注入 core-js，
+也不会替换适配器现有的客户端 target。
+
+配置 target 对象会选择支持的 Android 与 iOS 版本、输出 ES5 语法，并打包
+framework-owned `core-js/stable` 桥接模块。每个生成的客户端 facade 都会先 import
+该模块，再执行插件的 `polyfill` entry contribution 和应用入口。这会补齐
+ECMAScript 内建能力，同时增大客户端 bundle 体积。
+
+```ts
+export default defineConfig({
+  target: { android: 5, ios: 8 },
+});
+```
+
+业务可以提高任一版本基线，例如 `target: { android: 6, ios: 10 }`。Android 5 与
+iOS 8 是允许配置的最低版本；两个字段都必须提供有限数字。
+
+如需改用单独托管的 core-js UMD bundle，可以在 target 旁配置一个绝对 HTTP(S) URL：
+
+```ts
+export default defineConfig({
+  target: { android: 6, ios: 10 },
+  polyfill: {
+    coreJs: "https://cdn.example.com/core-js-bundle.min.js",
+  },
+});
+```
+
+外部模式会移除 bundled core-js import。所有包含客户端 JavaScript 的 SPA、MPA、
+SSR 与 SSG Document 都会在 EVJS client runtime 内嵌数据和带 `defer` 的应用脚本
+之前插入普通阻塞式 `<script src="...">`。配置 URL 会原样保留，不与
+`publicPath` 拼接；不包含客户端 JavaScript 的 Document 不会插入该标签。
+
+`polyfill` 只能与 `target` 一起配置，避免只加载 core-js、却没有降级
+JavaScript 语法。`polyfill.coreJs` 只接受绝对 `http:` 或 `https:` URL。相对路径、其他 URL
+scheme、非字符串值和未知 `polyfill` 字段都会在配置解析阶段报错。该设置不会
+注入 `fetch`、`AbortController`、Streams 等 Web API polyfill，也不会改变 Node、
+构建期或 server 编译 target。
+
 ### Server
 
 文件约定启用时，positive `api.*` server request-route 锚点固定从 `src/apis`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10803,11 +10803,14 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
-      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+      "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -25183,6 +25186,7 @@
         "@standard-schema/spec": "^1.1.0",
         "@swc/core": "^1.15.21",
         "@tanstack/react-router": "^1.168.3",
+        "core-js": "^3.50.0",
         "domparser-rs": "^0.1.0",
         "execa": "^9.6.1",
         "jiti": "^2.6.1"

--- a/packages/bundler-utoopack/src/adapter/create-config.ts
+++ b/packages/bundler-utoopack/src/adapter/create-config.ts
@@ -120,7 +120,7 @@ export async function createUtoopackConfig(
 
   const utoopackConfig: ConfigComplete = {
     mode,
-    ...(config.target !== undefined && clientEntries.length > 0
+    ...(isProduction && config.target !== undefined && clientEntries.length > 0
       ? { target: createClientBrowserslistTarget(config.target) }
       : {}),
     entry: clientEntries.map((entry) => ({

--- a/packages/bundler-utoopack/src/adapter/create-config.ts
+++ b/packages/bundler-utoopack/src/adapter/create-config.ts
@@ -15,6 +15,7 @@ import {
   assertPortableRelativeArtifactPath,
   assertSafeBuildOutputPaths,
   canonicalPortableArtifactPathKey,
+  createClientBrowserslistTarget,
   createPluginConfigView,
   resolveBuildOutputPaths,
   SERVER_FUNCTION_TRANSFORM_RUNTIME,
@@ -110,18 +111,22 @@ export async function createUtoopackConfig(
 
   const finalServerEntry = resolveServerEntries(plan);
   const expectedServerEntry = snapshotUtoopackServerEntry(finalServerEntry);
+  const clientEntries = plan.entries.filter(
+    (entry) => entry.environment === "client",
+  );
 
   const outputPaths = resolveBuildOutputPaths(cwd, plan);
   await assertSafeBuildOutputPaths(cwd, outputPaths);
 
   const utoopackConfig: ConfigComplete = {
     mode,
-    entry: plan.entries
-      .filter((entry) => entry.environment === "client")
-      .map((entry) => ({
-        import: entry.import,
-        name: entry.name,
-      })),
+    ...(config.target !== undefined && clientEntries.length > 0
+      ? { target: createClientBrowserslistTarget(config.target) }
+      : {}),
+    entry: clientEntries.map((entry) => ({
+      import: entry.import,
+      name: entry.name,
+    })),
     output: {
       path: outputPaths.clientDir,
       filename: isProduction ? "[name].[contenthash:8].js" : "[name].js",
@@ -322,6 +327,7 @@ type UtoopackServerOutputTemplateField =
 
 interface UtoopackFrameworkExpectation {
   mode: unknown;
+  target: unknown;
   clean: unknown;
   publicPath: unknown;
   crossOriginLoading: unknown;
@@ -340,6 +346,7 @@ function snapshotUtoopackFrameworkExpectation(
 ): UtoopackFrameworkExpectation {
   return {
     mode: config.mode,
+    target: config.target,
     clean: config.output?.clean,
     publicPath: config.output?.publicPath,
     crossOriginLoading: config.output?.crossOriginLoading,
@@ -373,6 +380,7 @@ function assertUtoopackFrameworkExpectation(
   expectation: UtoopackFrameworkExpectation,
 ): void {
   assertUtoopackFrameworkField("mode", config.mode, expectation.mode);
+  assertUtoopackFrameworkField("target", config.target, expectation.target);
   assertUtoopackFrameworkField(
     "output.clean",
     config.output?.clean,

--- a/packages/bundler-utoopack/tests/create-config.test.ts
+++ b/packages/bundler-utoopack/tests/create-config.test.ts
@@ -167,7 +167,7 @@ describe("createUtoopackConfig", () => {
     expect(utoopackConfig.target).toBeUndefined();
   });
 
-  it("targets Android 5 and iOS 8 only when compatibility is enabled", async () => {
+  it("targets configured browsers only in production", async () => {
     for (const coreJs of [
       "bundled",
       {
@@ -189,7 +189,9 @@ describe("createUtoopackConfig", () => {
           [],
         );
 
-        expect(utoopackConfig.target).toBe("android >= 6, ios >= 10");
+        expect(utoopackConfig.target).toBe(
+          mode === "production" ? "android >= 6, ios >= 10" : undefined,
+        );
       }
     }
   });
@@ -277,7 +279,7 @@ describe("createUtoopackConfig", () => {
     const config = createResolvedConfig({
       plugins: [plugin],
     });
-    const plan = await createPlan(config);
+    const plan = await createPlan(config, { mode: "production" });
 
     const utoopackConfig = await createUtoopackConfig(
       config,
@@ -1194,7 +1196,7 @@ describe("createUtoopackConfig", () => {
       target: { android: 5, ios: 8 },
       polyfill: { coreJs: "bundled" },
     });
-    const plan = await createPlan(config);
+    const plan = await createPlan(config, { mode: "production" });
 
     await expect(
       createUtoopackConfig(config, plan, process.cwd(), [

--- a/packages/bundler-utoopack/tests/create-config.test.ts
+++ b/packages/bundler-utoopack/tests/create-config.test.ts
@@ -81,6 +81,7 @@ describe("createUtoopackConfig", () => {
       { import: "./.ev/entries/main.ts", name: "main" },
     ]);
     expect(utoopackConfig.output?.publicPath).toBe("auto");
+    expect(utoopackConfig.target).toBeUndefined();
     expect(utoopackConfig.output?.crossOriginLoading).toBe("anonymous");
     expect(utoopackConfig.resolve?.alias?.["@"]).toBe("./src");
     expect(utoopackConfig.define).toMatchObject({
@@ -163,6 +164,34 @@ describe("createUtoopackConfig", () => {
       removeUnusedExports: true,
       removeUnusedImports: true,
     });
+    expect(utoopackConfig.target).toBeUndefined();
+  });
+
+  it("targets Android 5 and iOS 8 only when compatibility is enabled", async () => {
+    for (const coreJs of [
+      "bundled",
+      {
+        source: "umd",
+        url: "https://cdn.example.com/core-js-bundle.min.js",
+      },
+    ] as const) {
+      for (const mode of ["development", "production"] as const) {
+        const config = createResolvedConfig({
+          target: { android: 6, ios: 10 },
+          polyfill: { coreJs },
+        });
+        const plan = await createPlan(config, { mode });
+
+        const utoopackConfig = await createUtoopackConfig(
+          config,
+          plan,
+          process.cwd(),
+          [],
+        );
+
+        expect(utoopackConfig.target).toBe("android >= 6, ios >= 10");
+      }
+    }
   });
 
   it("disables module concatenation for mixed production builds", async () => {
@@ -1158,6 +1187,26 @@ describe("createUtoopackConfig", () => {
         ]),
       ).rejects.toThrow(testCase.expected);
     }
+  });
+
+  it("protects the enabled client compatibility target", async () => {
+    const config = createResolvedConfig({
+      target: { android: 5, ios: 8 },
+      polyfill: { coreJs: "bundled" },
+    });
+    const plan = await createPlan(config);
+
+    await expect(
+      createUtoopackConfig(config, plan, process.cwd(), [
+        {
+          configureBundler(utoopackConfig) {
+            utoopackConfig.target = "node";
+          },
+        },
+      ]),
+    ).rejects.toThrow(
+      'Utoopack target "node" must remain the framework-owned value "android >= 5, ios >= 8"',
+    );
   });
 
   it("rejects portable artifact escapes in added entry names after each configureBundler hook", async () => {

--- a/packages/bundler-webpack/src/adapter/create-config.ts
+++ b/packages/bundler-webpack/src/adapter/create-config.ts
@@ -7,7 +7,6 @@ import {
   assertSafeBuildOutputPaths,
   assertSafeBuildOwnedOutputPath,
   assertSafeBundlerCleanOutputPath,
-  CLIENT_ECMASCRIPT_TARGET,
   canonicalPortableArtifactPathKey,
   createClientBrowserslistTarget,
   createPluginConfigView,
@@ -112,7 +111,7 @@ export async function createWebpackConfigs(
             entry.name === "evjs-rsc-client",
         ),
         reactServerConditions: false,
-        browserTarget: config.target,
+        browserTarget: plan.mode === "production" ? config.target : undefined,
         clean: options.clean ?? true,
         target: "web",
       }),
@@ -923,7 +922,7 @@ function createWebpackConfig(options: {
     target: options.browserTarget
       ? [
           `browserslist:${createClientBrowserslistTarget(options.browserTarget)}`,
-          CLIENT_ECMASCRIPT_TARGET,
+          "es5",
         ]
       : options.target,
     entry: createEntryObject(options.entries),
@@ -1010,7 +1009,7 @@ function createWebpackConfig(options: {
               options: {
                 jsc: {
                   ...(isClient && options.browserTarget
-                    ? { target: CLIENT_ECMASCRIPT_TARGET }
+                    ? { target: "es5" }
                     : {}),
                   parser: {
                     syntax: "typescript",

--- a/packages/bundler-webpack/src/adapter/create-config.ts
+++ b/packages/bundler-webpack/src/adapter/create-config.ts
@@ -7,7 +7,9 @@ import {
   assertSafeBuildOutputPaths,
   assertSafeBuildOwnedOutputPath,
   assertSafeBundlerCleanOutputPath,
+  CLIENT_ECMASCRIPT_TARGET,
   canonicalPortableArtifactPathKey,
+  createClientBrowserslistTarget,
   createPluginConfigView,
   type ResolvedBuildOutputPaths,
   resolveBuildOutputPaths,
@@ -110,6 +112,7 @@ export async function createWebpackConfigs(
             entry.name === "evjs-rsc-client",
         ),
         reactServerConditions: false,
+        browserTarget: config.target,
         clean: options.clean ?? true,
         target: "web",
       }),
@@ -138,6 +141,7 @@ export async function createWebpackConfigs(
         enableRscClientRuntime: false,
         clean: (options.clean ?? true) && rscServerEntries.length === 0,
         reactServerConditions: false,
+        browserTarget: undefined,
         target: "node",
       }),
     );
@@ -165,6 +169,7 @@ export async function createWebpackConfigs(
         enableRscClientRuntime: false,
         clean: false,
         reactServerConditions: false,
+        browserTarget: undefined,
         target: "node",
       }),
     );
@@ -192,6 +197,7 @@ export async function createWebpackConfigs(
         enableRscClientRuntime: false,
         clean: false,
         reactServerConditions: true,
+        browserTarget: undefined,
         target: "node",
       }),
     );
@@ -372,7 +378,7 @@ interface FrameworkWebpackOutputExpectation {
   field: "output.client" | "output.server" | "build-only output";
   path: string;
   mode: unknown;
-  target: unknown;
+  target: Configuration["target"];
   clean: unknown;
   publicPath: unknown;
   crossOriginLoading: unknown;
@@ -415,7 +421,7 @@ function getFrameworkWebpackOutputExpectation(
   );
   const outputExpectation = {
     mode: config.mode,
-    target: config.target,
+    target: cloneWebpackTarget(config.target),
     clean: config.output?.clean,
     publicPath: config.output?.publicPath,
     crossOriginLoading: config.output?.crossOriginLoading,
@@ -491,7 +497,6 @@ function assertFrameworkWebpackIdentity(
 ): void {
   for (const [field, actual, expected] of [
     ["mode", config.mode, expectation.mode],
-    ["target", config.target, expectation.target],
     ["output.clean", config.output?.clean, expectation.clean],
     ["output.publicPath", config.output?.publicPath, expectation.publicPath],
     [
@@ -505,6 +510,30 @@ function assertFrameworkWebpackIdentity(
       `[evjs] Webpack config "${expectation.configName}" ${field} ${formatOutputTemplate(actual)} must remain the framework-owned value ${formatOutputTemplate(expected)}. configureBundler hooks cannot override framework runtime identity.`,
     );
   }
+  if (!sameWebpackTarget(config.target, expectation.target)) {
+    throw new Error(
+      `[evjs] Webpack config "${expectation.configName}" target ${formatOutputTemplate(config.target)} must remain the framework-owned value ${formatOutputTemplate(expectation.target)}. configureBundler hooks cannot override framework runtime identity.`,
+    );
+  }
+}
+
+function cloneWebpackTarget(
+  target: Configuration["target"],
+): Configuration["target"] {
+  return Array.isArray(target) ? [...target] : target;
+}
+
+function sameWebpackTarget(
+  actual: Configuration["target"],
+  expected: Configuration["target"],
+): boolean {
+  if (!Array.isArray(actual) || !Array.isArray(expected)) {
+    return Object.is(actual, expected);
+  }
+  return (
+    actual.length === expected.length &&
+    actual.every((target, index) => target === expected[index])
+  );
 }
 
 function assertSelfContainedServerEntrypoints(
@@ -877,10 +906,12 @@ function createWebpackConfig(options: {
   rscClientReferences: RscClientReferenceConfig[];
   enableRscClientRuntime: boolean;
   reactServerConditions: boolean;
+  browserTarget: ResolvedConfig["target"];
   clean: boolean;
   target: "web" | "node";
 }): Configuration {
   const isProduction = options.mode === "production";
+  const isClient = options.target === "web";
   const outputExtension = options.target === "node" ? ".cjs" : ".js";
   const chunkDirectory =
     options.target === "node" ? `chunks/${options.name}` : undefined;
@@ -889,7 +920,12 @@ function createWebpackConfig(options: {
     name: options.name,
     mode: options.mode,
     context: options.cwd,
-    target: options.target,
+    target: options.browserTarget
+      ? [
+          `browserslist:${createClientBrowserslistTarget(options.browserTarget)}`,
+          CLIENT_ECMASCRIPT_TARGET,
+        ]
+      : options.target,
     entry: createEntryObject(options.entries),
     output: {
       path: options.outputPath,
@@ -946,23 +982,8 @@ function createWebpackConfig(options: {
         {
           test: /\.[cm]?[jt]sx?$/,
           exclude: /node_modules/,
+          enforce: "pre",
           use: [
-            {
-              loader: swcLoader,
-              options: {
-                jsc: {
-                  parser: {
-                    syntax: "typescript",
-                    tsx: true,
-                  },
-                  transform: {
-                    react: {
-                      runtime: "automatic",
-                    },
-                  },
-                },
-              },
-            },
             {
               loader: serverFunctionLoader,
               options: {
@@ -977,6 +998,32 @@ function createWebpackConfig(options: {
                   },
                 ]
               : []),
+          ],
+        },
+        {
+          test: /\.[cm]?[jt]sx?$/,
+          exclude:
+            isClient && options.browserTarget ? undefined : /node_modules/,
+          use: [
+            {
+              loader: swcLoader,
+              options: {
+                jsc: {
+                  ...(isClient && options.browserTarget
+                    ? { target: CLIENT_ECMASCRIPT_TARGET }
+                    : {}),
+                  parser: {
+                    syntax: "typescript",
+                    tsx: true,
+                  },
+                  transform: {
+                    react: {
+                      runtime: "automatic",
+                    },
+                  },
+                },
+              },
+            },
           ],
         },
         {

--- a/packages/bundler-webpack/tests/create-config.test.ts
+++ b/packages/bundler-webpack/tests/create-config.test.ts
@@ -148,6 +148,26 @@ describe("createWebpackConfigs", () => {
     expect(syntaxRule.use?.[0]?.options?.jsc?.target).toBe("es5");
   });
 
+  it("keeps the existing client target and transpilation scope in development", async () => {
+    const config = createResolvedConfig({
+      target: { android: 5, ios: 8 },
+      polyfill: { coreJs: "bundled" },
+    });
+    const graph = createGraph(config);
+    const plan = await createGeneratedPlan(config, graph, "development");
+
+    const configs = await createWebpackConfigs(config, plan, process.cwd(), []);
+    const clientConfig = configs.find((item) => item.name === "client");
+    const syntaxRule = clientConfig?.module?.rules?.[1] as {
+      exclude?: RegExp;
+      use?: Array<{ options?: { jsc?: { target?: string } } }>;
+    };
+
+    expect(clientConfig?.target).toBe("web");
+    expect(syntaxRule.exclude).toEqual(/node_modules/);
+    expect(syntaxRule.use?.[0]?.options?.jsc?.target).toBeUndefined();
+  });
+
   it("forwards configureBundler watch files to the framework collector", async () => {
     const config = createResolvedConfig();
     const graph = createGraph(config);
@@ -427,7 +447,7 @@ describe("createWebpackConfigs", () => {
       polyfill: { coreJs: "bundled" },
     });
     const graph = createGraph(config);
-    const plan = await createGeneratedPlan(config, graph, "development");
+    const plan = await createGeneratedPlan(config, graph, "production");
 
     await expect(
       createWebpackConfigs(config, plan, process.cwd(), [

--- a/packages/bundler-webpack/tests/create-config.test.ts
+++ b/packages/bundler-webpack/tests/create-config.test.ts
@@ -31,6 +31,7 @@ describe("createWebpackConfigs", () => {
     expect(entry.main?.import).toBe("./.ev/entries/main.ts");
     expect(configs[0]?.output?.publicPath).toBe("auto");
     expect(configs[0]?.output?.crossOriginLoading).toBe("anonymous");
+    expect(configs[0]?.target).toBe("web");
     expect(configs[0]?.infrastructureLogging).toEqual({ level: "warn" });
     expect(configs[0]?.stats).toEqual({
       assets: true,
@@ -39,6 +40,19 @@ describe("createWebpackConfigs", () => {
     expect(configs[0]?.resolve?.alias).toMatchObject({
       "@": path.resolve(process.cwd(), "src"),
     });
+    const clientRules = configs[0]?.module?.rules ?? [];
+    const semanticRule = clientRules[0] as {
+      exclude?: RegExp;
+      enforce?: string;
+    };
+    const syntaxRule = clientRules[1] as {
+      exclude?: RegExp;
+      use?: Array<{ options?: { jsc?: { target?: string } } }>;
+    };
+    expect(semanticRule.enforce).toBe("pre");
+    expect(semanticRule.exclude).toEqual(/node_modules/);
+    expect(syntaxRule.exclude).toEqual(/node_modules/);
+    expect(syntaxRule.use?.[0]?.options?.jsc?.target).toBeUndefined();
     const definePlugin = configs[0]?.plugins?.find(
       (plugin) =>
         plugin &&
@@ -104,6 +118,34 @@ describe("createWebpackConfigs", () => {
       "process.env.EVJS_FUNCTION_ENDPOINT": JSON.stringify("plan-runtime/fn"),
       __EVJS_FUNCTION_ENDPOINT__: JSON.stringify("plan-runtime/fn"),
     });
+  });
+
+  it("keeps the client compatibility target in production builds", async () => {
+    const config = createResolvedConfig({
+      target: { android: 6, ios: 10 },
+      polyfill: {
+        coreJs: {
+          source: "umd",
+          url: "https://cdn.example.com/core-js-bundle.min.js",
+        },
+      },
+    });
+    const graph = createGraph(config);
+    const plan = await createGeneratedPlan(config, graph, "production");
+
+    const configs = await createWebpackConfigs(config, plan, process.cwd(), []);
+    const clientConfig = configs.find((item) => item.name === "client");
+    const syntaxRule = clientConfig?.module?.rules?.[1] as {
+      exclude?: RegExp;
+      use?: Array<{ options?: { jsc?: { target?: string } } }>;
+    };
+
+    expect(clientConfig?.target).toEqual([
+      "browserslist:android >= 6, ios >= 10",
+      "es5",
+    ]);
+    expect(syntaxRule.exclude).toBeUndefined();
+    expect(syntaxRule.use?.[0]?.options?.jsc?.target).toBe("es5");
   });
 
   it("forwards configureBundler watch files to the framework collector", async () => {
@@ -377,6 +419,28 @@ describe("createWebpackConfigs", () => {
         ]),
       ).rejects.toThrow(testCase.expected);
     }
+  });
+
+  it("protects the enabled client compatibility target", async () => {
+    const config = createResolvedConfig({
+      target: { android: 5, ios: 8 },
+      polyfill: { coreJs: "bundled" },
+    });
+    const graph = createGraph(config);
+    const plan = await createGeneratedPlan(config, graph, "development");
+
+    await expect(
+      createWebpackConfigs(config, plan, process.cwd(), [
+        {
+          configureBundler(configs) {
+            const client = configs.find((item) => item.name === "client");
+            if (Array.isArray(client?.target)) client.target[0] = "node";
+          },
+        },
+      ]),
+    ).rejects.toThrow(
+      'Webpack config "client" target ["node","es5"] must remain the framework-owned value ["browserslist:android >= 5, ios >= 8","es5"]',
+    );
   });
 
   it("rejects portable artifact escapes in added entry names after each configureBundler hook", async () => {
@@ -970,6 +1034,13 @@ describe("createWebpackConfigs", () => {
     expect(serverConfig?.resolve?.alias).toMatchObject({
       "server-sdk": path.resolve(process.cwd(), "src/server/sdk.ts"),
     });
+    expect(serverConfig?.target).toBe("node");
+    const serverSyntaxRule = serverConfig?.module?.rules?.[1] as {
+      exclude?: RegExp;
+      use?: Array<{ options?: { jsc?: { target?: string } } }>;
+    };
+    expect(serverSyntaxRule.exclude).toEqual(/node_modules/);
+    expect(serverSyntaxRule.use?.[0]?.options?.jsc?.target).toBeUndefined();
   });
 
   it("uses a generated server entry for framework-managed server routes", async () => {
@@ -1105,7 +1176,9 @@ describe("createWebpackConfigs", () => {
   });
 });
 
-function createResolvedConfig(): ResolvedConfig<WebpackConfigs> {
+function createResolvedConfig(
+  overrides: Partial<ResolvedConfig<WebpackConfigs>> = {},
+): ResolvedConfig<WebpackConfigs> {
   return {
     conventions: true,
     routing: {
@@ -1148,6 +1221,7 @@ function createResolvedConfig(): ResolvedConfig<WebpackConfigs> {
     },
     transport: {},
     plugins: [],
+    ...overrides,
   };
 }
 

--- a/packages/ev/package.json
+++ b/packages/ev/package.json
@@ -73,6 +73,11 @@
       "import": "./esm/_internal/generated/client/page-context.js",
       "default": "./esm/_internal/generated/client/page-context.js"
     },
+    "./_internal/client/polyfill": {
+      "types": "./esm/_internal/generated/client/polyfill.d.ts",
+      "import": "./esm/_internal/generated/client/polyfill.js",
+      "default": "./esm/_internal/generated/client/polyfill.js"
+    },
     "./_internal/client/react-page": {
       "types": "./esm/_internal/generated/client/react-page.d.ts",
       "import": "./esm/_internal/generated/client/react-page.js",
@@ -150,6 +155,7 @@
     "@standard-schema/spec": "^1.1.0",
     "@swc/core": "^1.15.21",
     "@tanstack/react-router": "^1.168.3",
+    "core-js": "^3.50.0",
     "domparser-rs": "^0.1.0",
     "execa": "^9.6.1",
     "jiti": "^2.6.1"

--- a/packages/ev/src/_internal/build/client-compatibility.ts
+++ b/packages/ev/src/_internal/build/client-compatibility.ts
@@ -1,0 +1,15 @@
+import type { ClientTarget } from "../../config/index.js";
+
+/** Lowest browser versions accepted by the compatibility target. */
+export const CLIENT_TARGET_MINIMUM = {
+  android: 5,
+  ios: 8,
+} as const;
+
+/** Convert a normalized client target to the shared Browserslist expression. */
+export function createClientBrowserslistTarget(target: ClientTarget): string {
+  return `android >= ${target.android}, ios >= ${target.ios}`;
+}
+
+/** Syntax baseline required by Android 5 WebView and iOS 8 Safari. */
+export const CLIENT_ECMASCRIPT_TARGET = "es5";

--- a/packages/ev/src/_internal/build/client-compatibility.ts
+++ b/packages/ev/src/_internal/build/client-compatibility.ts
@@ -10,6 +10,3 @@ export const CLIENT_TARGET_MINIMUM = {
 export function createClientBrowserslistTarget(target: ClientTarget): string {
   return `android >= ${target.android}, ios >= ${target.ios}`;
 }
-
-/** Syntax baseline required by Android 5 WebView and iOS 8 Safari. */
-export const CLIENT_ECMASCRIPT_TARGET = "es5";

--- a/packages/ev/src/_internal/build/framework-html-document.ts
+++ b/packages/ev/src/_internal/build/framework-html-document.ts
@@ -44,7 +44,12 @@ export function createFrameworkHtmlDocument<TBundlerCfg>(options: {
   if (html.assets.js.length > 0) {
     embedClientRuntime(doc, clientRuntime);
     const coreJs = config.polyfill?.coreJs;
-    if (config.target && coreJs && coreJs !== "bundled") {
+    if (
+      plan.mode === "production" &&
+      config.target &&
+      coreJs &&
+      coreJs !== "bundled"
+    ) {
       injectCoreJsUmd(doc, coreJs.url);
     }
   }

--- a/packages/ev/src/_internal/build/framework-html-document.ts
+++ b/packages/ev/src/_internal/build/framework-html-document.ts
@@ -42,6 +42,10 @@ export function createFrameworkHtmlDocument<TBundlerCfg>(options: {
   }
   if (html.assets.js.length > 0) {
     embedClientRuntime(doc, clientRuntime);
+    const coreJs = config.polyfill?.coreJs;
+    if (config.target && coreJs && coreJs !== "bundled") {
+      injectCoreJsUmd(doc, coreJs.url);
+    }
   }
   if (html.owner.kind === "page") {
     const page = output.pages[html.owner.pageId];
@@ -52,6 +56,27 @@ export function createFrameworkHtmlDocument<TBundlerCfg>(options: {
   }
   applyHtmlTagContributions(doc, html, plan);
   return doc;
+}
+
+function injectCoreJsUmd(
+  doc: ReturnType<typeof generateHtml>,
+  url: string,
+): void {
+  const body = doc.body ?? doc.querySelector("body");
+  if (!body) return;
+  const script = doc.createElement("script");
+  script.setAttribute("src", url);
+  const runtimeScript = body.querySelector(`#${CLIENT_RUNTIME_SCRIPT_ID}`);
+  if (runtimeScript) {
+    body.insertBefore(script, runtimeScript);
+    return;
+  }
+  const firstScript = body.querySelector("script[src]");
+  if (firstScript) {
+    body.insertBefore(script, firstScript);
+    return;
+  }
+  body.appendChild(script);
 }
 
 function hasSpaApplicationEntry(

--- a/packages/ev/src/_internal/build/generated-contributions.ts
+++ b/packages/ev/src/_internal/build/generated-contributions.ts
@@ -236,7 +236,10 @@ export async function prepareFrameworkIR<TBundlerCfg>(
   ensureServerEntryForMiddlewareContributions(plan, generated);
   assertUniqueBuildEntryNames(plan.entries);
   plan.generated = generated;
-  const entries = createGeneratedEntryPlans(plan, generated);
+  const bundleCoreJs =
+    options.config.target !== undefined &&
+    options.config.polyfill?.coreJs === "bundled";
+  const entries = createGeneratedEntryPlans(plan, generated, bundleCoreJs);
   generated.entries = entries;
   rewritePlanEntriesToGeneratedFiles(plan, entries);
 
@@ -246,6 +249,7 @@ export async function prepareFrameworkIR<TBundlerCfg>(
     plan,
     collector.modules,
     generated,
+    bundleCoreJs,
   );
   return { plan, image };
 }
@@ -567,6 +571,9 @@ class ContributionCollector<TBundlerCfg> {
             source: ({ importFile }) =>
               createOriginalClientEntryFacadeSource(entry, importFile, {
                 autoStart: input.autoStart,
+                bundleCoreJs:
+                  this.options.config.target !== undefined &&
+                  this.options.config.polyfill?.coreJs === "bundled",
               }),
             extension: ".ts",
             keyKind: "entry facade",
@@ -952,6 +959,7 @@ function renderGeneratedIRImage(
   plan: BuildPlan,
   modules: InternalGeneratedModule[],
   generated: GeneratedFrameworkPlan,
+  injectBundledCoreJs: boolean,
 ): GeneratedIRImage {
   const rootDir = path.resolve(cwd, GENERATED_IR_DIR);
   const files = new Map<string, GeneratedIRImageFile>();
@@ -1004,7 +1012,7 @@ function renderGeneratedIRImage(
     addFile(
       absoluteFile,
       withGeneratedHeader(
-        createEntrySource(cwd, buildEntry, entry, plan),
+        createEntrySource(cwd, buildEntry, entry, plan, injectBundledCoreJs),
         ".ts",
         { fromFile: absoluteFile, rootDir },
       ),
@@ -1488,10 +1496,13 @@ function assertUniqueBuildEntryNames(entries: BuildEntry[]): void {
 function createGeneratedEntryPlans(
   plan: BuildPlan,
   generated: GeneratedFrameworkPlan,
+  injectBundledCoreJs: boolean,
 ): GeneratedEntryPlan[] {
   const used = new Set<string>();
   return plan.entries
-    .filter((entry) => shouldGenerateEntry(entry, plan, generated))
+    .filter((entry) =>
+      shouldGenerateEntry(entry, plan, generated, injectBundledCoreJs),
+    )
     .map((entry) => {
       const fileName = uniqueEntryFileName(entry.name, used);
       return {
@@ -1508,6 +1519,7 @@ function shouldGenerateEntry(
   entry: BuildEntry,
   plan: BuildPlan,
   generated: GeneratedFrameworkPlan,
+  injectBundledCoreJs: boolean,
 ): boolean {
   if (entry.metadata) return true;
   if (
@@ -1520,6 +1532,7 @@ function shouldGenerateEntry(
   }
   if (entry.environment === "client") {
     return (
+      injectBundledCoreJs ||
       getMatchingClientEntrySlots(plan, entry).length > 0 ||
       getSlotItemsFromGenerated<ClientEntrySlotPlanItem>(
         generated,
@@ -1568,6 +1581,7 @@ function createEntrySource(
   entry: BuildEntry,
   generatedEntry: GeneratedEntryPlan,
   plan: BuildPlan,
+  injectBundledCoreJs: boolean,
 ): string {
   const fromFile = path.resolve(cwd, generatedEntry.file);
   function importFile(file: string): string {
@@ -1591,6 +1605,7 @@ function createEntrySource(
       entry,
       fromFile,
       plan,
+      injectBundledCoreJs,
       mainSource: createPagesAppEntryMainSource(entry.metadata, importFile),
     });
   }
@@ -1600,6 +1615,7 @@ function createEntrySource(
       entry,
       fromFile,
       plan,
+      injectBundledCoreJs,
       mainSource: createReactComponentPageEntryMainSource(
         entry.metadata,
         importFile,
@@ -1623,6 +1639,7 @@ function createEntrySource(
       entry,
       fromFile,
       plan,
+      injectBundledCoreJs,
       mainSource: [`import ${JSON.stringify(original)};`],
     });
   }
@@ -1663,6 +1680,7 @@ function createClientEntrySource(options: {
   entry: BuildEntry;
   fromFile: string;
   plan: BuildPlan;
+  injectBundledCoreJs: boolean;
   mainSource: string[];
 }): string {
   const entrySlots = getMatchingClientEntrySlots(options.plan, options.entry);
@@ -1695,6 +1713,9 @@ function createClientEntrySource(options: {
     : options.mainSource;
 
   return [
+    ...(options.injectBundledCoreJs
+      ? ['import "@evjs/ev/_internal/client/polyfill";']
+      : []),
     ...importsFor("polyfill"),
     ...importsFor("before-main-imports"),
     ...importsFor("before-main"),

--- a/packages/ev/src/_internal/build/generated-contributions.ts
+++ b/packages/ev/src/_internal/build/generated-contributions.ts
@@ -237,6 +237,7 @@ export async function prepareFrameworkIR<TBundlerCfg>(
   assertUniqueBuildEntryNames(plan.entries);
   plan.generated = generated;
   const bundleCoreJs =
+    options.mode === "production" &&
     options.config.target !== undefined &&
     options.config.polyfill?.coreJs === "bundled";
   const entries = createGeneratedEntryPlans(plan, generated, bundleCoreJs);
@@ -572,6 +573,7 @@ class ContributionCollector<TBundlerCfg> {
               createOriginalClientEntryFacadeSource(entry, importFile, {
                 autoStart: input.autoStart,
                 bundleCoreJs:
+                  this.options.mode === "production" &&
                   this.options.config.target !== undefined &&
                   this.options.config.polyfill?.coreJs === "bundled",
               }),

--- a/packages/ev/src/_internal/build/generated/client-entry-source.ts
+++ b/packages/ev/src/_internal/build/generated/client-entry-source.ts
@@ -9,22 +9,26 @@ type ImportFile = (file: string) => string;
 export function createOriginalClientEntryFacadeSource(
   entry: BuildEntry,
   importFile: ImportFile,
-  options: { autoStart?: boolean } = {},
+  options: { autoStart?: boolean; bundleCoreJs?: boolean } = {},
 ): string {
+  let source: string;
   if (entry.metadata?.type === "pages-app") {
-    return createPagesAppEntryMainSource(
+    source = createPagesAppEntryMainSource(
       entry.metadata,
       importFile,
       options.autoStart,
     ).join("\n");
-  }
-  if (entry.metadata?.type === "react-component-page") {
-    return createReactComponentPageEntryMainSource(
+  } else if (entry.metadata?.type === "react-component-page") {
+    source = createReactComponentPageEntryMainSource(
       entry.metadata,
       importFile,
     ).join("\n");
+  } else {
+    source = `import ${JSON.stringify(importFile(entry.import))};`;
   }
-  return `import ${JSON.stringify(importFile(entry.import))};`;
+  return options.bundleCoreJs
+    ? `import "@evjs/ev/_internal/client/polyfill";\n${source}`
+    : source;
 }
 
 export function createPagesAppEntryMainSource(

--- a/packages/ev/src/_internal/build/index.ts
+++ b/packages/ev/src/_internal/build/index.ts
@@ -20,7 +20,6 @@ export {
 } from "./bundler.js";
 export { assertBundlerEmittedFiles } from "./bundler-output-files.js";
 export {
-  CLIENT_ECMASCRIPT_TARGET,
   CLIENT_TARGET_MINIMUM,
   createClientBrowserslistTarget,
 } from "./client-compatibility.js";

--- a/packages/ev/src/_internal/build/index.ts
+++ b/packages/ev/src/_internal/build/index.ts
@@ -20,6 +20,11 @@ export {
 } from "./bundler.js";
 export { assertBundlerEmittedFiles } from "./bundler-output-files.js";
 export {
+  CLIENT_ECMASCRIPT_TARGET,
+  CLIENT_TARGET_MINIMUM,
+  createClientBrowserslistTarget,
+} from "./client-compatibility.js";
+export {
   type BuildOptions,
   build,
   type DevOptions,

--- a/packages/ev/src/_internal/generated/client/polyfill.ts
+++ b/packages/ev/src/_internal/generated/client/polyfill.ts
@@ -1,0 +1,1 @@
+import "core-js/stable/index.js";

--- a/packages/ev/src/config/index.ts
+++ b/packages/ev/src/config/index.ts
@@ -169,7 +169,7 @@ export interface Config<TBundlerCfg = unknown> {
    */
   conventions?: boolean;
 
-  /** Enable a framework-owned browser compilation target. */
+  /** Enable a framework-owned production browser compilation target. */
   target?: ClientTarget;
 
   /** Override the polyfill source used by an enabled client target. */
@@ -317,7 +317,8 @@ export interface ClientTarget {
 export interface PolyfillConfig {
   /**
    * Absolute HTTP(S) URL for an external core-js UMD bundle. Omit this field
-   * to bundle the framework-owned core-js runtime into every client entry.
+   * to bundle the framework-owned core-js runtime into every production client
+   * entry.
    */
   coreJs?: string;
 }

--- a/packages/ev/src/config/index.ts
+++ b/packages/ev/src/config/index.ts
@@ -21,6 +21,7 @@ import {
   type ServerRouteNode,
 } from "@evjs/shared/manifest";
 import type { BundlerAdapter } from "../_internal/build/bundler.js";
+import { CLIENT_TARGET_MINIMUM } from "../_internal/build/client-compatibility.js";
 import {
   assertFrameworkOutputDirectory,
   assertSeparateFrameworkOutputDirectories,
@@ -122,6 +123,10 @@ export interface ResolvedServerRuntimeConfig {
 export interface ResolvedConfig<TBundlerCfg = unknown> {
   /** Whether framework file conventions are enabled. */
   conventions: boolean;
+  /** Framework-owned browser compilation target, when explicitly enabled. */
+  target?: ClientTarget;
+  /** Browser polyfill mode derived from the enabled client target. */
+  polyfill?: ResolvedPolyfillConfig;
   /** Emitted HTML and asset-tag output options. */
   output: ResolvedOutputConfig;
   /** Framework-managed page routing declaration, when enabled. */
@@ -163,6 +168,12 @@ export interface Config<TBundlerCfg = unknown> {
    * disabled independently.
    */
   conventions?: boolean;
+
+  /** Enable a framework-owned browser compilation target. */
+  target?: ClientTarget;
+
+  /** Override the polyfill source used by an enabled client target. */
+  polyfill?: PolyfillConfig;
 
   /** Emitted HTML and asset-tag output options. */
   output?: OutputConfig;
@@ -285,6 +296,24 @@ export interface TransportConfig {
 
 export interface ResolvedTransportConfig {
   baseUrl?: string;
+}
+
+/** Browser versions supported by framework-owned client compilation. */
+export interface ClientTarget {
+  android: number;
+  ios: number;
+}
+
+export interface PolyfillConfig {
+  /**
+   * Absolute HTTP(S) URL for an external core-js UMD bundle. Omit this field
+   * to bundle the framework-owned core-js runtime into every client entry.
+   */
+  coreJs?: string;
+}
+
+export interface ResolvedPolyfillConfig {
+  coreJs: "bundled" | { source: "umd"; url: string };
 }
 
 export type CrossOriginLoadingPolicy = false | "anonymous" | "use-credentials";
@@ -512,6 +541,8 @@ export const CONFIG_DEFAULTS = {
 } as const;
 const PUBLIC_ROOT_CONFIG_KEYS = new Set([
   "conventions",
+  "target",
+  "polyfill",
   "output",
   "dev",
   "server",
@@ -521,6 +552,7 @@ const PUBLIC_ROOT_CONFIG_KEYS = new Set([
   "bundler",
   "plugins",
 ]);
+const PUBLIC_CLIENT_TARGET_KEYS = new Set(["android", "ios"]);
 const PUBLIC_PAGE_ROUTING_CONFIG_KEYS = new Set(["mode", "html", "mount"]);
 const PUBLIC_CONFIG_ROUTE_APPLICATION_KEYS = new Set([
   "pageRoot",
@@ -559,6 +591,7 @@ const PUBLIC_SERVER_RESOLVE_CONFIG_KEYS = new Set(["alias"]);
 const PUBLIC_SERVER_DEV_CONFIG_KEYS = new Set(["port", "https"]);
 const PUBLIC_SERVER_RSC_CONFIG_KEYS = new Set(["endpoint"]);
 const PUBLIC_TRANSPORT_CONFIG_KEYS = new Set(["baseUrl"]);
+const PUBLIC_POLYFILL_CONFIG_KEYS = new Set(["coreJs"]);
 const PUBLIC_OUTPUT_CONFIG_KEYS = new Set([
   "client",
   "server",
@@ -649,6 +682,17 @@ export function resolveConfig<TBundlerCfg = unknown>(
     "transport",
   );
   validateTransportConfigKeys(transportConfig);
+  const clientTarget = resolveClientTarget(config.target);
+  const polyfillConfig = resolveOptionalConfigRecord<PolyfillConfig>(
+    config.polyfill,
+    "polyfill",
+  );
+  validatePolyfillConfigKeys(polyfillConfig);
+  if (config.polyfill !== undefined && clientTarget === undefined) {
+    throw new Error(
+      "[evjs] polyfill requires target because core-js alone does not lower JavaScript syntax.",
+    );
+  }
   const outputConfig = resolveOptionalConfigRecord<OutputConfig>(
     config.output,
     "output",
@@ -693,6 +737,12 @@ export function resolveConfig<TBundlerCfg = unknown>(
 
   return {
     conventions,
+    ...(clientTarget !== undefined
+      ? {
+          target: clientTarget,
+          polyfill: resolvePolyfillConfig(polyfillConfig),
+        }
+      : {}),
     routing: resolvedPageRouting,
     ...(resolvedApplication
       ? {
@@ -1649,6 +1699,68 @@ function validateTransportConfigKeys(transport: TransportConfig): void {
     "transport",
     "baseUrl",
   );
+}
+
+function validatePolyfillConfigKeys(polyfill: PolyfillConfig): void {
+  assertKnownConfigKeys(
+    polyfill,
+    PUBLIC_POLYFILL_CONFIG_KEYS,
+    "polyfill",
+    "coreJs",
+  );
+}
+
+function resolveClientTarget(target: unknown): ClientTarget | undefined {
+  if (target === undefined) return undefined;
+  const targetConfig = assertPlainConfigRecord(
+    target,
+    "target",
+    "a browser target object",
+  );
+  assertKnownConfigKeys(
+    targetConfig,
+    PUBLIC_CLIENT_TARGET_KEYS,
+    "target",
+    "android and ios",
+  );
+  return {
+    android: assertMinimumBrowserVersion(
+      targetConfig.android,
+      "target.android",
+      CLIENT_TARGET_MINIMUM.android,
+    ),
+    ios: assertMinimumBrowserVersion(
+      targetConfig.ios,
+      "target.ios",
+      CLIENT_TARGET_MINIMUM.ios,
+    ),
+  };
+}
+
+function assertMinimumBrowserVersion(
+  value: unknown,
+  path: string,
+  minimum: number,
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`[evjs] ${path} must be a finite number.`);
+  }
+  if (value < minimum) {
+    throw new Error(`[evjs] ${path} must be at least ${minimum}.`);
+  }
+  return value;
+}
+
+function resolvePolyfillConfig(
+  polyfill: PolyfillConfig,
+): ResolvedPolyfillConfig {
+  if (polyfill.coreJs === undefined) return { coreJs: "bundled" };
+  return {
+    coreJs: {
+      source: "umd",
+      url: assertHttpUrl(polyfill.coreJs, "polyfill.coreJs"),
+    },
+  };
 }
 
 function validateOutputConfigKeys(output: OutputConfig): void {

--- a/packages/ev/src/config/index.ts
+++ b/packages/ev/src/config/index.ts
@@ -304,6 +304,16 @@ export interface ClientTarget {
   ios: number;
 }
 
+/**
+ * Framework-managed polyfills coupled to the configured client target.
+ *
+ * This is a compatibility capability namespace, not a registry of arbitrary
+ * npm packages. core-js is modeled explicitly because the framework owns its
+ * default implementation, entry ordering, and relationship with syntax
+ * lowering. If applications need arbitrary polyfills in the future, expose a
+ * separate ordered module/script list instead of adding capability fields such
+ * as `fetch` or `abortController` here.
+ */
 export interface PolyfillConfig {
   /**
    * Absolute HTTP(S) URL for an external core-js UMD bundle. Omit this field

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -1325,6 +1325,24 @@ describe("prepareFrameworkBuild", () => {
     await prepared.dispose();
   });
 
+  it("does not inject bundled core-js in development", async () => {
+    const cwd = await createSpaProject();
+    const prepared = await prepareFrameworkBuild(
+      {
+        target: { android: 5, ios: 8 },
+        routing: { mode: "spa" },
+      },
+      { cwd, mode: "development" },
+    );
+    const source = await fs.promises.readFile(
+      path.join(cwd, ".ev/entries/main.ts"),
+      "utf-8",
+    );
+
+    expect(source).not.toContain("@evjs/ev/_internal/client/polyfill");
+    await prepared.dispose();
+  });
+
   it("does not inject core-js when browser compatibility is omitted", async () => {
     const cwd = await createSpaProject();
     const prepared = await prepareFrameworkBuild(

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -1170,6 +1170,8 @@ describe("prepareFrameworkBuild", () => {
     const prepared = await prepareFrameworkBuild(
       {
         output: { client: "dist/client", server: "dist/server" },
+        target: { android: 5, ios: 8 },
+        polyfill: {},
         plugins: [plugin],
         routing: { mode: "spa" },
       },
@@ -1278,12 +1280,63 @@ describe("prepareFrameworkBuild", () => {
         runtimeModule?.file ?? "",
       )}";`,
     );
-    await expect(
-      fs.promises.readFile(path.join(cwd, entry?.file ?? ""), "utf-8"),
-    ).resolves.toContain(
+    const mainEntrySource = await fs.promises.readFile(
+      path.join(cwd, entry?.file ?? ""),
+      "utf-8",
+    );
+    expect(mainEntrySource).toContain(
       'import * as routeModule0 from "../../src/pages/page";',
     );
+    expect(mainEntrySource.indexOf("@evjs/ev/_internal/client/polyfill")).toBe(
+      mainEntrySource.lastIndexOf("@evjs/ev/_internal/client/polyfill"),
+    );
+    expect(
+      mainEntrySource.indexOf("@evjs/ev/_internal/client/polyfill"),
+    ).toBeLessThan(mainEntrySource.indexOf("generated-fixture/runtime"));
 
+    await prepared.dispose();
+  });
+
+  it("uses an external core-js UMD without a bundled entry import", async () => {
+    const cwd = await createProject();
+    await fs.promises.mkdir(path.join(cwd, "src/pages"), { recursive: true });
+    await writeFile(
+      path.join(cwd, "src/pages/page.tsx"),
+      "export default function Page() { return null; }",
+      "utf-8",
+    );
+
+    const prepared = await prepareFrameworkBuild(
+      {
+        target: { android: 5, ios: 8 },
+        polyfill: {
+          coreJs: "https://cdn.example.com/core-js-bundle.min.js",
+        },
+        routing: { mode: "spa" },
+      },
+      { cwd },
+    );
+    const source = await fs.promises.readFile(
+      path.join(cwd, ".ev/entries/main.ts"),
+      "utf-8",
+    );
+
+    expect(source).not.toContain("@evjs/ev/_internal/client/polyfill");
+    await prepared.dispose();
+  });
+
+  it("does not inject core-js when browser compatibility is omitted", async () => {
+    const cwd = await createSpaProject();
+    const prepared = await prepareFrameworkBuild(
+      { routing: { mode: "spa" } },
+      { cwd },
+    );
+    const source = await fs.promises.readFile(
+      path.join(cwd, ".ev/entries/main.ts"),
+      "utf-8",
+    );
+
+    expect(source).not.toContain("@evjs/ev/_internal/client/polyfill");
     await prepared.dispose();
   });
 
@@ -1388,7 +1441,10 @@ describe("prepareFrameworkBuild", () => {
     const prepared = await prepareFrameworkIR({
       cwd,
       mode: "production",
-      config: {} as never,
+      config: {
+        target: { android: 5, ios: 8 },
+        polyfill: { coreJs: "bundled" },
+      } as never,
       graph: {} as CoreGraph,
       plan,
       plugins: [],
@@ -1402,6 +1458,16 @@ describe("prepareFrameworkBuild", () => {
         "./.ev/entries/runtime-01a49654-2.ts",
       ],
     );
+    for (const generatedEntry of prepared.plan.generated?.entries ?? []) {
+      const entryFile = generatedEntry.file.replace(/^\.\/\.ev\//, "");
+      const source = prepared.image.files.find(
+        (file) => file.file === entryFile,
+      )?.source;
+      expect(source).toContain('import "@evjs/ev/_internal/client/polyfill";');
+      expect(
+        source?.match(/@evjs\/ev\/_internal\/client\/polyfill/g),
+      ).toHaveLength(1);
+    }
     await expect(
       fs.promises.access(path.join(cwd, ".ev")),
     ).rejects.toMatchObject({ code: "ENOENT" });
@@ -2391,6 +2457,8 @@ describe("prepareFrameworkBuild", () => {
     const prepared = await prepareFrameworkBuild(
       {
         output: { client: "dist/client", server: "dist/server" },
+        target: { android: 5, ios: 8 },
+        polyfill: {},
         routing: { mode: "mpa" },
         plugins: [plugin],
       },
@@ -2406,20 +2474,24 @@ describe("prepareFrameworkBuild", () => {
       const installer = manifest.generated?.modules.find(
         (module) => module.id === "installer",
       );
-      await expect(
-        fs.promises.readFile(
-          path.join(
-            cwd,
-            `.ev/entries/${createPageClientBuildEntryName("home")}.ts`,
-          ),
-          "utf-8",
+      const pageEntrySource = await fs.promises.readFile(
+        path.join(
+          cwd,
+          `.ev/entries/${createPageClientBuildEntryName("home")}.ts`,
         ),
-      ).resolves.toContain(
+        "utf-8",
+      );
+      expect(pageEntrySource).toContain(
         generatedImport(
           cwd,
           `.ev/entries/${createPageClientBuildEntryName("home")}.ts`,
           installer?.file ?? "",
         ),
+      );
+      expect(
+        pageEntrySource.indexOf("@evjs/ev/_internal/client/polyfill"),
+      ).toBeLessThan(
+        pageEntrySource.indexOf("mpa-application-target/installer"),
       );
     } finally {
       await prepared.dispose();
@@ -2635,6 +2707,8 @@ describe("prepareFrameworkBuild", () => {
 
     const prepared = await prepareFrameworkBuild(
       {
+        target: { android: 5, ios: 8 },
+        polyfill: {},
         routing: { mode: "spa" },
         output: { client: "dist/client", server: "dist/server" },
         plugins: [plugin],
@@ -2663,14 +2737,26 @@ describe("prepareFrameworkBuild", () => {
     expect(originalEntry).toContain("export const pagesApp = createPagesApp");
     expect(originalEntry).toContain("startPagesApp");
     expect(originalEntry).toContain("../../src/pages/page");
+    expect(
+      originalEntry.indexOf("@evjs/ev/_internal/client/polyfill"),
+    ).toBeLessThan(originalEntry.indexOf("createPagesApp"));
     expect(deferredEntry).toContain("createPagesApp");
     expect(deferredEntry).toContain("export const pagesApp = createPagesApp");
     expect(deferredEntry).toContain("export const start =");
     expect(deferredEntry).not.toContain('startPagesApp(app, "#app");');
+    expect(
+      deferredEntry.indexOf("@evjs/ev/_internal/client/polyfill"),
+    ).toBeLessThan(deferredEntry.indexOf("createPagesApp"));
     expect(wrapper).toContain('import("./original-entry")');
     expect(mainEntry).toContain(
       'export * from "../plugins/entry-wrapper/wrapper";',
     );
+    expect(
+      mainEntry.indexOf("@evjs/ev/_internal/client/polyfill"),
+    ).toBeLessThan(mainEntry.indexOf("entry-wrapper/wrapper"));
+    expect(
+      mainEntry.match(/@evjs\/ev\/_internal\/client\/polyfill/g),
+    ).toHaveLength(1);
     expect(mainEntry).not.toContain("createPagesApp");
 
     await prepared.dispose();

--- a/packages/ev/tests/config-route.test.ts
+++ b/packages/ev/tests/config-route.test.ts
@@ -818,6 +818,28 @@ describe("explicit SPA route graph", () => {
     expect(
       documentWithoutClientJs.getElementById("__EVJS_CLIENT_RUNTIME__"),
     ).toBeNull();
+
+    const developmentDocument = createFrameworkHtmlDocument({
+      cwd,
+      config,
+      output,
+      plan: { ...plan, mode: "development" },
+      html: {
+        documentId: htmlPlan.id,
+        applicationId: "default",
+        owner: { kind: "page", pageId: "report" },
+        template: htmlPlan.template,
+        fileName: htmlPlan.fileName,
+        assets: output.pages.report.assets,
+      },
+      clientRuntime: createClientRuntime(output),
+      purpose: "client-document",
+    });
+    expect(
+      developmentDocument.querySelector(
+        'script[src="https://cdn.example.com/core-js-bundle.min.js"]',
+      ),
+    ).toBeNull();
   });
 
   it("materializes the generated SPA facade without canonical route types", async () => {

--- a/packages/ev/tests/config-route.test.ts
+++ b/packages/ev/tests/config-route.test.ts
@@ -706,6 +706,10 @@ describe("explicit SPA route graph", () => {
       `,
     });
     const config = resolveConfig({
+      target: { android: 5, ios: 8 },
+      polyfill: {
+        coreJs: "https://cdn.example.com/core-js-bundle.min.js",
+      },
       application: {
         document: { template: "./app.html" },
         routes: [{ path: "/report", page: "report" }],
@@ -779,6 +783,39 @@ describe("explicit SPA route graph", () => {
     expect(viewport?.getAttribute("data-evjs-page-metadata-baseline")).toBe(
       "width=device-width",
     );
+    const scripts = [...doc.querySelectorAll("body script")];
+    expect(scripts.map((script) => script.getAttribute("src"))).toEqual([
+      "https://cdn.example.com/core-js-bundle.min.js",
+      null,
+      "/main.js",
+    ]);
+    expect(scripts[0]?.hasAttribute("async")).toBe(false);
+    expect(scripts[0]?.hasAttribute("defer")).toBe(false);
+    expect(scripts[2]?.hasAttribute("defer")).toBe(true);
+
+    const documentWithoutClientJs = createFrameworkHtmlDocument({
+      cwd,
+      config,
+      output,
+      plan,
+      html: {
+        documentId: htmlPlan.id,
+        applicationId: "default",
+        owner: { kind: "page", pageId: "report" },
+        template: htmlPlan.template,
+        fileName: htmlPlan.fileName,
+        assets: { ...output.pages.report.assets, js: [] },
+      },
+      clientRuntime: createClientRuntime(output),
+    });
+    expect(
+      documentWithoutClientJs.querySelector(
+        'script[src="https://cdn.example.com/core-js-bundle.min.js"]',
+      ),
+    ).toBeNull();
+    expect(
+      documentWithoutClientJs.getElementById("__EVJS_CLIENT_RUNTIME__"),
+    ).toBeNull();
   });
 
   it("materializes the generated SPA facade without canonical route types", async () => {

--- a/packages/ev/tests/config-route.test.ts
+++ b/packages/ev/tests/config-route.test.ts
@@ -808,6 +808,7 @@ describe("explicit SPA route graph", () => {
         assets: { ...output.pages.report.assets, js: [] },
       },
       clientRuntime: createClientRuntime(output),
+      purpose: "client-document",
     });
     expect(
       documentWithoutClientJs.querySelector(

--- a/packages/ev/tests/config.test.ts
+++ b/packages/ev/tests/config.test.ts
@@ -960,6 +960,89 @@ describe("resolveConfig", () => {
     expect(() => resolveConfig({ server: { unknown: true } } as never)).toThrow(
       "server.unknown is not supported",
     );
+    expect(() =>
+      resolveConfig({
+        target: { android: 5, ios: 8 },
+        polyfill: { unknown: true },
+      } as never),
+    ).toThrow("polyfill.unknown is not supported");
+  });
+
+  it("uses target as the compatibility switch and resolves core-js", () => {
+    expect(resolveConfig()).not.toHaveProperty("polyfill");
+    expect(resolveConfig()).not.toHaveProperty("target");
+    expect(resolveConfig({ target: { android: 6, ios: 10 } })).toMatchObject({
+      target: { android: 6, ios: 10 },
+      polyfill: { coreJs: "bundled" },
+    });
+    expect(
+      resolveConfig({ target: { android: 5, ios: 8 }, polyfill: {} }).polyfill,
+    ).toEqual({ coreJs: "bundled" });
+    expect(
+      resolveConfig({
+        target: { android: 6, ios: 10 },
+        polyfill: {
+          coreJs: "https://cdn.example.com/core-js-bundle.min.js",
+        },
+      }).polyfill,
+    ).toEqual({
+      coreJs: {
+        source: "umd",
+        url: "https://cdn.example.com/core-js-bundle.min.js",
+      },
+    });
+
+    for (const coreJs of [
+      "./core-js.js",
+      "/core-js.js",
+      "javascript:alert(1)",
+      " ",
+      42,
+    ]) {
+      expect(() =>
+        resolveConfig({
+          target: { android: 5, ios: 8 },
+          polyfill: { coreJs },
+        } as never),
+      ).toThrow("polyfill.coreJs");
+    }
+
+    for (const polyfill of [null, true, "core-js", []]) {
+      expect(() =>
+        resolveConfig({
+          target: { android: 5, ios: 8 },
+          polyfill,
+        } as never),
+      ).toThrow("polyfill must be a config object");
+    }
+
+    expect(() => resolveConfig({ polyfill: {} })).toThrow(
+      "polyfill requires target",
+    );
+    for (const target of ["legacy", true, [], null]) {
+      expect(() => resolveConfig({ target } as never)).toThrow(
+        "target must be a browser target object",
+      );
+    }
+    expect(() => resolveConfig({ target: { android: 4.4, ios: 8 } })).toThrow(
+      "target.android must be at least 5",
+    );
+    expect(() => resolveConfig({ target: { android: 5, ios: 7 } })).toThrow(
+      "target.ios must be at least 8",
+    );
+    for (const target of [
+      {},
+      { android: 5 },
+      { android: 5, ios: Number.NaN },
+      { android: "6", ios: 10 },
+    ]) {
+      expect(() => resolveConfig({ target } as never)).toThrow(
+        /target\.(android|ios) must be a finite number/,
+      );
+    }
+    expect(() =>
+      resolveConfig({ target: { android: 5, ios: 8, chrome: 37 } } as never),
+    ).toThrow("target.chrome is not supported");
   });
 
   it("rejects unsupported routing shapes", () => {

--- a/packages/ev/tests/package-surface.test.ts
+++ b/packages/ev/tests/package-surface.test.ts
@@ -235,6 +235,8 @@ const forbiddenPluginAuthoringFields = [
 ] as const;
 
 const expectedBuildToolsRuntimeExports = [
+  "CLIENT_ECMASCRIPT_TARGET",
+  "CLIENT_TARGET_MINIMUM",
   "GENERATED_IR_DIR",
   "GENERATED_IR_MANIFEST",
   "SERVER_FUNCTION_TRANSFORM_RUNTIME",
@@ -253,6 +255,7 @@ const expectedBuildToolsRuntimeExports = [
   "canonicalPortableArtifactPathKey",
   "collectPluginSettingsRegistry",
   "createBuildPlan",
+  "createClientBrowserslistTarget",
   "createCoreGraph",
   "createPluginConfigView",
   "createPluginSettingsResolutionSession",
@@ -320,6 +323,7 @@ const expectedPackageExportSubpaths = {
     "./_internal/build",
     "./_internal/client",
     "./_internal/client/page-context",
+    "./_internal/client/polyfill",
     "./_internal/client/react-page",
     "./_internal/client/route-types",
     "./_internal/client/rsc-page-context",

--- a/packages/ev/tests/package-surface.test.ts
+++ b/packages/ev/tests/package-surface.test.ts
@@ -235,7 +235,6 @@ const forbiddenPluginAuthoringFields = [
 ] as const;
 
 const expectedBuildToolsRuntimeExports = [
-  "CLIENT_ECMASCRIPT_TARGET",
   "CLIENT_TARGET_MINIMUM",
   "GENERATED_IR_DIR",
   "GENERATED_IR_MANIFEST",


### PR DESCRIPTION
## Summary
- Add opt-in low-end browser compatibility to `@evjs/ev` production builds while keeping development and the open-source package's default build behavior unchanged.
- Let applications select explicit Android and iOS baselines and choose bundled core-js or an external UMD URL.

## Changes
- Add `target: { android, ios }` as the production client compatibility master switch, with Android 5 and iOS 8 as the minimum accepted versions; stricter targets such as Android 6 and iOS 10 remain configurable.
- Normalize `polyfill.coreJs` to bundled or external UMD mode, reject polyfill configuration without a target, and validate unknown fields, value types, and URLs.
- Apply framework-owned client targets in Utoopack and Webpack production builds, lower enabled production client builds to ES5, transpile the Webpack production client dependency graph, and preserve existing development and server targets.
- Inject bundled core-js once before plugin polyfills and application entry code in production, or emit a blocking external UMD script before EVJS runtime data and deferred production client bundles.
- Keep ES5 as a Webpack production adapter detail rather than exporting a framework-wide ECMAScript target constant.
- Add adapter ownership checks, runtime dependency/export wiring, focused coverage, changelog entries, and equivalent English/Chinese documentation.

## Validation
- `npm run check-types`
- `npm run lint`
- `npm test`
- `npm --workspace evjs-docs run build`
- `git diff --check`

## Risk / rollout
- The new behavior is opt-in in `@evjs/ev`; projects without `target` retain their current production client targets and do not receive core-js.
- Development always retains each adapter's existing client target and dependency transpilation scope and does not inject core-js, even when `target` is configured.
- Enabling production compatibility increases client bundle size in bundled mode. External UMD mode depends on the configured URL being available before application scripts execute.
- Node, build-time, and server compilation targets are unchanged.
- Default enablement for `@alipay/evjs` is intentionally handled in its separate repository and is not part of this PR.

## Reviewer notes
- Please focus on production-only mode gating, config normalization and minimum-version semantics, Webpack dependency transpilation boundaries, generated entry ordering, and external UMD placement in production hydrated documents.