### PR TITLE
docs(changelog): prepare v0.3.17 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.17] — 2026-08-31
+
 ### ⚠️ Breaking Changes
 
 - **Consistent basepath spelling** — Framework server configuration, resolved


### PR DESCRIPTION
## Summary
- Prepare the changelog for the `v0.3.17` release dated 2026-08-31.
- Keep the basepath feature and spelling change on the Core 0.3 release line.

## Changes
- Move the merged SPA `routing.basepath` feature and lowercase `basepath` breaking-change notes into a new `0.3.17` section.
- Leave an empty `Unreleased` section for subsequent work.

## Validation
- `git diff --check`
- `npm run lint`
- `npm run check-types`
- `npm test`
- `npm --workspace evjs-docs run build`
- Implementation PR #125 `Build & Test` check passed.

## Risk / rollout
- This PR changes only release documentation.
- The ensuing 0.3.17 publication intentionally removes the `basePath` spelling without an alias; consumers must migrate to `basepath`.
- npm publication occurs only after the `v0.3.17` GitHub Release is published.

## Reviewer notes
- Verify that 0.3.17 is the intended release line and that the notes cover exactly the changes merged in #125.
