### PR TITLE
fix(release): publish server with OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
             throw new Error("RELEASE_VERSION is required.");
           }
           const registry = "https://registry.npmjs.org";
+          const trustedPublisherPackages = new Set([
+            "@evjs/ev",
+            "@evjs/server",
+          ]);
 
           const prereleaseId = version.match(
             /^[^-]+-([0-9A-Za-z-]+)(?:[.+]|$)/,
@@ -194,7 +198,7 @@ jobs:
 
             console.log(`Publishing ${spec}...`);
             const publishEnv = { ...process.env };
-            if (name === "@evjs/ev") {
+            if (trustedPublisherPackages.has(name)) {
               delete publishEnv.NODE_AUTH_TOKEN;
               delete publishEnv.NPM_CONFIG_USERCONFIG;
               publishEnv.NPM_ID_TOKEN = await getGithubNpmIdToken();


### PR DESCRIPTION
## Summary
- Publish `@evjs/server` through the npm trusted-publisher path already configured for the package.
- Fix the v0.3.16 release failure caused by retaining legacy token authentication for this workspace.

## Changes
- Define the workspaces that use npm trusted publishing in the release script.
- Remove `NODE_AUTH_TOKEN` and the setup-node user config, then inject `NPM_ID_TOKEN` for both `@evjs/ev` and `@evjs/server`.

## Validation
- `npm run check-types`
- `npm run lint`
- `npm test`
- `git diff --check`

## Risk / rollout
- Low: the change is scoped to npm authentication for two explicitly trusted-publisher packages.
- The release script remains resumable and will skip v0.3.16 packages that are already published.

## Reviewer notes
- Please focus on the authentication selection in `.github/workflows/release.yml` and the v0.3.16 recovery path.