### PR TITLE
ci(release): harden package publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,22 +8,33 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     name: Build & Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 22
+          node-version: 22.23.2
           cache: npm
 
+      - name: Setup npm
+        run: npm install --global npm@11.19.0
+
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build Core Packages
         run: npx turbo build --filter="./packages/*"
@@ -44,7 +55,7 @@ jobs:
         run: npm run test:e2e
 
       - name: Upload Playwright Report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() && hashFiles('e2e/playwright-report/**') != '' }}
         with:
           name: playwright-report

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,11 +8,6 @@ on:
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: pages
   cancel-in-progress: false
@@ -20,26 +15,33 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 22
+          node-version: 22.23.2
           cache: npm
 
+      - name: Setup npm
+        run: npm install --global npm@11.19.0
+
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build docs
         run: npm run build
         working-directory: docs
 
-      - uses: actions/configure-pages@v6
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: docs/build
 
@@ -49,7 +51,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,221 +5,203 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
+      operation:
+        description: "Release operation"
+        required: true
+        type: choice
+        default: publish
+        options:
+          - publish
+          - verify-oidc
       version:
-        description: "Version to publish, with or without the v prefix"
+        description: "Published GitHub release version, with or without the v prefix"
         required: true
 
+permissions: {}
+
+concurrency:
+  group: npm-release
+  queue: max
+
 jobs:
-  release:
-    name: Publish to npm
+  resolve:
+    name: Resolve release
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
-      contents: write
-      id-token: write
+      contents: read
+    outputs:
+      operation: ${{ steps.release.outputs.operation }}
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v6
+      - name: Checkout workflow source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Validate published release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RAW_OPERATION: ${{ github.event_name == 'release' && 'publish' || inputs.operation }}
+          RAW_VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version }}
+        run: |
+          VERSION="$(node --input-type=module -e '
+            import { normalizeVersion } from "./scripts/release-packages.mjs";
+            process.stdout.write(normalizeVersion(process.env.RAW_VERSION));
+          ')"
+          TAG="v${VERSION}"
+          OPERATION="${RAW_OPERATION:-publish}"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "release" && "${RAW_VERSION}" != "${TAG}" ]]; then
+            echo "Release tags must use the v<semver> form." >&2
+            exit 1
+          fi
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "Manual releases must be dispatched from main." >&2
+            exit 1
+          fi
+          if [[ "${OPERATION}" != "publish" && "${OPERATION}" != "verify-oidc" ]]; then
+            echo "Unsupported release operation: ${OPERATION}" >&2
+            exit 1
+          fi
+
+          if [[ "${OPERATION}" == "publish" ]]; then
+            RELEASE="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")"
+            if ! jq -e '.draft == false and .published_at != null' >/dev/null <<<"${RELEASE}"; then
+              echo "${TAG} is not a published GitHub release." >&2
+              exit 1
+            fi
+            COMPARISON="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${TAG}...main" --jq .status)"
+            if [[ "${COMPARISON}" != "identical" && "${COMPARISON}" != "ahead" ]]; then
+              echo "${TAG} does not point to a commit on main." >&2
+              exit 1
+            fi
+          fi
+
+          echo "operation=${OPERATION}" >>"${GITHUB_OUTPUT}"
+          echo "tag=${TAG}" >>"${GITHUB_OUTPUT}"
+          echo "version=${VERSION}" >>"${GITHUB_OUTPUT}"
+
+  build:
+    name: Build release artifacts
+    needs: resolve
+    if: needs.resolve.outputs.operation == 'publish'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 22
+          node-version: 22.23.2
+          package-manager-cache: false
+
+      - name: Setup npm
+        run: npm install --global npm@11.19.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Sync release versions
+        env:
+          RELEASE_VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          npm pkg set version="${RELEASE_VERSION}" --workspaces --include-workspace-root
+          npm run sync-release-dependencies -- --version "${RELEASE_VERSION}"
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Validate packages
+        run: npm run lint && npm run check-types && npm test
+
+      - name: Pack all release artifacts
+        env:
+          RELEASE_VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          node scripts/release-packages.mjs pack \
+            --version "${RELEASE_VERSION}" \
+            --output release-artifacts
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: npm-release-${{ needs.resolve.outputs.version }}
+          path: release-artifacts/
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  publish:
+    name: Publish to npm
+    needs: [resolve, build]
+    if: needs.resolve.outputs.operation == 'publish'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: npm-release
+      url: https://www.npmjs.com/org/evjs
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22.23.2
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
 
       - name: Setup npm
-        run: npm install -g npm@11.6.2
+        run: npm install --global npm@11.19.0
 
-      - name: Install Dependencies
-        run: npm install
+      - name: Download release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: npm-release-${{ needs.resolve.outputs.version }}
+          path: release-artifacts
 
-      - name: Sync version from release tag
+      - name: Publish immutable artifacts
         env:
-          RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+          RELEASE_VERSION: ${{ needs.resolve.outputs.version }}
         run: |
-          VERSION="${RELEASE_VERSION#v}"
-          npm pkg set version="${VERSION}" -ws --include-workspace-root
-          npm run sync-release-dependencies -- --version "${VERSION}"
+          node release-artifacts/release-packages.mjs publish \
+            --version "${RELEASE_VERSION}" \
+            --input release-artifacts
 
-      - name: Build Packages
-        run: npm run build
+  verify:
+    name: Verify npm OIDC
+    needs: resolve
+    if: needs.resolve.outputs.operation == 'verify-oidc'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: npm-release
+      url: https://www.npmjs.com/org/evjs
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: main
 
-      - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
-        run: |
-          node --input-type=module <<'NODE'
-          import { spawnSync } from "node:child_process";
-          import { existsSync, readFileSync, readdirSync } from "node:fs";
-          import path from "node:path";
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22.23.2
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
-          const version = process.env.RELEASE_VERSION?.replace(/^v/, "");
-          if (!version) {
-            throw new Error("RELEASE_VERSION is required.");
-          }
-          const registry = "https://registry.npmjs.org";
-          const trustedPublisherPackages = new Set([
-            "@evjs/ev",
-            "@evjs/server",
-          ]);
+      - name: Setup npm
+        run: npm install --global npm@11.19.0
 
-          const prereleaseId = version.match(
-            /^[^-]+-([0-9A-Za-z-]+)(?:[.+]|$)/,
-          )?.[1];
-          let npmTag = "latest";
-          if (prereleaseId === "alpha" || prereleaseId === "rc") {
-            npmTag = prereleaseId;
-          } else if (prereleaseId) {
-            npmTag = "next";
-          }
-
-          console.log(`Publishing ${version} with npm dist-tag ${npmTag}.`);
-
-          const wait = (ms) =>
-            new Promise((resolve) => {
-              setTimeout(resolve, ms);
-            });
-
-          async function getGithubNpmIdToken() {
-            const requestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
-            const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
-            if (!requestUrl || !requestToken) {
-              throw new Error(
-                "GitHub OIDC token request environment is unavailable.",
-              );
-            }
-
-            let lastError = "unknown error";
-            for (let attempt = 1; attempt <= 3; attempt += 1) {
-              const url = new URL(requestUrl);
-              url.searchParams.set(
-                "audience",
-                `npm:${new URL(registry).hostname}`,
-              );
-              const response = await fetch(url, {
-                headers: {
-                  Accept: "application/json",
-                  Authorization: `Bearer ${requestToken}`,
-                },
-              });
-              const text = await response.text();
-              let body = undefined;
-              try {
-                body = JSON.parse(text);
-              } catch {
-                lastError = text.slice(0, 200);
-              }
-              if (response.ok && typeof body?.value === "string") {
-                return body.value;
-              }
-              lastError =
-                typeof body?.message === "string"
-                  ? body.message
-                  : `${response.status}: ${lastError}`;
-              if (attempt < 3) {
-                console.log(
-                  `GitHub OIDC token request failed on attempt ${attempt}; retrying.`,
-                );
-                await wait(attempt * 2_000);
-              }
-            }
-            throw new Error(`Failed to retrieve GitHub OIDC token: ${lastError}`);
-          }
-
-          const workspacePackages = readdirSync("packages")
-            .map((name) => path.join("packages", name))
-            .filter((dir) => existsSync(path.join(dir, "package.json")))
-            .map((dir) => ({
-              dir,
-              packageJson: JSON.parse(
-                readFileSync(path.join(dir, "package.json"), "utf8"),
-              ),
-            }))
-            .filter(
-              ({ packageJson }) =>
-                packageJson.private !== true &&
-                typeof packageJson.name === "string",
-            );
-
-          const byName = new Map(
-            workspacePackages.map((workspacePackage) => [
-              workspacePackage.packageJson.name,
-              workspacePackage,
-            ]),
-          );
-          const ordered = [];
-          const visited = new Set();
-          const visiting = new Set();
-
-          function visit(workspacePackage) {
-            const name = workspacePackage.packageJson.name;
-            if (visited.has(name)) return;
-            if (visiting.has(name)) {
-              throw new Error(`Circular workspace dependency involving ${name}.`);
-            }
-            visiting.add(name);
-
-            const dependencyNames = new Set([
-              ...Object.keys(workspacePackage.packageJson.dependencies ?? {}),
-              ...Object.keys(workspacePackage.packageJson.peerDependencies ?? {}),
-              ...Object.keys(
-                workspacePackage.packageJson.optionalDependencies ?? {},
-              ),
-            ]);
-            for (const dependencyName of dependencyNames) {
-              const dependencyPackage = byName.get(dependencyName);
-              if (dependencyPackage) {
-                visit(dependencyPackage);
-              }
-            }
-
-            visiting.delete(name);
-            visited.add(name);
-            ordered.push(workspacePackage);
-          }
-
-          for (const workspacePackage of workspacePackages.toSorted((a, b) =>
-            a.packageJson.name.localeCompare(b.packageJson.name),
-          )) {
-            visit(workspacePackage);
-          }
-
-          for (const workspacePackage of ordered) {
-            const name = workspacePackage.packageJson.name;
-            const spec = `${name}@${version}`;
-            const viewResult = spawnSync("npm", ["view", spec, "version"], {
-              stdio: "ignore",
-            });
-            if (viewResult.status === 0) {
-              console.log(`${spec} is already published; skipping.`);
-              continue;
-            }
-
-            console.log(`Publishing ${spec}...`);
-            const publishEnv = { ...process.env };
-            if (trustedPublisherPackages.has(name)) {
-              delete publishEnv.NODE_AUTH_TOKEN;
-              delete publishEnv.NPM_CONFIG_USERCONFIG;
-              publishEnv.NPM_ID_TOKEN = await getGithubNpmIdToken();
-            }
-            const publishResult = spawnSync(
-              "npm",
-              [
-                "publish",
-                "--workspace",
-                workspacePackage.dir,
-                "--access",
-                "public",
-                "--tag",
-                npmTag,
-                "--registry",
-                registry,
-              ],
-              { stdio: "inherit", env: publishEnv },
-            );
-            if (publishResult.status !== 0) {
-              process.exit(publishResult.status ?? 1);
-            }
-          }
-          NODE
+      - name: Verify all trusted publishers
+        run: node scripts/release-packages.mjs verify

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "React fullstack framework for file-based pages and Hono servers",
   "private": true,
-  "packageManager": "npm@11.6.2",
+  "packageManager": "npm@11.19.0",
   "workspaces": [
     "packages/*",
     "examples/*",
@@ -22,7 +22,8 @@
   "author": "xusd320",
   "scripts": {
     "build": "turbo build",
-    "test": "turbo test",
+    "test": "turbo test && npm run test:release",
+    "test:release": "node --test scripts/release-packages.test.mjs",
     "test:e2e": "playwright test --config e2e/playwright.config.ts",
     "dev": "turbo dev",
     "lint": "biome check .",

--- a/scripts/release-packages.mjs
+++ b/scripts/release-packages.mjs
@@ -1,0 +1,770 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const defaultRootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const manifestFileName = "release-manifest.json";
+const releaseScriptFileName = "release-packages.mjs";
+const manifestSchemaVersion = 1;
+const registry = "https://registry.npmjs.org";
+const repositoryUrl = "git+https://github.com/afx-team/evjs.git";
+const dependencySections = [
+  "dependencies",
+  "peerDependencies",
+  "optionalDependencies",
+];
+const trustedPublisherPackages = new Set([
+  "@evjs/bundler-utoopack",
+  "@evjs/bundler-webpack",
+  "@evjs/cli",
+  "@evjs/client",
+  "@evjs/create-app",
+  "@evjs/ev",
+  "@evjs/plugin-qiankun",
+  "@evjs/server",
+  "@evjs/shared",
+]);
+const semverPattern =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+export function normalizeVersion(rawVersion) {
+  if (typeof rawVersion !== "string" || rawVersion.length === 0) {
+    throw new Error("A release version is required.");
+  }
+
+  const version = rawVersion.startsWith("v") ? rawVersion.slice(1) : rawVersion;
+  if (!semverPattern.test(version)) {
+    throw new Error(`${rawVersion} is not a valid semantic version.`);
+  }
+  return version;
+}
+
+export function getNpmTag(version) {
+  const normalizedVersion = normalizeVersion(version);
+  const prerelease = normalizedVersion.split("-")[1]?.split("+")[0];
+  const prereleaseId = prerelease?.split(".")[0];
+
+  if (prereleaseId === "alpha" || prereleaseId === "rc") {
+    return prereleaseId;
+  }
+  return prereleaseId ? "next" : "latest";
+}
+
+export function orderWorkspacePackages(workspacePackages) {
+  const packagesByName = new Map(
+    workspacePackages.map((workspacePackage) => [
+      workspacePackage.packageJson.name,
+      workspacePackage,
+    ]),
+  );
+  const ordered = [];
+  const visited = new Set();
+  const visiting = new Set();
+
+  function visit(workspacePackage) {
+    const name = workspacePackage.packageJson.name;
+    if (visited.has(name)) return;
+    if (visiting.has(name)) {
+      throw new Error(`Circular workspace dependency involving ${name}.`);
+    }
+
+    visiting.add(name);
+    const dependencyNames = new Set(
+      dependencySections.flatMap((section) =>
+        Object.keys(workspacePackage.packageJson[section] ?? {}),
+      ),
+    );
+    for (const dependencyName of [...dependencyNames].sort()) {
+      const dependencyPackage = packagesByName.get(dependencyName);
+      if (dependencyPackage) visit(dependencyPackage);
+    }
+
+    visiting.delete(name);
+    visited.add(name);
+    ordered.push(workspacePackage);
+  }
+
+  for (const workspacePackage of workspacePackages.toSorted((left, right) =>
+    left.packageJson.name.localeCompare(right.packageJson.name),
+  )) {
+    visit(workspacePackage);
+  }
+  return ordered;
+}
+
+export function planPublication(manifestPackages, registryStates, npmTag) {
+  const published = [];
+  const unpublished = [];
+
+  for (const manifestPackage of manifestPackages) {
+    const state = registryStates.get(manifestPackage.name);
+    if (!state?.versionMetadata) {
+      unpublished.push(manifestPackage);
+      continue;
+    }
+    published.push({ manifestPackage, state });
+  }
+
+  if (unpublished.length === 0) {
+    return { complete: true, published, unpublished };
+  }
+
+  for (const { manifestPackage, state } of published) {
+    assertMatchingIntegrity(manifestPackage, state.versionMetadata);
+    if (state.tagVersion !== manifestPackage.version) {
+      throw new Error(
+        `${manifestPackage.name}@${manifestPackage.version} exists, but its ${npmTag} dist-tag points to ${state.tagVersion ?? "nothing"}. Refusing to continue a mixed release.`,
+      );
+    }
+  }
+
+  return { complete: false, published, unpublished };
+}
+
+function readWorkspacePackages(rootDir, version) {
+  const packagesDir = path.join(rootDir, "packages");
+  const workspacePackages = readdirSync(packagesDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(packagesDir, entry.name))
+    .filter((dir) => existsSync(path.join(dir, "package.json")))
+    .map((dir) => ({
+      dir,
+      packageJson: JSON.parse(
+        readFileSync(path.join(dir, "package.json"), "utf8"),
+      ),
+    }))
+    .filter(
+      ({ packageJson }) =>
+        packageJson.private !== true &&
+        typeof packageJson.name === "string" &&
+        packageJson.name.startsWith("@evjs/"),
+    );
+  const packageNames = new Set(
+    workspacePackages.map(({ packageJson }) => packageJson.name),
+  );
+  for (const packageName of trustedPublisherPackages) {
+    if (!packageNames.has(packageName)) {
+      throw new Error(
+        `Trusted publisher package ${packageName} is missing from the workspace.`,
+      );
+    }
+  }
+  for (const packageName of packageNames) {
+    if (!trustedPublisherPackages.has(packageName)) {
+      throw new Error(
+        `${packageName} must be added to the npm trusted publisher preflight before release.`,
+      );
+    }
+  }
+
+  for (const workspacePackage of workspacePackages) {
+    const { packageJson } = workspacePackage;
+    const relativeManifestPath = path.relative(
+      rootDir,
+      path.join(workspacePackage.dir, "package.json"),
+    );
+    if (packageJson.version !== version) {
+      throw new Error(
+        `${relativeManifestPath} has version ${packageJson.version}; expected ${version}.`,
+      );
+    }
+    const packageRepositoryUrl =
+      typeof packageJson.repository === "string"
+        ? packageJson.repository
+        : packageJson.repository?.url;
+    if (packageRepositoryUrl !== repositoryUrl) {
+      throw new Error(
+        `${relativeManifestPath} must declare repository ${repositoryUrl} for npm trusted publishing.`,
+      );
+    }
+
+    for (const section of dependencySections) {
+      for (const [dependencyName, dependencyVersion] of Object.entries(
+        packageJson[section] ?? {},
+      )) {
+        if (packageNames.has(dependencyName) && dependencyVersion !== version) {
+          throw new Error(
+            `${relativeManifestPath} has ${section}.${dependencyName}=${dependencyVersion}; expected ${version}.`,
+          );
+        }
+      }
+    }
+  }
+
+  return orderWorkspacePackages(workspacePackages);
+}
+
+function parsePackOutput(stdout, packageName) {
+  try {
+    const result = JSON.parse(stdout);
+    if (Array.isArray(result) && result.length === 1) return result[0];
+  } catch {
+    // A package lifecycle script may have written a line before npm's JSON.
+  }
+
+  for (
+    let start = stdout.lastIndexOf("[");
+    start !== -1;
+    start = stdout.lastIndexOf("[", start - 1)
+  ) {
+    try {
+      const result = JSON.parse(stdout.slice(start).trim());
+      if (Array.isArray(result) && result.length === 1) return result[0];
+    } catch {
+      // Try the preceding array marker until npm's trailing JSON is found.
+    }
+  }
+  throw new Error(`npm pack returned invalid JSON for ${packageName}.`);
+}
+
+function getFileIntegrity(filePath) {
+  return `sha512-${createHash("sha512")
+    .update(readFileSync(filePath))
+    .digest("base64")}`;
+}
+
+function getSourceCommit(rootDir) {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: rootDir,
+    encoding: "utf8",
+  });
+  if (result.status !== 0 || !/^[0-9a-f]{40}$/.test(result.stdout.trim())) {
+    throw new Error("Unable to resolve the release source commit.");
+  }
+  return result.stdout.trim();
+}
+
+function packRelease({ rootDir, outputDir, version }) {
+  const normalizedVersion = normalizeVersion(version);
+  const absoluteRootDir = path.resolve(rootDir);
+  const absoluteOutputDir = path.resolve(outputDir);
+  if (absoluteOutputDir === absoluteRootDir) {
+    throw new Error(
+      "The release artifact directory cannot be the repository root.",
+    );
+  }
+  if (existsSync(absoluteOutputDir)) {
+    throw new Error(
+      `Release artifact directory already exists: ${absoluteOutputDir}`,
+    );
+  }
+  mkdirSync(absoluteOutputDir, { recursive: true });
+
+  const workspacePackages = readWorkspacePackages(
+    absoluteRootDir,
+    normalizedVersion,
+  );
+  if (workspacePackages.length === 0) {
+    throw new Error("No public @evjs workspace packages were found.");
+  }
+
+  const manifestPackages = [];
+  for (const workspacePackage of workspacePackages) {
+    const name = workspacePackage.packageJson.name;
+    console.log(`Packing ${name}@${normalizedVersion}...`);
+    const packResult = spawnSync(
+      "npm",
+      [
+        "pack",
+        "--workspace",
+        path.relative(absoluteRootDir, workspacePackage.dir),
+        "--pack-destination",
+        absoluteOutputDir,
+        "--json",
+      ],
+      {
+        cwd: absoluteRootDir,
+        encoding: "utf8",
+        env: process.env,
+        maxBuffer: 10 * 1024 * 1024,
+      },
+    );
+    if (packResult.status !== 0) {
+      process.stderr.write(packResult.stderr ?? "");
+      throw new Error(`npm pack failed for ${name}.`);
+    }
+
+    const packed = parsePackOutput(packResult.stdout, name);
+    if (packed.name !== name || packed.version !== normalizedVersion) {
+      throw new Error(
+        `npm pack produced ${packed.name}@${packed.version}; expected ${name}@${normalizedVersion}.`,
+      );
+    }
+    const tarball = path.basename(packed.filename);
+    const tarballPath = path.join(absoluteOutputDir, tarball);
+    if (!existsSync(tarballPath)) {
+      throw new Error(`npm pack did not create ${tarballPath}.`);
+    }
+    const integrity = getFileIntegrity(tarballPath);
+    if (packed.integrity && packed.integrity !== integrity) {
+      throw new Error(`npm pack reported the wrong integrity for ${name}.`);
+    }
+
+    manifestPackages.push({
+      name,
+      version: normalizedVersion,
+      tarball,
+      integrity,
+      shasum: packed.shasum,
+    });
+  }
+
+  const manifest = {
+    schemaVersion: manifestSchemaVersion,
+    version: normalizedVersion,
+    npmTag: getNpmTag(normalizedVersion),
+    registry,
+    sourceCommit: getSourceCommit(absoluteRootDir),
+    packages: manifestPackages,
+  };
+  writeFileSync(
+    path.join(absoluteOutputDir, manifestFileName),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  copyFileSync(
+    fileURLToPath(import.meta.url),
+    path.join(absoluteOutputDir, releaseScriptFileName),
+  );
+  console.log(
+    `Packed ${manifestPackages.length} packages for ${normalizedVersion} with npm dist-tag ${manifest.npmTag}.`,
+  );
+}
+
+function readReleaseManifest(inputDir, expectedVersion) {
+  const absoluteInputDir = path.resolve(inputDir);
+  const manifestPath = path.join(absoluteInputDir, manifestFileName);
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const version = normalizeVersion(expectedVersion);
+
+  if (manifest.schemaVersion !== manifestSchemaVersion) {
+    throw new Error(
+      `Unsupported release manifest schema ${manifest.schemaVersion}.`,
+    );
+  }
+  if (manifest.version !== version) {
+    throw new Error(
+      `Release manifest version is ${manifest.version}; expected ${version}.`,
+    );
+  }
+  if (
+    manifest.npmTag !== getNpmTag(version) ||
+    manifest.registry !== registry
+  ) {
+    throw new Error("Release manifest registry or npm dist-tag is invalid.");
+  }
+  if (!Array.isArray(manifest.packages) || manifest.packages.length === 0) {
+    throw new Error("Release manifest contains no packages.");
+  }
+  if (!/^[0-9a-f]{40}$/.test(manifest.sourceCommit)) {
+    throw new Error("Release manifest contains an invalid source commit.");
+  }
+
+  const packageNames = new Set();
+  for (const manifestPackage of manifest.packages) {
+    if (
+      typeof manifestPackage.name !== "string" ||
+      !manifestPackage.name.startsWith("@evjs/") ||
+      packageNames.has(manifestPackage.name)
+    ) {
+      throw new Error("Release manifest contains an invalid package name.");
+    }
+    packageNames.add(manifestPackage.name);
+    if (manifestPackage.version !== version) {
+      throw new Error(
+        `${manifestPackage.name} has the wrong manifest version.`,
+      );
+    }
+    if (
+      typeof manifestPackage.tarball !== "string" ||
+      path.basename(manifestPackage.tarball) !== manifestPackage.tarball
+    ) {
+      throw new Error(`${manifestPackage.name} has an invalid tarball path.`);
+    }
+    const tarballPath = path.join(absoluteInputDir, manifestPackage.tarball);
+    if (!existsSync(tarballPath)) {
+      throw new Error(`Missing release tarball: ${manifestPackage.tarball}`);
+    }
+    if (getFileIntegrity(tarballPath) !== manifestPackage.integrity) {
+      throw new Error(
+        `Release tarball integrity mismatch: ${manifestPackage.tarball}`,
+      );
+    }
+    manifestPackage.tarballPath = tarballPath;
+  }
+  for (const packageName of trustedPublisherPackages) {
+    if (!packageNames.has(packageName)) {
+      throw new Error(`Release manifest is missing ${packageName}.`);
+    }
+  }
+  for (const packageName of packageNames) {
+    if (!trustedPublisherPackages.has(packageName)) {
+      throw new Error(`Release manifest contains unexpected ${packageName}.`);
+    }
+  }
+  return manifest;
+}
+
+const wait = (milliseconds) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+
+async function fetchPackageState(
+  packageName,
+  version,
+  npmTag,
+  { attempts = 4 } = {},
+) {
+  const escapedPackageName = packageName.replace("/", "%2f");
+  const url = new URL(`/${escapedPackageName}`, registry);
+  let lastError = "unknown registry error";
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      url.searchParams.set("cache", `${Date.now()}-${attempt}`);
+      const response = await fetch(url, {
+        headers: {
+          Accept: "application/vnd.npm.install-v1+json",
+          "Cache-Control": "no-cache",
+        },
+      });
+      if (response.status === 404) {
+        return { versionMetadata: null, tagVersion: null };
+      }
+      if (response.ok) {
+        const packument = await response.json();
+        return {
+          versionMetadata: packument.versions?.[version] ?? null,
+          tagVersion: packument["dist-tags"]?.[npmTag] ?? null,
+        };
+      }
+      lastError = `${response.status} ${response.statusText}`;
+      if (response.status < 500 && response.status !== 429) break;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    if (attempt < attempts) await wait(attempt * 1_000);
+  }
+  throw new Error(`Failed to read ${packageName} from npm: ${lastError}`);
+}
+
+function assertMatchingIntegrity(manifestPackage, versionMetadata) {
+  const publishedIntegrity = versionMetadata.dist?.integrity;
+  const publishedShasum = versionMetadata.dist?.shasum;
+  if (
+    publishedIntegrity !== manifestPackage.integrity &&
+    (!manifestPackage.shasum || publishedShasum !== manifestPackage.shasum)
+  ) {
+    throw new Error(
+      `${manifestPackage.name}@${manifestPackage.version} is already published from a different tarball.`,
+    );
+  }
+}
+
+async function getGithubNpmIdToken() {
+  const requestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+  const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+  if (!requestUrl || !requestToken) {
+    throw new Error("GitHub OIDC token request environment is unavailable.");
+  }
+
+  let lastError = "unknown error";
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    const url = new URL(requestUrl);
+    url.searchParams.set("audience", `npm:${new URL(registry).hostname}`);
+    try {
+      const response = await fetch(url, {
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${requestToken}`,
+        },
+      });
+      const text = await response.text();
+      let body;
+      try {
+        body = JSON.parse(text);
+      } catch {
+        lastError = text.slice(0, 200);
+      }
+      if (response.ok && typeof body?.value === "string") return body.value;
+      lastError =
+        typeof body?.message === "string"
+          ? body.message
+          : `${response.status}: ${lastError}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    if (attempt < 3) await wait(attempt * 2_000);
+  }
+  throw new Error(`Failed to retrieve GitHub OIDC token: ${lastError}`);
+}
+
+async function verifyTrustedPublisher(packageName) {
+  let lastError = "unknown npm OIDC exchange error";
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    const idToken = await getGithubNpmIdToken();
+    const escapedPackageName = packageName.replace("/", "%2f");
+    try {
+      const response = await fetch(
+        new URL(
+          `/-/npm/v1/oidc/token/exchange/package/${escapedPackageName}`,
+          registry,
+        ),
+        {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            Authorization: `Bearer ${idToken}`,
+          },
+        },
+      );
+      const body = await response.json().catch(() => ({}));
+      if (response.ok && typeof body.token === "string") {
+        console.log(`${packageName}: npm trusted publisher verified.`);
+        return;
+      }
+      lastError =
+        typeof body.message === "string"
+          ? `${response.status} ${body.message}`
+          : `${response.status} ${response.statusText}`;
+      if (response.status < 500 && response.status !== 429) break;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    if (attempt < 3) await wait(attempt * 2_000);
+  }
+  throw new Error(
+    `${packageName}: npm trusted publisher verification failed: ${lastError}`,
+  );
+}
+
+async function verifyPublishCredentials(unpublishedPackages) {
+  for (const manifestPackage of unpublishedPackages) {
+    if (!trustedPublisherPackages.has(manifestPackage.name)) {
+      throw new Error(
+        `${manifestPackage.name} is not configured for trusted publishing.`,
+      );
+    }
+    await verifyTrustedPublisher(manifestPackage.name);
+  }
+}
+
+async function confirmPublished(manifestPackage, npmTag) {
+  let lastError;
+  for (let attempt = 1; attempt <= 6; attempt += 1) {
+    try {
+      const state = await fetchPackageState(
+        manifestPackage.name,
+        manifestPackage.version,
+        npmTag,
+        { attempts: 1 },
+      );
+      if (state.versionMetadata) {
+        assertMatchingIntegrity(manifestPackage, state.versionMetadata);
+        if (state.tagVersion !== manifestPackage.version) {
+          throw new Error(
+            `${manifestPackage.name} published without the expected ${npmTag} dist-tag.`,
+          );
+        }
+        return true;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    if (attempt < 6) await wait(attempt * 1_000);
+  }
+  if (lastError) throw lastError;
+  return false;
+}
+
+async function publishPackage(manifestPackage, npmTag) {
+  const publishEnv = { ...process.env };
+  delete publishEnv.NODE_AUTH_TOKEN;
+  delete publishEnv.NPM_CONFIG_USERCONFIG;
+  publishEnv.NPM_ID_TOKEN = await getGithubNpmIdToken();
+
+  console.log(
+    `Publishing ${manifestPackage.name}@${manifestPackage.version}...`,
+  );
+  const result = spawnSync(
+    "npm",
+    [
+      "publish",
+      manifestPackage.tarballPath,
+      "--access",
+      "public",
+      "--tag",
+      npmTag,
+      "--ignore-scripts",
+      "--registry",
+      registry,
+    ],
+    { stdio: "inherit", env: publishEnv },
+  );
+  const published = await confirmPublished(manifestPackage, npmTag);
+  if (!published) {
+    throw new Error(
+      `npm publish failed for ${manifestPackage.name} with exit code ${result.status ?? "unknown"}.`,
+    );
+  }
+  if (result.status !== 0) {
+    console.log(
+      `${manifestPackage.name}@${manifestPackage.version} reached npm despite the CLI error; continuing.`,
+    );
+  }
+}
+
+async function publishRelease({ inputDir, version }) {
+  const manifest = readReleaseManifest(inputDir, version);
+  console.log(
+    `Checking ${manifest.packages.length} packages for ${manifest.version}...`,
+  );
+  const registryStates = new Map(
+    await Promise.all(
+      manifest.packages.map(async (manifestPackage) => [
+        manifestPackage.name,
+        await fetchPackageState(
+          manifestPackage.name,
+          manifestPackage.version,
+          manifest.npmTag,
+        ),
+      ]),
+    ),
+  );
+  const plan = planPublication(
+    manifest.packages,
+    registryStates,
+    manifest.npmTag,
+  );
+  if (plan.complete) {
+    console.log(`All packages for ${manifest.version} are already published.`);
+    return;
+  }
+
+  for (const { manifestPackage } of plan.published) {
+    console.log(
+      `${manifestPackage.name}@${manifestPackage.version} is already published from the matching tarball; skipping.`,
+    );
+  }
+  await verifyPublishCredentials(plan.unpublished);
+  console.log("All required npm publishing credentials passed preflight.");
+
+  for (const manifestPackage of plan.unpublished) {
+    await publishPackage(manifestPackage, manifest.npmTag);
+  }
+  console.log(
+    `Published all ${manifest.packages.length} packages for ${manifest.version}.`,
+  );
+}
+
+async function verifyAllTrustedPublishers() {
+  await verifyPublishCredentials(
+    [...trustedPublisherPackages].sort().map((name) => ({ name })),
+  );
+  console.log(
+    `Verified npm trusted publishing for all ${trustedPublisherPackages.size} packages.`,
+  );
+}
+
+function readRequiredArg(args, index, flag) {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value.`);
+  }
+  return value;
+}
+
+function parseArgs(args) {
+  const command = args[0];
+  if (command === "--help" || command === "-h") return { command: "help" };
+  if (command !== "pack" && command !== "publish" && command !== "verify") {
+    throw new Error("The first argument must be pack, publish, or verify.");
+  }
+
+  const options = { command, rootDir: defaultRootDir };
+  for (let index = 1; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--version") {
+      options.version = readRequiredArg(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--root") {
+      options.rootDir = path.resolve(readRequiredArg(args, index, arg));
+      index += 1;
+      continue;
+    }
+    if (arg === "--output") {
+      options.outputDir = path.resolve(readRequiredArg(args, index, arg));
+      index += 1;
+      continue;
+    }
+    if (arg === "--input") {
+      options.inputDir = path.resolve(readRequiredArg(args, index, arg));
+      index += 1;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") return { command: "help" };
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (command !== "verify" && !options.version) {
+    throw new Error("--version is required.");
+  }
+  if (command === "pack" && !options.outputDir) {
+    throw new Error("--output is required for pack.");
+  }
+  if (command === "publish" && !options.inputDir) {
+    throw new Error("--input is required for publish.");
+  }
+  return options;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/release-packages.mjs pack --version <version> --output <dir>
+  node scripts/release-packages.mjs publish --version <version> --input <dir>
+  node scripts/release-packages.mjs verify
+
+The pack command validates and packs every public @evjs workspace before any
+credentials are granted. The publish command verifies all required credentials
+before publishing the immutable tarballs in dependency order. The verify
+command checks every npm trusted publisher without publishing.`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.command === "help") {
+    printHelp();
+    return;
+  }
+  if (options.command === "pack") {
+    packRelease(options);
+    return;
+  }
+  if (options.command === "verify") {
+    await verifyAllTrustedPublishers();
+    return;
+  }
+  await publishRelease(options);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/release-packages.test.mjs
+++ b/scripts/release-packages.test.mjs
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getNpmTag,
+  normalizeVersion,
+  orderWorkspacePackages,
+  planPublication,
+} from "./release-packages.mjs";
+
+test("normalizes valid release versions", () => {
+  assert.equal(normalizeVersion("0.3.17"), "0.3.17");
+  assert.equal(
+    normalizeVersion("v1.2.3-alpha.1+build.5"),
+    "1.2.3-alpha.1+build.5",
+  );
+});
+
+test("rejects ambiguous or invalid release versions", () => {
+  for (const version of ["", "1.2", "01.2.3", "1.2.3-01", "vv1.2.3"]) {
+    assert.throws(() => normalizeVersion(version));
+  }
+});
+
+test("maps release versions to npm dist-tags", () => {
+  assert.equal(getNpmTag("1.2.3"), "latest");
+  assert.equal(getNpmTag("1.2.3-alpha.1"), "alpha");
+  assert.equal(getNpmTag("1.2.3-rc.2"), "rc");
+  assert.equal(getNpmTag("1.2.3-beta.1"), "next");
+});
+
+test("orders packages after their internal dependencies", () => {
+  const workspacePackages = [
+    {
+      packageJson: {
+        name: "@evjs/cli",
+        dependencies: { "@evjs/ev": "1.0.0" },
+      },
+    },
+    {
+      packageJson: {
+        name: "@evjs/ev",
+        dependencies: { "@evjs/shared": "1.0.0" },
+      },
+    },
+    { packageJson: { name: "@evjs/shared" } },
+  ];
+
+  assert.deepEqual(
+    orderWorkspacePackages(workspacePackages).map(
+      ({ packageJson }) => packageJson.name,
+    ),
+    ["@evjs/shared", "@evjs/ev", "@evjs/cli"],
+  );
+});
+
+test("rejects circular internal dependencies", () => {
+  const workspacePackages = [
+    {
+      packageJson: {
+        name: "@evjs/a",
+        dependencies: { "@evjs/b": "1.0.0" },
+      },
+    },
+    {
+      packageJson: {
+        name: "@evjs/b",
+        dependencies: { "@evjs/a": "1.0.0" },
+      },
+    },
+  ];
+
+  assert.throws(
+    () => orderWorkspacePackages(workspacePackages),
+    /Circular workspace dependency/,
+  );
+});
+
+test("continues a partial release only from matching tarballs and tags", () => {
+  const packages = [
+    {
+      name: "@evjs/shared",
+      version: "1.0.0",
+      integrity: "sha512-shared",
+    },
+    {
+      name: "@evjs/server",
+      version: "1.0.0",
+      integrity: "sha512-server",
+    },
+  ];
+  const registryStates = new Map([
+    [
+      "@evjs/shared",
+      {
+        versionMetadata: { dist: { integrity: "sha512-shared" } },
+        tagVersion: "1.0.0",
+      },
+    ],
+    ["@evjs/server", { versionMetadata: null, tagVersion: "0.9.0" }],
+  ]);
+
+  const plan = planPublication(packages, registryStates, "latest");
+  assert.equal(plan.complete, false);
+  assert.deepEqual(
+    plan.published.map(({ manifestPackage }) => manifestPackage.name),
+    ["@evjs/shared"],
+  );
+  assert.deepEqual(
+    plan.unpublished.map(({ name }) => name),
+    ["@evjs/server"],
+  );
+});
+
+test("rejects a partial release containing a different published tarball", () => {
+  const packages = [
+    {
+      name: "@evjs/shared",
+      version: "1.0.0",
+      integrity: "sha512-local",
+    },
+    {
+      name: "@evjs/server",
+      version: "1.0.0",
+      integrity: "sha512-server",
+    },
+  ];
+  const registryStates = new Map([
+    [
+      "@evjs/shared",
+      {
+        versionMetadata: { dist: { integrity: "sha512-published" } },
+        tagVersion: "1.0.0",
+      },
+    ],
+    ["@evjs/server", { versionMetadata: null, tagVersion: null }],
+  ]);
+
+  assert.throws(
+    () => planPublication(packages, registryStates, "latest"),
+    /different tarball/,
+  );
+});
+
+test("rejects a partial release with an unexpected dist-tag", () => {
+  const packages = [
+    {
+      name: "@evjs/shared",
+      version: "1.0.0",
+      integrity: "sha512-shared",
+    },
+    {
+      name: "@evjs/server",
+      version: "1.0.0",
+      integrity: "sha512-server",
+    },
+  ];
+  const registryStates = new Map([
+    [
+      "@evjs/shared",
+      {
+        versionMetadata: { dist: { integrity: "sha512-shared" } },
+        tagVersion: "1.1.0",
+      },
+    ],
+    ["@evjs/server", { versionMetadata: null, tagVersion: null }],
+  ]);
+
+  assert.throws(
+    () => planPublication(packages, registryStates, "latest"),
+    /dist-tag points to 1.1.0/,
+  );
+});
+
+test("treats a fully published release as idempotently complete", () => {
+  const packages = [
+    {
+      name: "@evjs/shared",
+      version: "1.0.0",
+      integrity: "sha512-local",
+    },
+  ];
+  const registryStates = new Map([
+    [
+      "@evjs/shared",
+      {
+        versionMetadata: { dist: { integrity: "sha512-older-build" } },
+        tagVersion: "2.0.0",
+      },
+    ],
+  ]);
+
+  assert.equal(
+    planPublication(packages, registryStates, "latest").complete,
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- Make CI and docs installs deterministic and cancel stale CI runs.
- Replace direct workspace publishing with an immutable, preflighted npm release pipeline.
- Move all nine public packages to environment-bound npm trusted publishing.

## Changes
- Pin Node 22.23.2, npm 11.19.0, and every GitHub Action to an exact commit SHA.
- Add explicit permissions, job timeouts, and workflow concurrency controls.
- Resolve releases only from published `v<semver>` tags whose commits are on `main`.
- Build and validate without publish credentials, pack all nine packages first, then pass immutable tarballs to the protected publish job.
- Verify every npm OIDC exchange before the first package is published.
- Validate registry failures, existing tarball integrity, dist-tags, publish propagation, and idempotent retries.
- Add a non-publishing `verify-oidc` workflow operation and focused release invariant tests.

## Validation
- `npx npm@11.19.0 ci`
- `npm run lint`
- `npm run check-types`
- `npm test`
- `npm run build`
- `npm run test:e2e` (53 passed)
- `actionlint` 1.7.12
- Release rehearsal for 0.3.17: built and packed 9/9 tarballs without publishing
- `git diff --check`

## Risk / rollout
- The `npm-release` GitHub environment is already configured with required reviewer `xusd320`; only `main` and `v*` tags are allowed.
- Before merge, all nine npm package Trusted Publisher records must use repository `afx-team/evjs`, workflow `release.yml`, environment `npm-release`, and allow `npm publish`.
- After the new `verify-oidc` operation passes, remove the legacy repository `NPM_TOKEN`; this PR no longer consumes it.
- Publishing remains sequential because internal packages have a dependency order, but all artifact and credential failures are preflighted before the first irreversible publish.

## Reviewer notes
- Focus review on `scripts/release-packages.mjs`, the partial-release recovery invariants, and the release job permission boundary.
- Keep this PR in draft until npm Trusted Publisher configuration and the non-publishing OIDC check are complete.
