### PR TITLE
perf(ev): reduce framework dev startup overhead

### DIFF
--- a/packages/ev/src/_internal/build/config-module.ts
+++ b/packages/ev/src/_internal/build/config-module.ts
@@ -44,6 +44,13 @@ interface ObservedStaticConfigDependencies {
   nativeModules: string[];
 }
 
+type ConfigLoader = ReturnType<typeof createJiti>;
+
+interface StaticConfigModuleSessionState {
+  evaluationLoaders: Map<string, ConfigLoader>;
+  resolutionLoader?: ConfigLoader;
+}
+
 interface FreshPackageSpecifierResolution {
   candidates: string[];
   matched: boolean;
@@ -88,6 +95,14 @@ export interface LoadStaticConfigModuleOptions {
   onDependency?: (file: string) => void;
 }
 
+export interface StaticConfigModuleSession {
+  /** Load one config through the resolution and module state for this revision. */
+  load(
+    configPath: string,
+    options?: Pick<LoadStaticConfigModuleOptions, "onDependency">,
+  ): Promise<LoadedStaticConfigModule>;
+}
+
 export interface ClearStaticConfigModuleCacheOptions {
   /**
    * Also clear dependency closures recorded for previous config roots in this
@@ -98,6 +113,28 @@ export interface ClearStaticConfigModuleCacheOptions {
 }
 
 const staticConfigDependencies = new Map<string, string[]>();
+
+export function createStaticConfigModuleSession(
+  projectRoot: string,
+): StaticConfigModuleSession {
+  const absoluteProjectRoot = path.resolve(projectRoot);
+  const state: StaticConfigModuleSessionState = {
+    evaluationLoaders: new Map(),
+  };
+  return Object.freeze({
+    load(
+      configPath: string,
+      options: Pick<LoadStaticConfigModuleOptions, "onDependency"> = {},
+    ) {
+      return loadStaticConfigModuleWithState(
+        configPath,
+        absoluteProjectRoot,
+        { ...options, cache: true },
+        state,
+      );
+    },
+  });
+}
 
 export async function loadConfigFile<TBundlerCfg = unknown>(
   configPath: string,
@@ -156,6 +193,15 @@ export async function loadStaticConfigModule(
   projectRoot: string,
   options: LoadStaticConfigModuleOptions = {},
 ): Promise<LoadedStaticConfigModule> {
+  return loadStaticConfigModuleWithState(configPath, projectRoot, options);
+}
+
+async function loadStaticConfigModuleWithState(
+  configPath: string,
+  projectRoot: string,
+  options: LoadStaticConfigModuleOptions,
+  sessionState?: StaticConfigModuleSessionState,
+): Promise<LoadedStaticConfigModule> {
   const absoluteConfigPath = path.resolve(configPath);
   const absoluteProjectRoot = path.resolve(projectRoot);
 
@@ -170,7 +216,16 @@ export async function loadStaticConfigModule(
     if (resolvedConfigPath !== absoluteConfigPath) {
       options.onDependency?.(absoluteConfigPath);
     }
-    const resolutionLoader = createConfigLoader(resolvedConfigPath, true);
+    let resolutionLoader: ConfigLoader;
+    if (sessionState) {
+      sessionState.resolutionLoader ??= createConfigLoader(
+        resolvedConfigPath,
+        true,
+      );
+      resolutionLoader = sessionState.resolutionLoader;
+    } else {
+      resolutionLoader = createConfigLoader(resolvedConfigPath, true);
+    }
     const observed = await observeStaticConfigDependencyCandidates(
       resolvedConfigPath,
       absoluteProjectRoot,
@@ -178,12 +233,18 @@ export async function loadStaticConfigModule(
       (fromFile, specifier) =>
         resolveStaticConfigImport(resolutionLoader, fromFile, specifier),
     );
-    const loader = createConfigLoader(
-      resolvedConfigPath,
-      true,
-      observed.aliases,
-      observed.nativeModules,
-    );
+    const loader = sessionState
+      ? getStaticConfigModuleSessionLoader(
+          sessionState,
+          resolvedConfigPath,
+          observed,
+        )
+      : createConfigLoader(
+          resolvedConfigPath,
+          true,
+          observed.aliases,
+          observed.nativeModules,
+        );
     let loaded: unknown;
     try {
       loaded = loader(resolvedConfigPath);
@@ -1138,6 +1199,28 @@ function createConfigLoader(
   });
 }
 
+function getStaticConfigModuleSessionLoader(
+  state: StaticConfigModuleSessionState,
+  configPath: string,
+  observed: ObservedStaticConfigDependencies,
+): ConfigLoader {
+  const key = JSON.stringify([
+    [...observed.aliases].sort(([left], [right]) => left.localeCompare(right)),
+    observed.nativeModules,
+  ]);
+  const cached = state.evaluationLoaders.get(key);
+  if (cached) return cached;
+
+  const loader = createConfigLoader(
+    configPath,
+    true,
+    observed.aliases,
+    observed.nativeModules,
+  );
+  state.evaluationLoaders.set(key, loader);
+  return loader;
+}
+
 function collectProjectModuleDependencies(
   root: NodeJS.Module,
   configPath: string,
@@ -1171,7 +1254,14 @@ function findCachedModule(
   cache: NodeJS.Require["cache"],
   filename: string,
 ): NodeJS.Module | undefined {
-  const realFilename = safeRealpath(filename);
+  const absoluteFilename = path.resolve(filename);
+  const direct = cache[absoluteFilename];
+  if (direct) return direct;
+
+  const realFilename = safeRealpath(absoluteFilename);
+  const realDirect = cache[realFilename];
+  if (realDirect) return realDirect;
+
   return Object.values(cache).find(
     (candidate) =>
       candidate?.filename && safeRealpath(candidate.filename) === realFilename,

--- a/packages/ev/src/_internal/build/dev-revision.ts
+++ b/packages/ev/src/_internal/build/dev-revision.ts
@@ -29,6 +29,10 @@ import {
 import { validateHtmlTemplates } from "./framework-output.js";
 import type { GeneratedIRImage } from "./generated-contributions.js";
 import type { GraphAnalysisResult } from "./graph/index.js";
+import {
+  collectProjectSourceResolutionWatchDirectories,
+  type SourceDependencyReporter,
+} from "./graph/source-resolution.js";
 import { CANONICAL_PAGE_ROUTE_ROOT } from "./page-route-conventions.js";
 import {
   orderPluginsByDependencies,
@@ -209,6 +213,23 @@ export async function prepareDevRevision<TBundlerCfg>(
     },
   };
 
+  const reportSourceDependency = ((file: string) => {
+    addDependency(file, "semantic");
+  }) as SourceDependencyReporter;
+  reportSourceDependency.resolutionCandidates = (candidates) => {
+    const firstCandidate = candidates[0];
+    const directParent = firstCandidate
+      ? path.dirname(firstCandidate)
+      : undefined;
+    if (directParent) addDependency(directParent, "semantic");
+    for (const directory of collectProjectSourceResolutionWatchDirectories(
+      candidates,
+    )) {
+      if (directory === directParent) continue;
+      addDependency(directory, "semantic");
+    }
+  };
+
   validateHtmlTemplates(options.cwd, config);
   const materialized = await analyzeAndMaterializeFrameworkIR({
     cwd: options.cwd,
@@ -222,9 +243,7 @@ export async function prepareDevRevision<TBundlerCfg>(
     beforeSourceRead(file) {
       addDependency(file, "semantic");
     },
-    onSourceDependency(file) {
-      addDependency(file, "semantic");
-    },
+    onSourceDependency: reportSourceDependency,
     onAnalysis(analysis) {
       reportGraphDiagnostics(analysis);
       for (const dependency of analysis.fileDependencies) {

--- a/packages/ev/src/_internal/build/dev-supervisor.ts
+++ b/packages/ev/src/_internal/build/dev-supervisor.ts
@@ -24,8 +24,10 @@ import {
 import type { DevSession } from "./dev-session.js";
 import { startDevSession } from "./dev-session.js";
 import {
-  collectWatchFilesChangedSince,
+  type CapturedWatchInputSnapshot,
+  captureWatchInputSnapshot,
   createWatchFilesPlan,
+  didWatchInputChange,
   listConfigDependencyFiles,
   type PreparedWatchFilesPlan,
   prepareWatchFilesPlan,
@@ -239,6 +241,12 @@ export async function runDevSupervisor<TBundlerCfg>(
       ...extra,
     ]);
 
+  const preparedDependencySet = (
+    dependencies: Iterable<string>,
+    sessionWatchFiles: Iterable<string> = active?.sessionWatchFiles ?? [],
+  ): Set<string> =>
+    new Set([...fixedDependencies, ...dependencies, ...sessionWatchFiles]);
+
   const fail = (error: unknown) => {
     if (stopping || fatalError !== undefined) return;
     fatalError = error;
@@ -255,9 +263,8 @@ export async function runDevSupervisor<TBundlerCfg>(
     );
   };
 
-  const refreshWatcher = (dependencies: Iterable<string>) => {
+  const activateWatcherPlan = (nextPlan: PreparedWatchFilesPlan) => {
     if (stopping) return;
-    const nextPlan = createPreparedWatchPlan(dependencies);
     if (watcher?.key === nextPlan.key) return;
     const nextStop = watchFiles(nextPlan, scheduleFileChange, {
       ignorePath: isIgnoredDependency,
@@ -277,6 +284,10 @@ export async function runDevSupervisor<TBundlerCfg>(
       stop: nextStop,
     };
     previous?.stop();
+  };
+
+  const refreshWatcher = (dependencies: Iterable<string>) => {
+    activateWatcherPlan(createPreparedWatchPlan(dependencies));
   };
 
   function scheduleFileChange(file: string): void {
@@ -301,11 +312,14 @@ export async function runDevSupervisor<TBundlerCfg>(
     target: Set<string>,
     file: string,
     switchingDependencies: Iterable<string>,
+    refresh: boolean,
   ) => {
     const absolute = path.resolve(options.cwd, file);
     if (isIgnoredDependency(absolute) || target.has(absolute)) return;
     target.add(absolute);
-    refreshWatcher(currentDependencySet([...switchingDependencies, ...target]));
+    if (refresh) {
+      refreshWatcher(preparedDependencySet(switchingDependencies, target));
+    }
   };
 
   const applyReservedPorts = async (
@@ -380,6 +394,7 @@ export async function runDevSupervisor<TBundlerCfg>(
     if (stopping) return;
 
     const sessionWatchFiles = new Set<string>();
+    let sessionStarting = true;
     const session = await startDevSession({
       bundler: prepared.bundler,
       config: prepared.config,
@@ -393,9 +408,11 @@ export async function runDevSupervisor<TBundlerCfg>(
           sessionWatchFiles,
           file,
           prepared.dependencies,
+          !sessionStarting,
         );
       },
     });
+    sessionStarting = false;
     if (stopping) {
       await session.close();
       return;
@@ -409,24 +426,24 @@ export async function runDevSupervisor<TBundlerCfg>(
     active = nextState;
     shortcutOwnerSession = session;
     retainedFailedDependencies.clear();
-    refreshWatcher(currentDependencySet());
+    if (sessionWatchFiles.size > 0) {
+      refreshWatcher(
+        preparedDependencySet(prepared.dependencies, sessionWatchFiles),
+      );
+    }
     monitorSession(nextState);
     void activateSession(nextState);
     void refreshCLIShortcutsSafely();
   };
 
   const reconcileAttemptChanged = (
-    baselines: ReadonlyMap<string, PreparedWatchFilesPlan>,
+    baselines: ReadonlyMap<string, CapturedWatchInputSnapshot>,
+    current: PreparedWatchFilesPlan,
   ): boolean => {
-    let changed = false;
     for (const [file, baseline] of baselines) {
-      const current = createPreparedWatchPlan([file]);
-      if (collectWatchFilesChangedSince(baseline, current).length === 0) {
-        continue;
-      }
-      changed = true;
+      if (didWatchInputChange(baseline, current, file)) return true;
     }
-    return changed;
+    return false;
   };
 
   async function runReconcileLoop(): Promise<void> {
@@ -437,14 +454,19 @@ export async function runDevSupervisor<TBundlerCfg>(
         if (attemptedRevision === targetRevision) continue;
         attemptedRevision = targetRevision;
         const attemptDependencies = new Set<string>();
-        const baselines = new Map<string, PreparedWatchFilesPlan>();
+        const baselines = new Map<string, CapturedWatchInputSnapshot>();
         const collector: DevDependencyCollector = {
           add(file: string, _kind: DevDependencyKind) {
             const absolute = path.resolve(file);
             if (isIgnoredDependency(absolute)) return;
             attemptDependencies.add(absolute);
             if (!baselines.has(absolute)) {
-              baselines.set(absolute, createPreparedWatchPlan([absolute]));
+              baselines.set(
+                absolute,
+                captureWatchInputSnapshot(absolute, {
+                  ignorePath: isIgnoredDependency,
+                }),
+              );
             }
           },
         };
@@ -484,15 +506,18 @@ export async function runDevSupervisor<TBundlerCfg>(
           continue;
         }
 
+        const nextWatchPlan = createPreparedWatchPlan(
+          preparedDependencySet(prepared.dependencies),
+        );
         if (
           targetRevision !== desiredRevision ||
-          reconcileAttemptChanged(baselines)
+          reconcileAttemptChanged(baselines, nextWatchPlan)
         ) {
           if (targetRevision === desiredRevision) desiredRevision += 1;
           reconcileRequested = true;
           continue;
         }
-        refreshWatcher(currentDependencySet(prepared.dependencies));
+        activateWatcherPlan(nextWatchPlan);
         if (active?.fingerprint === prepared.semanticFingerprint) {
           retainedFailedDependencies.clear();
           const current = active;
@@ -507,7 +532,6 @@ export async function runDevSupervisor<TBundlerCfg>(
               plan: current.revision.plan,
             },
           };
-          refreshWatcher(currentDependencySet());
           continue;
         }
         await switchSession(prepared);

--- a/packages/ev/src/_internal/build/dev-watch.ts
+++ b/packages/ev/src/_internal/build/dev-watch.ts
@@ -73,6 +73,11 @@ export interface PreparedWatchFilesPlan extends WatchFilesPlan {
   readonly unknownBaselineTargets: ReadonlySet<string>;
 }
 
+export interface CapturedWatchInputSnapshot {
+  readonly snapshot?: string;
+  readonly unknown: boolean;
+}
+
 interface PollingReadCache {
   readonly directories: Map<string, Promise<string[] | undefined>>;
   readonly files: Map<string, Promise<Buffer | undefined>>;
@@ -242,21 +247,45 @@ export function prepareWatchFilesPlan(
   const baselineSnapshots = new Map<string, string>();
   const unknownBaselineTargets = new Set<string>();
   for (const file of plan.logicalTargets) {
-    try {
-      baselineSnapshots.set(file, readWatchInputSnapshot(file, options));
-    } catch (error) {
-      if (isWatchResourceError(error)) {
-        unknownBaselineTargets.add(file);
-        continue;
-      }
-      throw createWatchError(file, error);
-    }
+    const captured = captureWatchInputSnapshot(file, options);
+    if (captured.unknown) unknownBaselineTargets.add(file);
+    else if (captured.snapshot !== undefined)
+      baselineSnapshots.set(file, captured.snapshot);
   }
   return {
     ...plan,
     baselineSnapshots,
     unknownBaselineTargets,
   };
+}
+
+/** Capture one input without constructing its physical watcher topology. */
+export function captureWatchInputSnapshot(
+  file: string,
+  options: WatchInputSnapshotOptions = {},
+): CapturedWatchInputSnapshot {
+  try {
+    return {
+      snapshot: readWatchInputSnapshot(file, options),
+      unknown: false,
+    };
+  } catch (error) {
+    if (isWatchResourceError(error)) return { unknown: true };
+    throw createWatchError(file, error);
+  }
+}
+
+export function didWatchInputChange(
+  baseline: CapturedWatchInputSnapshot,
+  current: PreparedWatchFilesPlan,
+  file: string,
+): boolean {
+  const absolute = path.resolve(file);
+  const currentUnknown = current.unknownBaselineTargets.has(absolute);
+  if (baseline.unknown || currentUnknown) {
+    return baseline.unknown !== currentUnknown;
+  }
+  return baseline.snapshot !== current.baselineSnapshots.get(absolute);
 }
 
 /** Returns an opaque semantic identity for a file or directory watch input. */

--- a/packages/ev/src/_internal/build/graph/source-resolution.ts
+++ b/packages/ev/src/_internal/build/graph/source-resolution.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { ROUTE_SOURCE_EXTENSIONS } from "../route-conventions.js";
 import { isInsideCwd } from "../utils.js";
@@ -6,6 +7,15 @@ export const PROJECT_SOURCE_EXTENSIONS = ROUTE_SOURCE_EXTENSIONS;
 
 const PROJECT_SOURCE_EXTENSION_SET = new Set<string>(PROJECT_SOURCE_EXTENSIONS);
 
+export interface SourceDependencyReporter {
+  (file: string): void;
+  /**
+   * Reports one ordered resolver probe without expanding every missing
+   * candidate into an independent file dependency.
+   */
+  resolutionCandidates?: (candidates: readonly string[]) => void;
+}
+
 export function isProjectSourceModule(file: string): boolean {
   return PROJECT_SOURCE_EXTENSION_SET.has(path.extname(file));
 }
@@ -13,7 +23,7 @@ export function isProjectSourceModule(file: string): boolean {
 export function registerProjectSourceResolutionCandidates(
   cwd: string,
   base: string,
-  onSourceDependency?: (file: string) => void,
+  onSourceDependency?: SourceDependencyReporter,
 ): string[] {
   const candidates = [base];
   if (!isProjectSourceModule(base)) {
@@ -30,15 +40,47 @@ export function registerProjectSourceResolutionCandidates(
 export function registerProjectSourceDependencies(
   cwd: string,
   candidates: readonly string[],
-  onSourceDependency?: (file: string) => void,
+  onSourceDependency?: SourceDependencyReporter,
 ): string[] {
   const projectCandidates = candidates.filter((candidate) =>
     isInsideCwd(cwd, candidate),
   );
-  for (const candidate of projectCandidates) {
-    onSourceDependency?.(candidate);
+  if (onSourceDependency?.resolutionCandidates) {
+    onSourceDependency.resolutionCandidates(projectCandidates);
+  } else {
+    for (const candidate of projectCandidates) {
+      onSourceDependency?.(candidate);
+    }
   }
   return projectCandidates;
+}
+
+/**
+ * Collapse one resolver probe into directory topology dependencies.
+ *
+ * The direct candidate parent observes extension alternatives. An existing
+ * nested candidate directory additionally observes index.* alternatives. A
+ * missing nested directory is intentionally omitted until its creation is
+ * observed by the direct parent and the next revision resolves it again.
+ */
+export function collectProjectSourceResolutionWatchDirectories(
+  candidates: readonly string[],
+): string[] {
+  const firstCandidate = candidates[0];
+  if (!firstCandidate) return [];
+
+  const directParent = path.dirname(firstCandidate);
+  const directories = new Set([directParent]);
+  for (const candidate of candidates) {
+    const directory = path.dirname(candidate);
+    if (directory === directParent || directories.has(directory)) continue;
+    try {
+      if (fs.statSync(directory).isDirectory()) directories.add(directory);
+    } catch (error) {
+      if (!isMissingSourcePathError(error)) throw error;
+    }
+  }
+  return [...directories].sort();
 }
 
 export function isMissingSourcePathError(error: unknown): boolean {

--- a/packages/ev/src/_internal/build/page-config-module.ts
+++ b/packages/ev/src/_internal/build/page-config-module.ts
@@ -24,7 +24,7 @@ import {
 } from "../../config/plugins.js";
 import {
   clearStaticConfigModuleCache,
-  loadStaticConfigModule,
+  createStaticConfigModuleSession,
 } from "./config-module.js";
 import { validatePageRenderingContract } from "./page-rendering-contract.js";
 
@@ -113,9 +113,10 @@ async function resolveKnownPageConfigModules(
     configuredPages.map((page) => path.resolve(cwd, page.configModule)),
     { projectRoot: cwd },
   );
+  const session = createStaticConfigModuleSession(cwd);
 
   for (const page of configuredPages) {
-    const resolved = await resolvePageConfigModule(cwd, page, options);
+    const resolved = await resolvePageConfigModule(cwd, page, options, session);
     defineRecordValue(pages, page.pageId, resolved.config);
     for (const dependency of resolved.dependencies) {
       dependencies.add(dependency);
@@ -132,6 +133,7 @@ async function resolvePageConfigModule(
   cwd: string,
   page: PageConfigMetadata,
   options: ResolvePageConfigModulesOptions,
+  session: ReturnType<typeof createStaticConfigModuleSession>,
 ): Promise<{
   config: ResolvedPageFileConfig;
   dependencies: string[];
@@ -139,8 +141,7 @@ async function resolvePageConfigModule(
   const source = page.configModule;
   const absoluteSource = path.resolve(cwd, source);
   options.beforeSourceRead?.(absoluteSource);
-  const loaded = await loadStaticConfigModule(absoluteSource, cwd, {
-    cache: true,
+  const loaded = await session.load(absoluteSource, {
     onDependency: options.onSourceDependency,
   });
   if (!loaded.hasDefaultExport) {

--- a/packages/ev/tests/dev-supervisor.test.ts
+++ b/packages/ev/tests/dev-supervisor.test.ts
@@ -886,6 +886,35 @@ describe("immutable dev supervisor", { timeout: 15_000 }, () => {
     await stopDev(run);
   });
 
+  it("reconciles when a higher-priority source candidate appears", async () => {
+    const cwd = await createProject({ page: true });
+    const sourceDirectory = path.join(cwd, "src/lib");
+    await fs.mkdir(sourceDirectory, { recursive: true });
+    await fs.writeFile(
+      path.join(cwd, "src/pages/page.tsx"),
+      'import { action } from "@/lib/helper";\nvoid action;\nexport default function Page() { return null; }\n',
+    );
+    await fs.writeFile(
+      path.join(sourceDirectory, "helper.js"),
+      '"use server";\nexport async function action() {}\n',
+    );
+    const controlled = createControlledBundler();
+    const config = { routing: { mode: "spa" } } as Config<
+      Record<string, never>
+    >;
+    const run = dev(config, { cwd, bundler: controlled.adapter });
+    await vi.waitFor(() => expect(controlled.starts).toHaveLength(1));
+
+    await fs.writeFile(
+      path.join(sourceDirectory, "helper.ts"),
+      "export async function action() {}\n",
+    );
+
+    await vi.waitFor(() => expect(controlled.starts).toHaveLength(2));
+    expect(controlled.maxActive).toBe(1);
+    await stopDev(run);
+  });
+
   it("keeps the active session when a reloaded config requests new ports", async () => {
     const cwd = await createProject();
     const configFile = path.join(cwd, "dev-config.json");

--- a/packages/ev/tests/dev-watch.test.ts
+++ b/packages/ev/tests/dev-watch.test.ts
@@ -4,9 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  captureWatchInputSnapshot,
   collectServerRouteWatchState,
   collectWatchFilesChangedSince,
   createWatchFilesPlan,
+  didWatchInputChange,
   listConfigDependencyFiles,
   prepareWatchFilesPlan,
   readWatchInputSnapshot,
@@ -126,6 +128,20 @@ describe("watchFiles", () => {
 
     expect(collectWatchFilesChangedSince(baseline, current)).toEqual([first]);
     expect(collectWatchFilesChangedSince(current, current)).toEqual([]);
+  });
+
+  it("compares a lightweight input capture with a prepared plan", async () => {
+    const root = await createTemporaryDirectory();
+    const file = path.join(root, "dependency.ts");
+    await writeFile(file);
+
+    const baseline = captureWatchInputSnapshot(file);
+    const unchanged = prepareWatchFilesPlan(createWatchFilesPlan([file]));
+    expect(didWatchInputChange(baseline, unchanged, file)).toBe(false);
+
+    await fs.promises.writeFile(file, "changed", "utf-8");
+    const changed = prepareWatchFilesPlan(createWatchFilesPlan([file]));
+    expect(didWatchInputChange(baseline, changed, file)).toBe(true);
   });
 
   it("canonicalizes dependency order without erasing recovery semantics", async () => {

--- a/packages/ev/tests/page-config-module.test.ts
+++ b/packages/ev/tests/page-config-module.test.ts
@@ -151,6 +151,104 @@ describe("page.config modules", () => {
     expect(second.dependencies).toEqual(first.dependencies);
   });
 
+  it("reuses one loading session across Page configs without retaining stale helpers", async () => {
+    const cwd = await createFixture({
+      "src/config/page-title.ts": 'export const title = "initial";',
+      "src/pages/first/page.tsx":
+        "export default function First() { return null; }",
+      "src/pages/first/page.config.ts": `
+        import { title } from "../../config/page-title.js";
+        export default { title: \`first:\${title}\` };
+      `,
+      "src/pages/second/page.tsx":
+        "export default function Second() { return null; }",
+      "src/pages/second/page.config.ts": `
+        import { title } from "../../config/page-title.js";
+        export default { title: \`second:\${title}\` };
+      `,
+    });
+    const metadata = createPagesMetadata([
+      {
+        pageId: "first",
+        configModule: "./src/pages/first/page.config.ts",
+      },
+      {
+        pageId: "second",
+        configModule: "./src/pages/second/page.config.ts",
+      },
+    ]);
+
+    const first = await resolvePageConfigModules(cwd, metadata);
+    expect(first.pages.first.metadata?.title).toBe("first:initial");
+    expect(first.pages.second.metadata?.title).toBe("second:initial");
+    await expectRealDependencies(first.dependencies, [
+      path.join(cwd, "src/config/page-title.ts"),
+      path.join(cwd, "src/pages/first/page.config.ts"),
+      path.join(cwd, "src/pages/second/page.config.ts"),
+    ]);
+
+    await fs.writeFile(
+      path.join(cwd, "src/config/page-title.ts"),
+      'export const title = "updated";',
+      "utf-8",
+    );
+
+    const second = await resolvePageConfigModules(cwd, metadata);
+    expect(second.pages.first.metadata?.title).toBe("first:updated");
+    expect(second.pages.second.metadata?.title).toBe("second:updated");
+    expect(second.dependencies).toEqual(first.dependencies);
+  });
+
+  it("keeps package-scoped aliases isolated within a shared loading session", async () => {
+    const cwd = await createFixture({
+      "src/pages/first/package.json": JSON.stringify({
+        imports: { "#settings": "./settings.ts" },
+      }),
+      "src/pages/first/settings.ts": 'export const title = "first";',
+      "src/pages/first/page.tsx":
+        "export default function First() { return null; }",
+      "src/pages/first/page.config.ts": `
+        import { title } from "#settings";
+        export default { title };
+      `,
+      "src/pages/second/package.json": JSON.stringify({
+        imports: { "#settings": "./settings.ts" },
+      }),
+      "src/pages/second/settings.ts": 'export const title = "second";',
+      "src/pages/second/page.tsx":
+        "export default function Second() { return null; }",
+      "src/pages/second/page.config.ts": `
+        import { title } from "#settings";
+        export default { title };
+      `,
+    });
+
+    const resolved = await resolvePageConfigModules(
+      cwd,
+      createPagesMetadata([
+        {
+          pageId: "first",
+          configModule: "./src/pages/first/page.config.ts",
+        },
+        {
+          pageId: "second",
+          configModule: "./src/pages/second/page.config.ts",
+        },
+      ]),
+    );
+
+    expect(resolved.pages.first.metadata?.title).toBe("first");
+    expect(resolved.pages.second.metadata?.title).toBe("second");
+    await expectRealDependencies(resolved.dependencies, [
+      path.join(cwd, "src/pages/first/package.json"),
+      path.join(cwd, "src/pages/first/settings.ts"),
+      path.join(cwd, "src/pages/first/page.config.ts"),
+      path.join(cwd, "src/pages/second/package.json"),
+      path.join(cwd, "src/pages/second/settings.ts"),
+      path.join(cwd, "src/pages/second/page.config.ts"),
+    ]);
+  });
+
   it("resolves false, true, and static object Page plugin settings", async () => {
     const cwd = await createFixture({
       "src/pages/checkout/page.tsx":
@@ -1254,16 +1352,25 @@ function createPageMetadata(
   pageId: string,
   configModule?: string,
 ): PageRouteDiscoveryMetadata {
-  const directory =
-    pageId === "index" ? "./src/pages" : `./src/pages/${pageId}`;
-  const page: PageAnchorMetadata = {
-    pageId,
-    directory,
-    entry: `${directory}/page.tsx`,
-    exportName: "default",
-    ...(configModule ? { configModule } : {}),
+  return createPagesMetadata([{ pageId, configModule }]);
+}
+
+function createPagesMetadata(
+  entries: Array<{ pageId: string; configModule?: string }>,
+): PageRouteDiscoveryMetadata {
+  return {
+    pages: entries.map(({ pageId, configModule }): PageAnchorMetadata => {
+      const directory =
+        pageId === "index" ? "./src/pages" : `./src/pages/${pageId}`;
+      return {
+        pageId,
+        directory,
+        entry: `${directory}/page.tsx`,
+        exportName: "default",
+        ...(configModule ? { configModule } : {}),
+      };
+    }),
   };
-  return { pages: [page] };
 }
 
 function createCanonicalGraphConfig(

--- a/packages/ev/tests/source-resolution.test.ts
+++ b/packages/ev/tests/source-resolution.test.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  collectProjectSourceResolutionWatchDirectories,
+  registerProjectSourceResolutionCandidates,
+  type SourceDependencyReporter,
+} from "../src/_internal/build/graph/source-resolution.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function createTemporaryDirectory(): Promise<string> {
+  const directory = await fs.mkdtemp(
+    path.join(os.tmpdir(), "evjs-source-resolution-"),
+  );
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+describe("source resolution dependencies", () => {
+  it("keeps candidate-by-candidate reporting for basic collectors", async () => {
+    const cwd = await createTemporaryDirectory();
+    const base = path.join(cwd, "src", "feature");
+    const report = vi.fn();
+
+    const candidates = registerProjectSourceResolutionCandidates(
+      cwd,
+      base,
+      report,
+    );
+
+    expect(report.mock.calls.map(([candidate]) => candidate)).toEqual(
+      candidates,
+    );
+  });
+
+  it("reports one ordered resolver probe to capable collectors", async () => {
+    const cwd = await createTemporaryDirectory();
+    const base = path.join(cwd, "src", "feature");
+    const resolutionCandidates = vi.fn();
+    const report = Object.assign(vi.fn(), {
+      resolutionCandidates,
+    }) as SourceDependencyReporter;
+
+    const candidates = registerProjectSourceResolutionCandidates(
+      cwd,
+      base,
+      report,
+    );
+
+    expect(report).not.toHaveBeenCalled();
+    expect(resolutionCandidates).toHaveBeenCalledOnce();
+    expect(resolutionCandidates).toHaveBeenCalledWith(candidates);
+  });
+
+  it("watches the direct parent and only existing index directories", async () => {
+    const cwd = await createTemporaryDirectory();
+    const source = path.join(cwd, "src");
+    const base = path.join(source, "feature");
+    await fs.mkdir(source, { recursive: true });
+    const missingCandidates = registerProjectSourceResolutionCandidates(
+      cwd,
+      base,
+    );
+
+    expect(
+      collectProjectSourceResolutionWatchDirectories(missingCandidates),
+    ).toEqual([source]);
+
+    await fs.mkdir(base);
+    expect(
+      collectProjectSourceResolutionWatchDirectories(missingCandidates),
+    ).toEqual([source, base].sort());
+  });
+});


### PR DESCRIPTION
## Summary
- Reduce framework dev startup overhead in dependency watching and Page config loading.
- Preserve revision freshness and source-resolution invalidation semantics while removing repeated preparation work.

## Changes
- Report ordered source resolution probes to capable dev collectors while preserving basic callback behavior.
- Watch candidate directory topology instead of every missing extension path, and reuse one prepared watcher plan per successful revision.
- Reuse one static config loading session across all Page configs in a revision.
- Group Jiti evaluation loaders by package alias/native-module resolution state so package scopes remain isolated.
- Resolve exact config roots directly from the shared module cache before falling back to realpath scanning.
- Add resolver, watcher race, cache freshness, shared-helper, and package-scope regression tests.

## Validation
- `npx turbo run build --filter=@evjs/ev`
- `npx turbo run test --filter=@evjs/ev` (32 files, 822 tests)
- `npm run check-types`
- `npm run lint`
- `npm test`
- `git diff --check`
- jinni-explore watcher A/B: median start-to-ready 3102 ms -> 2715 ms (3 alternating warm runs per variant)
- jinni-explore Page config batch: median 1021 ms -> 567 ms (7 fresh processes, 20 configs)
- jinni-explore framework boundary excluding Utoopack: median about 1.86 s -> 1.30 s (5 fresh processes)

## Risk / rollout
- Medium: framework dependency invalidation and config loading are startup-sensitive paths.
- Resolved source files remain content-watched; candidate creation/deletion is covered through directory topology.
- Page config sessions are revision-scoped. Every new revision clears config roots and prior project-local dependency closures before loading.
- Configs with different package aliases or native-module sets use separate evaluation loaders.
- Public plugin APIs and bundler HMR ownership do not change.

## Reviewer notes
- The first commit owns source-resolution watcher compaction and prepared-plan reuse.
- The second commit owns Page config session reuse and exact module-cache lookup.
- Please focus on resolution priority, package-scope isolation, and cache invalidation across dev revisions.
