### PR TITLE
test(cli): raise inspect diagnostic timeout

### DIFF
--- a/packages/cli/tests/inspect.test.ts
+++ b/packages/cli/tests/inspect.test.ts
@@ -682,7 +682,7 @@ describe("inspect", () => {
     );
     await expectPathMissing(path.join(cwd, "dist"));
     await expectPathMissing(path.join(cwd, "src/route-types.d.ts"));
-  });
+  }, 10_000);
 
   it("returns server-route diagnostics and a failing exit code for an invalid api anchor", async () => {
     const cwd = await createFixture({


### PR DESCRIPTION
## Summary
- Prevent the CLI inspect diagnostics test from flaking when GitHub runners are under load.
- Keep the change scoped to the test that exceeded Vitest's default 5-second timeout.

## Changes
- Raise the timeout for the CLI error-diagnostics integration test from the default 5 seconds to 10 seconds.

## Validation
- `npm --workspace @evjs/cli test -- tests/inspect.test.ts -t "returns a failing CLI exit code for error diagnostics"`
- `npm --workspace @evjs/cli test`
- `npm run check-types`
- `npm run lint`
- `npm test`
- `git diff --check`

## Risk / rollout
- Low risk: test-only timeout adjustment with no runtime or production behavior changes.

## Reviewer notes
- The failed main run timed out at 5.017 seconds, while the identical source tree passed the PR run in 4.712 seconds. The 10-second limit preserves timeout coverage while allowing for runner contention.