### PR TITLE
chore: upgrade TypeScript to 7

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
     "@docusaurus/module-type-aliases": "^3.7.0",
     "@docusaurus/tsconfig": "^3.9.2",
     "@docusaurus/types": "^3.7.0",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   },
   "browserslist": {
     "production": [

--- a/examples/api-routes/package.json
+++ b/examples/api-routes/package.json
@@ -16,6 +16,6 @@
     "@evjs/cli": "*",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.8",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   }
 }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -16,6 +16,6 @@
     "@evjs/cli": "*",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.8",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   }
 }

--- a/examples/complex-routing/package.json
+++ b/examples/complex-routing/package.json
@@ -16,6 +16,6 @@
     "@evjs/cli": "*",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.8",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   }
 }

--- a/examples/custom-ws-transport/package.json
+++ b/examples/custom-ws-transport/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.8",
     "@types/ws": "^8.18.1",
-    "typescript": "^6.0.2",
+    "typescript": "^7.0.2",
     "ws": "^8.18.2"
   }
 }

--- a/examples/deployment-adapters/package.json
+++ b/examples/deployment-adapters/package.json
@@ -17,6 +17,6 @@
     "@evjs/cli": "*",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.8",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   }
 }

--- a/examples/mpa/package.json
+++ b/examples/mpa/package.json
@@ -16,6 +16,6 @@
     "@evjs/cli": "*",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.8",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   }
 }

--- a/examples/plugin-authoring/package.json
+++ b/examples/plugin-authoring/package.json
@@ -17,6 +17,6 @@
     "@evjs/cli": "*",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.8",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   }
 }

--- a/examples/qiankun-master/package.json
+++ b/examples/qiankun-master/package.json
@@ -17,6 +17,6 @@
     "@evjs/cli": "*",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.8",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   }
 }

--- a/examples/qiankun-slave/package.json
+++ b/examples/qiankun-slave/package.json
@@ -17,6 +17,6 @@
     "@evjs/cli": "*",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.8",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   }
 }

--- a/examples/render-modes/package.json
+++ b/examples/render-modes/package.json
@@ -17,6 +17,6 @@
     "@evjs/cli": "*",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.8",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   }
 }

--- a/examples/ssg/package.json
+++ b/examples/ssg/package.json
@@ -17,6 +17,6 @@
     "@evjs/cli": "*",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.8",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   }
 }

--- a/examples/with-sqlite/package.json
+++ b/examples/with-sqlite/package.json
@@ -16,6 +16,6 @@
     "@evjs/cli": "*",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.8",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   }
 }

--- a/examples/with-tailwind/package.json
+++ b/examples/with-tailwind/package.json
@@ -23,6 +23,6 @@
     "postcss-loader": "^8.1.1",
     "style-loader": "^4.0.0",
     "tailwindcss": "^4.1.10",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   }
 }

--- a/examples/with-trpc/package.json
+++ b/examples/with-trpc/package.json
@@ -19,6 +19,6 @@
     "@evjs/cli": "*",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.8",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "husky": "^9.1.7",
         "tailwindcss": "^4.1.10",
         "turbo": "^2.4.2",
+        "typescript": "^7.0.2",
         "vitest": "^4.0.18"
       }
     },
@@ -45,7 +46,7 @@
         "@docusaurus/module-type-aliases": "^3.7.0",
         "@docusaurus/tsconfig": "^3.9.2",
         "@docusaurus/types": "^3.7.0",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "examples/api-routes": {
@@ -60,7 +61,7 @@
         "@evjs/cli": "*",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.8",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "examples/basic": {
@@ -75,7 +76,7 @@
         "@evjs/cli": "*",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.8",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "examples/basic-csr": {
@@ -196,7 +197,7 @@
         "@evjs/cli": "*",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.8",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "examples/configured-server-fns": {
@@ -230,7 +231,7 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.8",
         "@types/ws": "^8.18.1",
-        "typescript": "^6.0.2",
+        "typescript": "^7.0.2",
         "ws": "^8.18.2"
       }
     },
@@ -247,7 +248,7 @@
         "@evjs/cli": "*",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.8",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "examples/mpa": {
@@ -262,7 +263,7 @@
         "@evjs/cli": "*",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.8",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "examples/plugin-authoring": {
@@ -278,7 +279,7 @@
         "@evjs/cli": "*",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.8",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "examples/qiankun-master": {
@@ -294,7 +295,7 @@
         "@evjs/cli": "*",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.8",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "examples/qiankun-slave": {
@@ -310,7 +311,7 @@
         "@evjs/cli": "*",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.8",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "examples/render-modes": {
@@ -326,7 +327,7 @@
         "@evjs/cli": "*",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.8",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "examples/server-fns-query": {
@@ -378,7 +379,7 @@
         "@evjs/cli": "*",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.8",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "examples/trpc-server-fns": {
@@ -434,7 +435,7 @@
         "@evjs/cli": "*",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.8",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "examples/with-tailwind": {
@@ -456,7 +457,7 @@
         "postcss-loader": "^8.1.1",
         "style-loader": "^4.0.0",
         "tailwindcss": "^4.1.10",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "examples/with-trpc": {
@@ -474,7 +475,7 @@
         "@evjs/cli": "*",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.8",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -613,7 +614,6 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.50.2.tgz",
       "integrity": "sha512-ypSboUJ3XJoQz5DeDo82hCnrRuwq3q9ZdFhVKAik9TnZh1DvLqoQsrbBjXg7C7zQOtV/Qbge/HmyoV6V5L7MhQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.50.2",
         "@algolia/requester-browser-xhr": "5.50.2",
@@ -765,7 +765,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2848,7 +2847,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2871,7 +2869,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2981,7 +2978,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3403,7 +3399,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -4474,7 +4469,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.10.0.tgz",
       "integrity": "sha512-GNPtVH14ISjHfSwnHu3KiFGf86ICmJSQDeSv/QaanpBgiZGOtgZaslnC5q8WiguxM1EVkwcGxPuD8BXF4eggKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/types": "3.10.0",
         "@rspack/core": "^1.7.10",
@@ -4605,7 +4599,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.0.tgz",
       "integrity": "sha512-9BjHhf15ct8Z7TThTC0xRndKDVvMKmVsAGAN7W9FpNRzfMdScOGcXtLmcCWtJGvAezjOJIm6CxOYCy3Io5+RnQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.10.0",
         "@docusaurus/logger": "3.10.0",
@@ -5200,6 +5193,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -5267,7 +5270,6 @@
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -5858,7 +5860,6 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -6706,7 +6707,6 @@
       "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.7.11.tgz",
       "integrity": "sha512-rsD9b+Khmot5DwCMiB3cqTQo53ioPG3M/A7BySu8+0+RS7GCxKm+Z+mtsjtG/vsu4Tn2tcqCdZtA3pgLoJB+ew==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/runtime-tools": "0.22.0",
         "@rspack/binding": "1.7.11",
@@ -6963,7 +6963,6 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -7068,7 +7067,6 @@
       "integrity": "sha512-R8VQbQY1BZcbIF2p3gjlTCwAQzx1A194ugWfwld5y+WgVVWqVKm7eURGGOVbQVubgKWzidP2agomBbg96rZilQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.26"
@@ -7915,7 +7913,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.2.tgz",
       "integrity": "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.99.2"
       },
@@ -8008,7 +8005,6 @@
         "https://trpc.io/sponsor"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "intent": "bin/intent.js"
       },
@@ -8041,7 +8037,6 @@
         "https://trpc.io/sponsor"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "intent": "bin/intent.js"
       },
@@ -8674,7 +8669,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -8820,6 +8814,326 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -9293,7 +9607,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9360,6 +9673,7 @@
       "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
       "integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loader-utils": "^2.0.0",
         "regex-parser": "^2.2.11"
@@ -9386,7 +9700,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9432,7 +9745,6 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.50.2.tgz",
       "integrity": "sha512-Tfp26yoNWurUjfgK4GOrVJQhSNXu9tJtHfFFNosgT2YClG+vPyUjX/gbC8rG39qLncnZg8Fj34iarQWpMkqefw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.16.2",
         "@algolia/client-abtesting": "5.50.2",
@@ -9946,7 +10258,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.11.12",
         "caniuse-lite": "^1.0.30001809",
@@ -10277,7 +10588,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
       "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "12.0.0",
         "@chevrotain/gast": "12.0.0",
@@ -10430,7 +10740,8 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/clone-deep": {
       "version": "4.0.1",
@@ -10713,6 +11024,7 @@
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
       "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-what": "^4.1.8"
       },
@@ -11015,7 +11327,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11335,7 +11646,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
       "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -11745,7 +12055,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -13178,7 +13487,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13956,7 +14264,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -14739,6 +15046,7 @@
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
       "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.13"
       },
@@ -15061,6 +15369,7 @@
       "resolved": "https://registry.npmjs.org/less/-/less-4.6.4.tgz",
       "integrity": "sha512-OJmO5+HxZLLw0RLzkqaNHzcgEAQG7C0y3aMbwtCzIUFZsLMNNq/1IdAdHEycQ58CwUO3jPTHmoN+tE5I7FQxNg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "copy-anything": "^3.0.5",
         "parse-node-version": "^1.0.1"
@@ -15086,7 +15395,6 @@
       "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-12.3.2.tgz",
       "integrity": "sha512-uLV5c702ff2jBvO7qewpkLRzkh/I9QW07ur2NKkv8TVTrtX2lrKjEbEU/LLXAn7cgpCIBbkfyUm4qYXCQs5/+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18.12.0"
       },
@@ -15114,6 +15422,7 @@
       "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
         "image-size": "bin/image-size.js"
       },
@@ -15127,6 +15436,7 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18242,7 +18552,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18777,7 +19086,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18905,7 +19213,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -19898,7 +20205,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -20776,7 +21082,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20841,7 +21146,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -20870,7 +21174,6 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -21070,7 +21373,8 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.3.1.tgz",
       "integrity": "sha512-yXLRqatcCuKtVHsWrNg0JL3l1zGfdXeEvDa0bdu4tCDQw0RpMDZsqbkyRTUnKMR0tXF627V2oEWjBEaEdqTwtQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/regexpu-core": {
       "version": "6.4.0",
@@ -21496,13 +21800,15 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/resolve-url-loader/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21884,7 +22190,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.2.tgz",
       "integrity": "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -22724,8 +23029,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -22991,8 +23295,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -23086,17 +23389,37 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/ufo": {
@@ -23450,7 +23773,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -23631,7 +23953,6 @@
       "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -23895,7 +24216,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -24559,7 +24879,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.19.15",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "packages/bundler-utoopack/node_modules/@babel/code-frame": {
@@ -24874,7 +25194,8 @@
       "version": "4.3.8",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
       "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "packages/bundler-utoopack/node_modules/is-what": {
       "version": "3.14.1",
@@ -24887,7 +25208,6 @@
       "resolved": "https://registry.npmjs.org/less/-/less-4.1.3.tgz",
       "integrity": "sha512-w16Xk/Ta9Hhyei0Gpz9m7VS8F28nieJaL/VyShID7cYvP6IL5oHeL6p4TXSDJqZE/lNv0oJ2pGVjJsRkfwm5FA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -25112,7 +25432,7 @@
         "@types/node": "^22.19.15",
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0",
-        "typescript": "^6.0.2",
+        "typescript": "^7.0.2",
         "vitest": "^4.0.18"
       }
     },
@@ -25132,7 +25452,7 @@
       "devDependencies": {
         "@evjs/shared": "*",
         "@types/node": "^22.19.15",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "packages/client": {
@@ -25148,7 +25468,7 @@
         "@types/react": ">=18.0.0",
         "@types/react-dom": ">=18.0.0",
         "react-server-dom-webpack": "^19.2.5",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -25171,12 +25491,12 @@
         "prompts": "^2.4.2"
       },
       "bin": {
-        "create-evjs-app": "dist/index.js"
+        "create-evjs-app": "bin/create-evjs-app.js"
       },
       "devDependencies": {
         "@types/node": "^22.19.15",
         "@types/prompts": "^2.4.9",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     },
     "packages/ev": {
@@ -25203,7 +25523,7 @@
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0",
         "react-server-dom-webpack": "^19.2.5",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -25229,7 +25549,7 @@
         "@types/node": "^22.19.15",
         "@types/react": ">=18.0.0",
         "domparser-rs": "^0.1.0",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       },
       "peerDependencies": {
         "react": ">=18.0.0"
@@ -25249,7 +25569,7 @@
         "@types/node": "^22.19.15",
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0",
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -25273,7 +25593,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "typescript": "^6.0.2"
+        "typescript": "^7.0.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "husky": "^9.1.7",
     "tailwindcss": "^4.1.10",
     "turbo": "^2.4.2",
+    "typescript": "^7.0.2",
     "vitest": "^4.0.18"
   }
 }

--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.15",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   },
   "homepage": "https://github.com/afx-team/evjs#readme",
   "bugs": {

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -49,7 +49,7 @@
     "@types/node": "^22.19.15",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0",
-    "typescript": "^6.0.2",
+    "typescript": "^7.0.2",
     "vitest": "^4.0.18"
   },
   "homepage": "https://github.com/afx-team/evjs#readme",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@evjs/shared": "*",
     "@types/node": "^22.19.15",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   },
   "homepage": "https://github.com/afx-team/evjs#readme",
   "bugs": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -21,7 +21,7 @@
     "@types/react": ">=18.0.0",
     "@types/react-dom": ">=18.0.0",
     "react-server-dom-webpack": "^19.2.5",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   },
   "homepage": "https://github.com/afx-team/evjs#readme",
   "bugs": {

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/node": "^22.19.15",
     "@types/prompts": "^2.4.9",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   },
   "homepage": "https://github.com/afx-team/evjs#readme",
   "bugs": {

--- a/packages/create-app/tests/scaffold.test.ts
+++ b/packages/create-app/tests/scaffold.test.ts
@@ -254,6 +254,19 @@ describe("create-app scaffolding", () => {
     }
   });
 
+  it("templates target the TypeScript 7 compiler", () => {
+    for (const template of listTemplateNames()) {
+      const pkg = JSON.parse(
+        fs.readFileSync(
+          path.join(templatesDir, template, "package.json"),
+          "utf-8",
+        ),
+      );
+
+      expect(pkg.devDependencies?.typescript).toMatch(/^\^7\./);
+    }
+  });
+
   it("template tsconfig enables the default source import alias", () => {
     const templates = listTemplateNames();
 

--- a/packages/ev/package.json
+++ b/packages/ev/package.json
@@ -177,7 +177,7 @@
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0",
     "react-server-dom-webpack": "^19.2.5",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   },
   "keywords": [
     "evjs",

--- a/packages/ev/tests/plugin-types.test.ts
+++ b/packages/ev/tests/plugin-types.test.ts
@@ -415,8 +415,6 @@ describe("plugin type output", () => {
       `,
       "tsconfig.json": JSON.stringify({
         compilerOptions: {
-          baseUrl: ".",
-          ignoreDeprecations: "6.0",
           module: "ESNext",
           moduleResolution: "Bundler",
           noEmit: true,
@@ -432,7 +430,7 @@ describe("plugin type output", () => {
     });
     await syncPluginTypes({ cwd });
 
-    const tsc = require.resolve("typescript/bin/tsc");
+    const tsc = resolveTypeScriptCli();
     await expect(
       execFileAsync(process.execPath, [tsc, "--project", "tsconfig.json"], {
         cwd,
@@ -491,8 +489,6 @@ describe("plugin type output", () => {
       `,
         "tsconfig.json": JSON.stringify({
           compilerOptions: {
-            baseUrl: ".",
-            ignoreDeprecations: "6.0",
             module: "ESNext",
             moduleResolution: "Bundler",
             noEmit: true,
@@ -518,7 +514,7 @@ describe("plugin type output", () => {
       });
       await syncPluginTypes({ cwd });
 
-      const tsc = require.resolve("typescript/bin/tsc");
+      const tsc = resolveTypeScriptCli();
       await expect(
         execFileAsync(process.execPath, [tsc, "--project", "tsconfig.json"], {
           cwd,
@@ -549,8 +545,6 @@ describe("plugin type output", () => {
       `,
       "tsconfig.json": JSON.stringify({
         compilerOptions: {
-          baseUrl: ".",
-          ignoreDeprecations: "6.0",
           module: "ESNext",
           moduleResolution: "Bundler",
           noEmit: true,
@@ -566,7 +560,7 @@ describe("plugin type output", () => {
     });
     await syncPluginTypes({ cwd });
 
-    const tsc = require.resolve("typescript/bin/tsc");
+    const tsc = resolveTypeScriptCli();
     await expect(
       execFileAsync(process.execPath, [tsc, "--project", "tsconfig.json"], {
         cwd,
@@ -579,6 +573,14 @@ async function createTempDir(): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ev-plugin-types-"));
   tempDirs.push(dir);
   return dir;
+}
+
+function resolveTypeScriptCli(): string {
+  return path.join(
+    path.dirname(require.resolve("typescript/package.json")),
+    "bin",
+    "tsc",
+  );
 }
 
 async function writeFixtureFiles(

--- a/packages/plugin-qiankun/package.json
+++ b/packages/plugin-qiankun/package.json
@@ -49,7 +49,7 @@
     "@types/node": "^22.19.15",
     "@types/react": ">=18.0.0",
     "domparser-rs": "^0.1.0",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   },
   "keywords": [
     "evjs",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -83,7 +83,7 @@
     "@types/node": "^22.19.15",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   },
   "keywords": [
     "evjs",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -44,7 +44,7 @@
   "author": "xusd320",
   "dependencies": {},
   "devDependencies": {
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   },
   "keywords": [
     "evjs",


### PR DESCRIPTION
## Summary
- Upgrade the repository compiler baseline from TypeScript 6 to TypeScript 7.0.2.
- Keep the root toolchain, framework packages, documentation workspace, examples, and create-app templates on one compiler version.
- Adapt compiler-invoking tests to the public TypeScript 7 package surface.

