### PR TITLE
feat(ev): support Page server entry imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+### ✨ Features
+
+- **Page server entry imports** — Plugins can import generated or authored
+  modules at ordered positions around an exact Page-owned `page-server` entry.
+  Import contributions compose with the existing replacement mode without
+  changing other server renderer kinds.
+
 ---
 
 ## [0.3.12] — 2026-08-14

--- a/docs/docs/generated-contributions.md
+++ b/docs/docs/generated-contributions.md
@@ -201,7 +201,7 @@ The supported slots are:
 | Slot | Covers |
 |------|--------|
 | `client.entry` | Entry imports and entry wrapper modules, including replacement wrappers |
-| `server.entry` | Replacement modules for existing Page server entries |
+| `server.entry` | Entry imports and replacement modules for existing Page server entries |
 | `page.wrapper` | Semantic Page component wrapping across client and server projections |
 | `server.request.middleware` | Framework request middleware in the server pipeline |
 | `html.tag` | Structured `meta`, `link`, `script`, and `style` tags |
@@ -211,12 +211,26 @@ The supported slots are:
 Use `client.entry` to import a side-effect module or call an explicit
 installer. The IR does not carry an inert runtime-plugin registry.
 
-`server.entry` is replacement-only. It requires `mode: "replace"` and an exact
-Page target, and that Page must already own a `page-server` entry. The
-contribution replaces only that entry's generated facade module; its framework
-name, kind, owner, environment, renderer identity, and output asset binding
-remain unchanged. It cannot create an entry or target another server renderer
-kind.
+`server.entry` requires an exact Page target, and that Page must already own a
+`page-server` entry. Import contributions preserve the generated Page server
+facade and use the same positions as `client.entry`:
+
+```ts
+emitIR(ctx) {
+  ctx.slot("server.entry").add({
+    id: "monitoring",
+    target: { kind: "page", pageId: "dashboard" },
+    module: "./src/monitoring/server-entry.ts",
+    position: "before-main",
+  });
+}
+```
+
+Use `mode: "replace"` when a plugin must replace the Page server facade. The
+replacement preserves the framework entry's name, kind, owner, environment,
+renderer identity, and output asset binding. It cannot create an entry or
+target another server renderer kind. Other import contributions around that
+entry remain active.
 
 ```ts
 emitIR(ctx) {

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/generated-contributions.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/generated-contributions.md
@@ -190,7 +190,7 @@ slots 如下：
 | Slot | 覆盖能力 |
 |------|----------|
 | `client.entry` | Entry imports、entry wrapper modules 和 replacement wrappers |
-| `server.entry` | 替换已有 Page server entry 的模块 |
+| `server.entry` | 已有 Page server entry 的 imports 与 replacement modules |
 | `page.wrapper` | 跨 client/server projection 的语义 Page component 包装 |
 | `server.request.middleware` | Server pipeline 中的 framework request middleware |
 | `html.tag` | 结构化 `meta`、`link`、`script`、`style` tags |
@@ -200,11 +200,25 @@ slots 如下：
 需要 import side-effect module 或执行安装逻辑时，使用 `client.entry` 显式调用
 installer。IR 不携带 inert runtime-plugin registry。
 
-`server.entry` 只支持 replacement。它要求显式提供 `mode: "replace"` 和精确的 Page
-target，且该 Page 必须已经拥有 `page-server` entry。Contribution 只替换该 entry 的
-generated facade module；框架持有的 name、kind、owner、environment、renderer identity
-与 output asset binding 均保持不变。它不能新增 entry，也不能命中其他 server renderer
-kind。
+`server.entry` 要求精确的 Page target，且该 Page 必须已经拥有 `page-server` entry。
+Import contribution 会保留 generated Page server facade，并使用与 `client.entry` 相同的
+positions：
+
+```ts
+emitIR(ctx) {
+  ctx.slot("server.entry").add({
+    id: "monitoring",
+    target: { kind: "page", pageId: "dashboard" },
+    module: "./src/monitoring/server-entry.ts",
+    position: "before-main",
+  });
+}
+```
+
+插件必须替换 Page server facade 时使用 `mode: "replace"`。Replacement 会保留框架
+entry 的 name、kind、owner、environment、renderer identity 与 output asset binding。
+它不能新增 entry，也不能命中其他 server renderer kind。该 entry 周围的其他 import
+contributions 仍然生效。
 
 ```ts
 emitIR(ctx) {

--- a/packages/ev/src/_internal/build/generated-contributions.ts
+++ b/packages/ev/src/_internal/build/generated-contributions.ts
@@ -92,7 +92,7 @@ const CONTRIBUTION_RUNTIMES = [
 ] as const satisfies readonly ContributionRuntime[];
 const CLIENT_ENTRY_RUNTIMES = ["client"] as const;
 const CLIENT_ENTRY_MODES = ["import", "replace"] as const;
-const SERVER_ENTRY_MODES = ["replace"] as const;
+const SERVER_ENTRY_MODES = ["import", "replace"] as const;
 const HTML_TAG_NAMES = [
   "meta",
   "link",
@@ -392,13 +392,15 @@ class ContributionCollector<TBundlerCfg> {
           );
         }
         const entry = matches[0];
-        const previous = serverEntryReplacements.get(entry.name);
-        if (previous) {
-          throw new Error(
-            `[evjs] Server page entry "${entry.name}" has multiple replacement server.entry contributions: ${previous.key}, ${slot.key}.`,
-          );
+        if (slot.mode === "replace") {
+          const previous = serverEntryReplacements.get(entry.name);
+          if (previous) {
+            throw new Error(
+              `[evjs] Server page entry "${entry.name}" has multiple replacement server.entry contributions: ${previous.key}, ${slot.key}.`,
+            );
+          }
+          serverEntryReplacements.set(entry.name, slot);
         }
-        serverEntryReplacements.set(entry.name, slot);
       }
 
       if (
@@ -692,6 +694,11 @@ class ContributionCollector<TBundlerCfg> {
       case "server.entry": {
         const item = input as FrameworkSlotInput<"server.entry">;
         assertGeneratedModuleOrString(pluginId, item.id, item.module);
+        const mode = validateEnum(
+          item.mode ?? "import",
+          SERVER_ENTRY_MODES,
+          `${base.key}.mode`,
+        );
         return {
           ...base,
           slot: name,
@@ -703,8 +710,16 @@ class ContributionCollector<TBundlerCfg> {
             },
             "file",
           ),
+          position:
+            mode === "replace" && item.position === undefined
+              ? "before-main"
+              : validateEnum(
+                  item.position,
+                  ENTRY_POSITIONS,
+                  `${base.key}.position`,
+                ),
           target: validateServerEntryTarget(item.target),
-          mode: validateEnum(item.mode, SERVER_ENTRY_MODES, `${base.key}.mode`),
+          mode,
         };
       }
       case "page.wrapper": {
@@ -1590,17 +1605,6 @@ function createEntrySource(
     return toGeneratedImportSpecifier(cwd, fromFile, file);
   }
 
-  if (entry.kind === "page-server") {
-    const replacement = getMatchingServerEntryReplacement(plan, entry);
-    if (replacement) {
-      const mod = toGeneratedImportSpecifier(cwd, fromFile, replacement.module);
-      return [
-        `export { default } from ${JSON.stringify(mod)};`,
-        `export * from ${JSON.stringify(mod)};`,
-      ].join("\n");
-    }
-  }
-
   if (entry.metadata?.type === "pages-app") {
     return createClientEntrySource({
       cwd,
@@ -1625,11 +1629,14 @@ function createEntrySource(
     });
   }
   if (entry.metadata?.type === "react-server-page") {
-    return createReactServerPageEntrySource(
+    const mainSource = createReactServerPageEntrySource(
       entry.metadata,
       entry.kind,
       importFile,
     );
+    return entry.kind === "page-server"
+      ? composePageServerEntrySource({ cwd, entry, fromFile, plan, mainSource })
+      : mainSource;
   }
   if (entry.metadata?.type === "server-app") {
     return createServerAppEntrySource(cwd, fromFile, entry.metadata, plan);
@@ -1664,11 +1671,14 @@ function createEntrySource(
     fromFile,
     generatedEntry.originalImport,
   );
-  return [
+  const mainSource = [
     `export { PageProvider } from "@evjs/ev/_internal/client/page-context";`,
     `export { default } from ${JSON.stringify(mod)};`,
     `export * from ${JSON.stringify(mod)};`,
   ].join("\n");
+  return entry.kind === "page-server"
+    ? composePageServerEntrySource({ cwd, entry, fromFile, plan, mainSource })
+    : mainSource;
 }
 
 /**
@@ -1718,6 +1728,57 @@ function createClientEntrySource(options: {
     ...(options.injectBundledCoreJs
       ? ['import "@evjs/ev/_internal/client/polyfill";']
       : []),
+    ...importsFor("polyfill"),
+    ...importsFor("before-main-imports"),
+    ...importsFor("before-main"),
+    ...mainSource,
+    ...importsFor("after-main-imports"),
+    ...importsFor("after-main"),
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+/** Compose imports around one Page server entry or its replacement facade. */
+function composePageServerEntrySource(options: {
+  cwd: string;
+  entry: BuildEntry;
+  fromFile: string;
+  plan: BuildPlan;
+  mainSource: string;
+}): string {
+  const entrySlots = getMatchingServerEntrySlots(options.plan, options.entry);
+  const replacements = entrySlots.filter((slot) => slot.mode === "replace");
+  if (replacements.length > 1) {
+    throw new Error(
+      `[evjs] Server page entry "${options.entry.name}" has multiple replacement server.entry contributions: ${replacements
+        .map((slot) => slot.key)
+        .join(", ")}.`,
+    );
+  }
+
+  const importsFor = (position: ServerEntrySlotPlanItem["position"]) =>
+    entrySlots
+      .filter((slot) => slot.position === position && slot.mode !== "replace")
+      .map((slot) =>
+        importSlotModule(options.cwd, options.fromFile, slot.module, position),
+      );
+  const replacement = replacements[0];
+  const mainSource = replacement
+    ? (() => {
+        const mod = toGeneratedImportSpecifier(
+          options.cwd,
+          options.fromFile,
+          replacement.module,
+        );
+        return [
+          `export { default } from ${JSON.stringify(mod)};`,
+          `export * from ${JSON.stringify(mod)};`,
+        ];
+      })()
+    : [options.mainSource];
+
+  return [
     ...importsFor("polyfill"),
     ...importsFor("before-main-imports"),
     ...importsFor("before-main"),
@@ -1876,11 +1937,11 @@ function getMatchingClientEntrySlots(
   );
 }
 
-function getMatchingServerEntryReplacement(
+function getMatchingServerEntrySlots(
   plan: BuildPlan,
   entry: BuildEntry,
-): ServerEntrySlotPlanItem | undefined {
-  return getSlotItems<ServerEntrySlotPlanItem>(plan, "server.entry").find(
+): ServerEntrySlotPlanItem[] {
+  return getSlotItems<ServerEntrySlotPlanItem>(plan, "server.entry").filter(
     (slot) => targetMatchesEntry(slot.target, entry),
   );
 }
@@ -1948,7 +2009,7 @@ function importSlotModule(
   cwd: string,
   fromFile: string,
   specifier: string,
-  position: ClientEntrySlotPlanItem["position"],
+  position: EntryContributionPosition,
 ): string {
   const mod = toGeneratedImportSpecifier(cwd, fromFile, specifier);
   if (position === "after-main") {

--- a/packages/ev/src/plugin/index.ts
+++ b/packages/ev/src/plugin/index.ts
@@ -650,13 +650,25 @@ export interface ClientEntryContribution {
   mode?: "import" | "replace";
 }
 
-/** Replaces one existing framework-owned Page server entry facade. */
-export interface ServerEntryContribution {
+interface ServerEntryContributionBase {
   id: string;
   module: GeneratedModuleRef | string;
   target: { kind: "page"; pageId: string };
-  mode: "replace";
 }
+
+/** Imports into or replaces one existing framework-owned Page server entry. */
+export type ServerEntryContribution = ServerEntryContributionBase &
+  (
+    | {
+        position: EntryContributionPosition;
+        mode?: "import";
+      }
+    | {
+        /** Replacement positions are normalized but do not affect output. */
+        position?: EntryContributionPosition;
+        mode: "replace";
+      }
+  );
 
 /**
  * Wraps semantic Pages with one React component module.

--- a/packages/ev/tests/commands.test.ts
+++ b/packages/ev/tests/commands.test.ts
@@ -2780,6 +2780,170 @@ describe("prepareFrameworkBuild", () => {
     await prepared.dispose();
   });
 
+  it("composes Page server entry imports around a replacement", async () => {
+    const cwd = await createProject();
+    for (const pageId of ["home", "admin"]) {
+      await writeFile(
+        path.join(cwd, `src/pages/${pageId}/page.tsx`),
+        `export default function ${pageId}Page() { return null; }`,
+        "utf-8",
+      );
+      await writeFile(
+        path.join(cwd, `src/pages/${pageId}/page.config.ts`),
+        'export default { render: "ssr" };',
+        "utf-8",
+      );
+    }
+
+    const importsPlugin: Plugin<Record<string, never>> = {
+      id: "server-entry-imports",
+      emitIR(ctx) {
+        for (const [id, position] of [
+          ["before", "before-main"],
+          ["after", "after-main"],
+        ] as const) {
+          const module = ctx.emit.module({
+            id,
+            scope: { kind: "page", pageId: "home" },
+            source: `globalThis.__${id}ServerEntry = true;`,
+          });
+          ctx.slot("server.entry").add({
+            id: `${id}-slot`,
+            target: { kind: "page", pageId: "home" },
+            module,
+            position,
+          });
+        }
+        const admin = ctx.emit.module({
+          id: "admin",
+          scope: { kind: "page", pageId: "admin" },
+          source: "globalThis.__adminServerEntry = true;",
+        });
+        ctx.slot("server.entry").add({
+          id: "admin-slot",
+          target: { kind: "page", pageId: "admin" },
+          module: admin,
+          position: "before-main",
+        });
+      },
+    };
+    const replacementPlugin: Plugin<Record<string, never>> = {
+      id: "server-entry-replacement",
+      emitIR(ctx) {
+        const module = ctx.emit.module({
+          id: "home",
+          scope: { kind: "page", pageId: "home" },
+          source: [
+            "export default function Home() { return null; }",
+            "export const replaced = true;",
+          ].join("\n"),
+        });
+        ctx.slot("server.entry").add({
+          id: "home-slot",
+          target: { kind: "page", pageId: "home" },
+          module,
+          mode: "replace",
+        });
+      },
+    };
+
+    const prepared = await prepareFrameworkBuild(
+      {
+        routing: { mode: "spa" },
+        plugins: [importsPlugin, replacementPlugin],
+      },
+      { cwd },
+    );
+    const manifest = JSON.parse(
+      await fs.promises.readFile(path.join(cwd, ".ev/manifest.json"), "utf-8"),
+    ) as BuildPlan;
+    const homeEntryFile = `.ev/entries/${createPageServerBuildEntryName("home")}.ts`;
+    const adminEntryFile = `.ev/entries/${createPageServerBuildEntryName("admin")}.ts`;
+    const homeEntry = await fs.promises.readFile(
+      path.join(cwd, homeEntryFile),
+      "utf-8",
+    );
+    const adminEntry = await fs.promises.readFile(
+      path.join(cwd, adminEntryFile),
+      "utf-8",
+    );
+    const before = manifest.generated?.modules.find(
+      (module) =>
+        module.pluginId === "server-entry-imports" && module.id === "before",
+    );
+    const after = manifest.generated?.modules.find(
+      (module) =>
+        module.pluginId === "server-entry-imports" && module.id === "after",
+    );
+    const replacement = manifest.generated?.modules.find(
+      (module) =>
+        module.pluginId === "server-entry-replacement" && module.id === "home",
+    );
+    const admin = manifest.generated?.modules.find(
+      (module) =>
+        module.pluginId === "server-entry-imports" && module.id === "admin",
+    );
+    const beforeImport = generatedImport(
+      cwd,
+      homeEntryFile,
+      before?.file ?? "",
+    );
+    const afterImport = generatedImport(cwd, homeEntryFile, after?.file ?? "");
+    const replacementImport = generatedImport(
+      cwd,
+      homeEntryFile,
+      replacement?.file ?? "",
+    );
+    const adminImport = generatedImport(cwd, adminEntryFile, admin?.file ?? "");
+
+    expect(homeEntry).toContain(`import ${JSON.stringify(beforeImport)};`);
+    expect(homeEntry).toContain(
+      `export { default } from ${JSON.stringify(replacementImport)};`,
+    );
+    expect(homeEntry).toContain(`void import(${JSON.stringify(afterImport)});`);
+    expect(homeEntry.indexOf(beforeImport)).toBeLessThan(
+      homeEntry.indexOf(replacementImport),
+    );
+    expect(homeEntry.indexOf(replacementImport)).toBeLessThan(
+      homeEntry.indexOf(afterImport),
+    );
+    expect(homeEntry).not.toContain("src/pages/home/page");
+    expect(adminEntry).toContain(`import ${JSON.stringify(adminImport)};`);
+    expect(adminEntry).toContain("src/pages/admin/page");
+    expect(adminEntry).not.toContain(beforeImport);
+    expect(adminEntry).not.toContain(afterImport);
+    expect(manifest.generated?.slots).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          slot: "server.entry",
+          id: "before-slot",
+          position: "before-main",
+          mode: "import",
+        }),
+        expect.objectContaining({
+          slot: "server.entry",
+          id: "after-slot",
+          position: "after-main",
+          mode: "import",
+        }),
+        expect.objectContaining({
+          slot: "server.entry",
+          id: "home-slot",
+          position: "before-main",
+          mode: "replace",
+        }),
+        expect.objectContaining({
+          slot: "server.entry",
+          id: "admin-slot",
+          position: "before-main",
+          mode: "import",
+        }),
+      ]),
+    );
+
+    await prepared.dispose();
+  });
+
   it("replaces exact Page server entry facades without changing framework entry identity", async () => {
     const cwd = await createProject();
     for (const pageId of ["home", "admin", "profile"]) {
@@ -3072,6 +3236,44 @@ describe("prepareFrameworkBuild", () => {
         { cwd },
       ),
     ).rejects.toThrow('server.entry target.kind must be "page".');
+  });
+
+  it("requires a position for Page server entry imports", async () => {
+    const cwd = await createProject();
+    await writeFile(
+      path.join(cwd, "src/pages/page.tsx"),
+      "export default function Page() { return null; }",
+      "utf-8",
+    );
+    await writeFile(
+      path.join(cwd, "src/pages/page.config.ts"),
+      'export default { render: "ssr" };',
+      "utf-8",
+    );
+    const plugin: Plugin<Record<string, never>> = {
+      id: "invalid-server-entry-import",
+      emitIR(ctx) {
+        const module = ctx.emit.module({
+          id: "entry",
+          scope: { kind: "page", pageId: "index" },
+          source: "export {};",
+        });
+        ctx.slot("server.entry").add({
+          id: "entry-slot",
+          target: { kind: "page", pageId: "index" },
+          module,
+        } as never);
+      },
+    };
+
+    await expect(
+      prepareFrameworkBuild(
+        { routing: { mode: "spa" }, plugins: [plugin] },
+        { cwd },
+      ),
+    ).rejects.toThrow(
+      'invalid-server-entry-import:entry-slot.position must be one of: "polyfill", "before-main-imports", "after-main-imports", "before-main", "after-main"',
+    );
   });
 
   it("adds server.request.middleware contributions to the generated server entry", async () => {

--- a/packages/shared/src/manifest/index.ts
+++ b/packages/shared/src/manifest/index.ts
@@ -838,7 +838,8 @@ export interface ClientEntrySlotPlanItem extends FrameworkSlotPlanItemBase {
 export interface ServerEntrySlotPlanItem extends FrameworkSlotPlanItemBase {
   slot: "server.entry";
   module: string;
-  mode: "replace";
+  position: EntryContributionPosition;
+  mode: "import" | "replace";
   target: { kind: "page"; pageId: string };
 }
 


### PR DESCRIPTION
## Summary

- align SSR Page server entry contributions with client entry import positions
- compose import contributions around the original Page entry or a replacement
- preserve replacement compatibility while limiting targeting to exact Page server entries
- document the behavior in English and Chinese

## Validation

- `npm run check-types`
- `npm run lint`
- `npm test`
- documentation builds for English and Chinese
- `git diff --check`