### PR TITLE
docs(changelog): prepare v0.3.15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ---
 
+## [0.3.15] — 2026-08-20
+
+### ✨ Features
+
+- **Client development middleware** — Plugins can install ordered asynchronous
+  middleware in front of the public development server with request-origin,
+  Session abort, and cleanup lifecycles. Utoopack and Webpack both support the
+  capability, including HTTP, HTTPS, and HMR/WebSocket forwarding.
+- **Application root wrappers** — Plugins can contribute stable, ordered
+  `application.wrapper` Framework IR around the complete CSR application root
+  without replacing framework-owned entry source.
+
+### ✨ Improvements
+
+- **Domain-oriented framework sources** — Reorganized Core, shared contracts,
+  bundler adapters, runtimes, CLI, scaffolding, and plugin implementations by
+  capability while preserving supported package entry points as thin façades.
+  Published package builds now clean compiled output first so removed physical
+  paths cannot remain in release tarballs.
+
+---
+
 ## [0.3.14] — 2026-08-18
 
 ### 🐛 Bug Fixes


### PR DESCRIPTION
## Summary
- Prepare the changelog for the `v0.3.15` patch release dated 2026-08-20.
- Capture the two changes merged since `v0.3.14`: client development middleware/application wrappers and the repository-wide domain reorganization.

## Changes
- Add the `0.3.15` release section with feature and improvement notes.
- Leave a new empty `Unreleased` section for subsequent work.

## Validation
- `npm run lint` — 561 files checked.
- `npm run check-types` — 31/31 tasks passed.
- `npm --workspace evjs-docs run build` — English and Chinese builds passed.
- `git diff --check` — passed.
- Main CI for the release contents passed: https://github.com/afx-team/evjs/actions/runs/32319589755

## Risk / rollout
- Documentation-only release preparation; no runtime, configuration, data, security, or performance behavior changes.
- npm publication occurs only after the follow-up `v0.3.15` GitHub Release is published.

## Reviewer notes
- Verify the version, date, and that the notes cover exactly the changes merged in #114 and #82.