### PR TITLE
docs(changelog): prepare v0.3.16 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.16] — 2026-08-24
+
+### ✨ Features
+
+- **Browser logs in the development terminal** — Applications can configure
+  `logging.browserToTerminal` as `"error"`, `"warn"`, `true`, or `false`.
+  Utoopack forwards browser console output with source-mapped locations during
+  `ev dev`, defaulting to errors only; Webpack remains unchanged.
+
+### ✨ Improvements
+
+- **TypeScript 7 toolchain** — The repository compiler baseline, published
+  workspace development toolchain, documentation, examples, and create-app
+  templates now consistently target TypeScript 7.0.2. Compiler-invoking tests
+  use the public TypeScript package surface.
+
 ### 🐛 Bug Fixes
 
 - **Single-realm Utoopack native ownership** — `ev dev` now keeps Utoopack's


### PR DESCRIPTION
## Summary
- Prepare the changelog for the `v0.3.16` patch release dated 2026-08-24.
- Capture the three changes merged since `v0.3.15`: browser-to-terminal development logs, single-realm Utoopack native ownership, and the TypeScript 7 toolchain.

## Changes
- Add the `0.3.16` release section with feature, improvement, and bug-fix notes.
- Leave a new empty `Unreleased` section for subsequent work.

## Validation
- `npm run check-types` — 31/31 tasks passed.
- `npm run lint` — 565 files checked.
- `npm test` — 17/17 tasks passed.
- `npm --workspace evjs-docs run build` — English and Chinese builds passed.
- `git diff --check` — passed.

## Risk / rollout
- Documentation-only release preparation; it does not change runtime, configuration, data, security, or performance behavior.
- npm publication occurs only after the follow-up `v0.3.16` GitHub Release is published.

## Reviewer notes
- Verify the version and date, and confirm that the notes cover exactly #118, #117, and #120.