### PR TITLE
docs(changelog): prepare v0.3.14 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.14] — 2026-08-18
+
 ### 🐛 Bug Fixes
 
 - **Aligned plugin planning lifecycle** — Development, inspect, prepare, and


### PR DESCRIPTION
## Summary
- Promote the current plugin lifecycle fix from `Unreleased` to the `0.3.14` patch release dated 2026-08-18.
- Prepare the canonical changelog state used for the `v0.3.14` GitHub Release and npm publication.

## Changes
- Add the `0.3.14` release heading in `CHANGELOG.md`.
- Leave a new empty `Unreleased` section for subsequent changes.

## Validation
- `npm run lint`
- `npm run check-types`
- `npm --workspace evjs-docs run build`
- `git diff --check`

## Risk / rollout
- Documentation-only release preparation; no runtime, configuration, data, security, or performance behavior changes.
- npm publication occurs only after the follow-up `v0.3.14` GitHub Release is published.

## Reviewer notes
- Please verify the version, date, and that the release contains only the plugin lifecycle fix already merged in #112.