### PR TITLE
docs(changelog): prepare v0.3.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.13] — 2026-08-17
+
 ### ⚠️ Breaking Changes
 
 - **Explicit global middleware composition** — The global server middleware
@@ -25,6 +29,21 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
   modules at ordered positions around an exact Page-owned `page-server` entry.
   Import contributions compose with the existing replacement mode without
   changing other server renderer kinds.
+
+### ✨ Improvements
+
+- **Faster framework development startup** — Development dependency collection
+  collapses ordered source-resolution probes into directory topology watches,
+  reuses prepared watcher plans, and shares Page-config loading sessions while
+  preserving higher-priority candidate invalidation and package-scoped module
+  resolution.
+
+### 🐛 Bug Fixes
+
+- **Complete Session watch coverage during startup** — Plugin and bundler watch
+  files become observable as soon as they are registered, preventing edits
+  during adapter startup from leaving the active immutable Session on stale
+  input. Replacement Sessions also reconcile final watcher ownership.
 
 ---
 


### PR DESCRIPTION
## Summary
- Prepare the 0.3.13 release changelog from the changes merged since v0.3.12.
- Keep source workspace versions at 0.0.0 so the existing Release workflow can stamp and publish the requested version.

## Changes
- Move the current Unreleased entries under a dated 0.3.13 section.
- Document the global middleware composition breaking change and Page server entry imports.
- Document the framework dev startup improvements and Session startup watch fix.

## Validation
- `npm run lint`
- `npm run check-types` (pre-push hook)

## Risk / rollout
- Documentation-only change; no runtime, package manifest, or lockfile changes.
- After merge, publishing GitHub Release `v0.3.13` will trigger the existing npm release workflow.

## Reviewer notes
- Confirm the changelog covers all user-facing changes in `v0.3.12...main`.
- The 0.3.x version is intentional; the changelog records why the pre-1.0 middleware convention change remains on this release line.