### PR TITLE
fix(ev): observe watch files during session startup

### DIFF
--- a/packages/ev/src/_internal/build/dev-supervisor.ts
+++ b/packages/ev/src/_internal/build/dev-supervisor.ts
@@ -312,14 +312,11 @@ export async function runDevSupervisor<TBundlerCfg>(
     target: Set<string>,
     file: string,
     switchingDependencies: Iterable<string>,
-    refresh: boolean,
   ) => {
     const absolute = path.resolve(options.cwd, file);
     if (isIgnoredDependency(absolute) || target.has(absolute)) return;
     target.add(absolute);
-    if (refresh) {
-      refreshWatcher(preparedDependencySet(switchingDependencies, target));
-    }
+    refreshWatcher(preparedDependencySet(switchingDependencies, target));
   };
 
   const applyReservedPorts = async (
@@ -394,7 +391,6 @@ export async function runDevSupervisor<TBundlerCfg>(
     if (stopping) return;
 
     const sessionWatchFiles = new Set<string>();
-    let sessionStarting = true;
     const session = await startDevSession({
       bundler: prepared.bundler,
       config: prepared.config,
@@ -408,11 +404,9 @@ export async function runDevSupervisor<TBundlerCfg>(
           sessionWatchFiles,
           file,
           prepared.dependencies,
-          !sessionStarting,
         );
       },
     });
-    sessionStarting = false;
     if (stopping) {
       await session.close();
       return;
@@ -426,11 +420,9 @@ export async function runDevSupervisor<TBundlerCfg>(
     active = nextState;
     shortcutOwnerSession = session;
     retainedFailedDependencies.clear();
-    if (sessionWatchFiles.size > 0) {
-      refreshWatcher(
-        preparedDependencySet(prepared.dependencies, sessionWatchFiles),
-      );
-    }
+    refreshWatcher(
+      preparedDependencySet(prepared.dependencies, sessionWatchFiles),
+    );
     monitorSession(nextState);
     void activateSession(nextState);
     void refreshCLIShortcutsSafely();

--- a/packages/ev/tests/dev-supervisor.test.ts
+++ b/packages/ev/tests/dev-supervisor.test.ts
@@ -886,6 +886,62 @@ describe("immutable dev supervisor", { timeout: 15_000 }, () => {
     await stopDev(run);
   });
 
+  it("observes Session watch files while the bundler is starting", async () => {
+    const cwd = await createProject();
+    const watchFile = path.join(cwd, "plugin-state.txt");
+    await fs.writeFile(watchFile, "old");
+
+    let notifyFirstStartEntered!: () => void;
+    const firstStartEntered = new Promise<void>((resolve) => {
+      notifyFirstStartEntered = resolve;
+    });
+    let releaseFirstStart!: () => void;
+    const firstStartGate = new Promise<void>((resolve) => {
+      releaseFirstStart = resolve;
+    });
+    const controlled = createControlledBundler({
+      async beforeStart(_context, index) {
+        if (index !== 1) return;
+        notifyFirstStartEntered();
+        await firstStartGate;
+      },
+    });
+    const observedValues: string[] = [];
+    const plugin: Plugin<Record<string, never>> = {
+      id: "startup-watch",
+      async setup(context) {
+        observedValues.push(await fs.readFile(watchFile, "utf-8"));
+        context.addWatchFile(watchFile);
+        return {};
+      },
+    };
+    const run = dev(
+      { plugins: [plugin] },
+      { cwd, bundler: controlled.adapter },
+    );
+    let stopped = false;
+
+    try {
+      await firstStartEntered;
+      await fs.writeFile(watchFile, "new");
+      releaseFirstStart();
+
+      await vi.waitFor(() => expect(controlled.starts).toHaveLength(2));
+      expect(observedValues).toEqual(["old", "new"]);
+      expect(controlled.events.slice(0, 3)).toEqual([
+        "start:1",
+        "close:1",
+        "start:2",
+      ]);
+      expect(controlled.maxActive).toBe(1);
+      await stopDev(run);
+      stopped = true;
+    } finally {
+      releaseFirstStart();
+      if (!stopped) await stopDev(run).catch(() => {});
+    }
+  });
+
   it("reconciles when a higher-priority source candidate appears", async () => {
     const cwd = await createProject({ page: true });
     const sourceDirectory = path.join(cwd, "src/lib");


### PR DESCRIPTION
## Summary
- Fix a startup race where Session watch files could change after being consumed but before their watcher baseline was installed.
- Preserve the source-resolution candidate compaction and Page config loader reuse introduced by #107.

## Changes
- Refresh the framework watcher immediately whenever a plugin or bundler registers a new Session watch file, including while the bundler is starting.
- Always reconcile the final watcher plan after a Session starts so watch files owned only by the previous Session are removed.
- Add a deterministic regression test that changes a plugin watch file while the first bundler startup is blocked and verifies a replacement Session consumes the new value.

## Validation
- `npm --workspace @evjs/ev test` — 32 files, 823 tests passed.
- `npm run check-types` — 31 tasks passed.
- `npm run lint` — 529 files checked.

## Risk / rollout
- This restores immediate watcher refresh for newly registered Session watch files, so startup work can grow with the number of plugin or bundler watch registrations.
- The larger #107 performance wins remain in place; there are no API, configuration, or production-build behavior changes.

## Reviewer notes
- Please focus on watcher ownership during `startDevSession` and the blocked-start regression test.
- A future optimization can batch Session watch registration only after an incremental watcher API can preserve continuous observation.