### PR TITLE
docs(changelog): prepare v0.3.12 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.12] — 2026-08-14
+
 ### ✨ Features
 
 - **Low-end browser compatibility** — Applications can opt into Android 5 and
@@ -13,6 +17,13 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
   Android/iOS versions, which bundle `core-js/stable` by default. An absolute
   `polyfill.coreJs` UMD URL overrides the bundled source. Development and server
   targets are unchanged.
+
+### ✨ Improvements
+
+- **Faster configuration loading** — Installed packages imported by EVJS
+  configuration are loaded natively, reducing startup overhead while
+  project-local TypeScript configuration and helper modules remain fresh for
+  development reloads.
 
 ---
 


### PR DESCRIPTION
## Summary
- prepare the changelog for the next stable 0.3 release, v0.3.12
- capture the complete user-facing changes merged after v0.3.11

## Changes
- document opt-in Android 5 and iOS 8 compatibility targets with bundled or external core-js
- document faster native loading for installed config packages while preserving fresh local TypeScript config reloads
- update the release date to 2026-08-14
- leave source package versions and internal dependency ranges unchanged; release automation owns publish-time versioning

## Validation
- npm run check-types
- npm run lint
- npm --workspace evjs-docs run build
- npm test (all suites except a transient native Utoopack worker-shutdown panic)
- npm --workspace @evjs/bundler-utoopack test (retry: 12 files and 101 tests passed)
- git diff --check

## Risk / rollout
- low risk: this PR changes only release metadata in CHANGELOG.md
- publishing occurs separately when the v0.3.12 GitHub Release is created after merge

## Reviewer notes
- verify the v0.3.12 entry matches the complete v0.3.11...main commit range