### PR TITLE
perf(ev): load config packages natively

### DIFF
--- a/packages/ev/src/_internal/build/config-module.ts
+++ b/packages/ev/src/_internal/build/config-module.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { createJiti } from "jiti";
+import { createJiti, type ModuleCache } from "jiti";
 import type { Config } from "../../config/index.js";
 import { extractRuntimeModuleReferences } from "./static-imports.js";
 
@@ -41,6 +41,7 @@ const STATIC_CONFIG_CONDITION_SETS = [
 interface ObservedStaticConfigDependencies {
   aliases: Map<string, string>;
   dependencies: string[];
+  nativeModules: string[];
 }
 
 interface FreshPackageSpecifierResolution {
@@ -128,8 +129,15 @@ export async function loadConfigFile<TBundlerCfg = unknown>(
       resolvedConfigPath,
       options.cache === true,
       observed.aliases,
+      observed.nativeModules,
     );
-    const mod = loader(resolvedConfigPath);
+    const source = await fs.promises.readFile(resolvedConfigPath, "utf-8");
+    const mod = loader.evalModule(source, {
+      cache: Object.create(null) as ModuleCache,
+      ext: path.extname(resolvedConfigPath),
+      filename: resolvedConfigPath,
+      forceTranspile: true,
+    });
     return resolveConfigExport<TBundlerCfg>(mod);
   } catch (error) {
     throw new Error(`Failed to load evjs config from ${absoluteConfigPath}`, {
@@ -174,6 +182,7 @@ export async function loadStaticConfigModule(
       resolvedConfigPath,
       true,
       observed.aliases,
+      observed.nativeModules,
     );
     let loaded: unknown;
     try {
@@ -276,6 +285,7 @@ async function observeStaticConfigDependencyCandidates(
   const aliases = new Map<string, string>();
   const aliasScopes = new Map<string, string>();
   const dependencies = new Set<string>();
+  const nativeModules = new Set<string>();
   const visited = new Set<string>();
   const pending = [root];
   const packageManifests = new Map<
@@ -311,6 +321,8 @@ async function observeStaticConfigDependencyCandidates(
       includeRequire: true,
     })) {
       const { specifier } = reference;
+      const packageName = packageNameFromSpecifier(specifier);
+      if (packageName) nativeModules.add(packageName);
       const authoredPath = assertProjectLocalStaticConfigSpecifier(
         file,
         specifier,
@@ -413,7 +425,27 @@ async function observeStaticConfigDependencyCandidates(
     }
   }
 
-  return { aliases, dependencies: [...dependencies].sort() };
+  return {
+    aliases,
+    dependencies: [...dependencies].sort(),
+    nativeModules: [...nativeModules].sort(),
+  };
+}
+
+function packageNameFromSpecifier(specifier: string): string | undefined {
+  if (
+    specifier.startsWith(".") ||
+    specifier.startsWith("/") ||
+    specifier.startsWith("#") ||
+    specifier.startsWith("node:") ||
+    URL.canParse(specifier)
+  ) {
+    return undefined;
+  }
+  const segments = specifier.split("/");
+  return specifier.startsWith("@")
+    ? segments.slice(0, 2).join("/")
+    : segments[0];
 }
 
 function assertProjectLocalStaticConfigSpecifier(
@@ -1090,6 +1122,7 @@ function createConfigLoader(
   configPath: string,
   moduleCache: boolean,
   freshPackageAliases: ReadonlyMap<string, string> = new Map(),
+  nativeModules: string[] = [],
 ) {
   return createJiti(configPath, {
     alias: {
@@ -1099,7 +1132,9 @@ function createConfigLoader(
     fsCache: false,
     interopDefault: true,
     moduleCache,
-    tryNative: false,
+    nativeModules,
+    transformOptions: {},
+    tryNative: true,
   });
 }
 

--- a/packages/ev/tests/config-loader-options.test.ts
+++ b/packages/ev/tests/config-loader-options.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const jitiMocks = vi.hoisted(() => ({
+  createJiti: vi.fn((_filename: string, _options: Record<string, unknown>) =>
+    Object.assign(() => ({}), {
+      cache: Object.create(null),
+      esmResolve: vi.fn(),
+      evalModule: vi.fn(() => ({ default: { html: "./index.html" } })),
+      resolve: vi.fn(() => {
+        throw Object.assign(new Error("not found"), {
+          code: "MODULE_NOT_FOUND",
+        });
+      }),
+    }),
+  ),
+}));
+
+vi.mock("jiti", () => jitiMocks);
+
+import { loadConfigFile } from "../src/_internal/build/config-module.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  jitiMocks.createJiti.mockClear();
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("config loader options", () => {
+  it("tries native module loading before transforming config dependencies", async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "evjs-config-loader-"));
+    tempDirs.push(cwd);
+    const configPath = path.join(cwd, "ev.config.ts");
+    await fs.writeFile(
+      configPath,
+      'import "example-package"; export default {};',
+    );
+
+    await expect(loadConfigFile(configPath)).resolves.toEqual({
+      html: "./index.html",
+    });
+
+    expect(jitiMocks.createJiti).toHaveBeenCalledTimes(2);
+    for (const [, options] of jitiMocks.createJiti.mock.calls) {
+      expect(options).toMatchObject({
+        fsCache: false,
+        interopDefault: true,
+        moduleCache: false,
+        transformOptions: {},
+        tryNative: true,
+      });
+    }
+    expect(jitiMocks.createJiti.mock.calls[1]?.[1]).toMatchObject({
+      nativeModules: ["example-package"],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Reduce config-loading startup overhead by letting Jiti use native loading for installed packages.
- Preserve fresh evaluation for project-local TypeScript configuration and helper modules.

## Changes
- Enable `tryNative` in the EVJS Core config loader.
- Collect package imports from the observed config dependency closure and pass them through Jiti `nativeModules`.
- Force-transpile the config root with an isolated module cache so dev reloads continue to observe local edits.
- Add a regression test for the Jiti loader options and package allowlist.

## Validation
- `npm run build`
- `npm test --workspace=@evjs/ev` (808 tests)
- `npm run check-types`
- `npm run lint`
- Focused config loader suite (21 tests)

## Risk / rollout
- Moderate: config evaluation strategy changes for installed dependencies, while project-local modules retain no-cache behavior.
- No public API or configuration migration.

## Reviewer notes
- Please focus on package specifier classification and preservation of config/helper hot reload behavior.