### PR TITLE
fix(routing): enforce strict SPA basepath mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- **Strict SPA basepath mounts** — Browser locations outside
+  `routing.basepath` now remain unchanged and resolve through the application's
+  not-found boundary instead of being normalized into the mounted SPA.
+
 ---
 
 ## [0.3.17] — 2026-08-31

--- a/packages/client/src/framework/page/page-route.ts
+++ b/packages/client/src/framework/page/page-route.ts
@@ -25,6 +25,7 @@ import {
   createHashHistory,
   createMemoryHistory,
   createRootRouteWithContext,
+  notFound as createRouterNotFound,
   redirect as createRouterRedirect,
   createRoute as createTanStackRoute,
   Outlet,
@@ -49,11 +50,14 @@ interface PageRouteContext {
 const EV_BYPASS_ROOT_LAYOUT_STATIC_DATA = "__evjsBypassRootLayout";
 const EV_PAGE_METADATA_OWNER_STATIC_DATA = "__evjsPageMetadataOwner";
 const EV_PAGE_METADATA_STATIC_DATA = "__evjsPageMetadata";
+const EV_OUTSIDE_BASEPATH_STATIC_DATA = "__evjsOutsideBasepath";
+const OUTSIDE_BASEPATH_MARKER = "/__evjs_outside_basepath__";
 
 interface EvRouteStaticData {
   __evjsBypassRootLayout?: boolean;
   __evjsPageMetadataOwner?: true;
   __evjsPageMetadata?: PageMetadata;
+  __evjsOutsideBasepath?: true;
 }
 
 const createPageRootRoute = createRootRouteWithContext<PageRouteContext>();
@@ -196,6 +200,7 @@ export function createPagesApp(options: CreatePagesAppOptions): PagesApp {
     const routeTree = createGeneratedRouteTree({
       routes: composePageDefinitions(canonicalRoutes, state.routes),
       ...(rootModule ? { rootModule } : {}),
+      ...(state.basepath ? { basepath: state.basepath } : {}),
     });
     const runtimeApp = createFrameworkApp(
       {
@@ -611,7 +616,40 @@ function createGeneratedRouteTree(options: CreatePagesAppOptions): AnyRoute {
     ),
   );
 
+  if (options.basepath) {
+    routes.unshift(
+      ...createOutsideBasepathBoundaryRoutes(rootRoute, definitions),
+    );
+  }
+
   return rootRoute.addChildren(routes);
+}
+
+function createOutsideBasepathBoundaryRoutes(
+  rootRoute: AnyRoute,
+  definitions: NormalizedPageDefinition[],
+): AnyRoute[] {
+  const notFoundComponent = definitions.find(
+    (definition) =>
+      normalizeGeneratedRoutePath(definition.path) === "/" &&
+      definition.module?.notFoundComponent,
+  )?.module?.notFoundComponent;
+
+  return [OUTSIDE_BASEPATH_MARKER, `${OUTSIDE_BASEPATH_MARKER}/$`].map(
+    (path) => {
+      let route: AnyRoute;
+      route = createTanStackRoute({
+        getParentRoute: () => rootRoute,
+        path,
+        staticData: { [EV_OUTSIDE_BASEPATH_STATIC_DATA]: true },
+        ...(notFoundComponent ? { notFoundComponent } : {}),
+        beforeLoad() {
+          throw createRouterNotFound({ routeId: route.id });
+        },
+      });
+      return route;
+    },
+  );
 }
 
 function createGeneratedRoute<TRootRoute extends AnyRoute>(

--- a/packages/client/src/standalone/app.tsx
+++ b/packages/client/src/standalone/app.tsx
@@ -8,9 +8,12 @@ import type {
   TrailingSlashOption,
 } from "@tanstack/react-router";
 import {
+  composeRewrites,
   createRouter,
+  type LocationRewrite,
   RouterProvider,
   stringifySearchWith,
+  trimPath,
 } from "@tanstack/react-router";
 import { type ComponentType, createElement, type ReactNode } from "react";
 import { createRoot, hydrateRoot } from "react-dom/client";
@@ -18,6 +21,7 @@ import { formatErrorDetail } from "../shared/validation.js";
 import type { AppRouteContext } from "./context.js";
 
 const stringifyRawSearch = stringifySearchWith(String);
+const OUTSIDE_BASEPATH_MARKER = "/__evjs_outside_basepath__";
 
 /**
  * Router options available to standalone CSR applications.
@@ -166,6 +170,13 @@ function createAppRuntime<
     history,
     router: routerOptions,
   } = options;
+  const configuredBasepath = routerOptions?.basepath ?? basepath;
+  const basepathRewrite = createStrictBasepathRewrite(configuredBasepath);
+  const rewrite = basepathRewrite
+    ? routerOptions?.rewrite
+      ? composeRewrites([basepathRewrite, routerOptions.rewrite])
+      : basepathRewrite
+    : routerOptions?.rewrite;
 
   const router = createRouter<
     TRouteTree,
@@ -176,13 +187,25 @@ function createAppRuntime<
   >({
     ...routerOptions,
     routeTree,
-    basepath: routerOptions?.basepath ?? basepath,
+    // TanStack Router's built-in basepath rewrite treats paths outside the
+    // mount as application-relative paths. EVJS supplies a strict rewrite and
+    // keeps the Router's internal basepath at root to avoid composing both.
+    basepath: basepathRewrite ? "/" : configuredBasepath,
+    rewrite,
     history: routerOptions?.history ?? history,
     defaultPreload: routerOptions?.defaultPreload ?? "intent",
     parseSearch: routerOptions?.parseSearch ?? parsePageSearch,
     stringifySearch: routerOptions?.stringifySearch ?? stringifyRawSearch,
     context: { queryClient } as AppRouteContext,
   });
+
+  if (basepathRewrite && configuredBasepath) {
+    // Preserve the configured public metadata for consumers such as Link while
+    // the Router continues to use the strict rewrite assembled above.
+    router.basepath = configuredBasepath;
+    router.options.basepath = configuredBasepath;
+    installStrictBasepathMatchBoundary(router);
+  }
 
   let root: ReturnType<typeof createRoot> | undefined;
   let renderGeneration = 0;
@@ -227,6 +250,93 @@ function createAppRuntime<
   }
 
   return { router, queryClient, render, unmount };
+}
+
+function installStrictBasepathMatchBoundary(router: AnyRouter): void {
+  if (!router.routeTree.options.notFoundComponent) {
+    const rootPageNotFoundComponent = Object.values(router.routesById).find(
+      (route) =>
+        route !== router.routeTree &&
+        route.fullPath === "/" &&
+        route.options.notFoundComponent,
+    )?.options.notFoundComponent;
+    if (rootPageNotFoundComponent) {
+      router.routeTree.options.notFoundComponent = rootPageNotFoundComponent;
+    }
+  }
+
+  const matchRoutes = router.matchRoutes;
+  router.matchRoutes = ((...args: unknown[]) => {
+    const matches = Reflect.apply(matchRoutes, router, args) as ReturnType<
+      AnyRouter["matchRoutes"]
+    >;
+    const location = args[0];
+    const pathname =
+      typeof location === "string"
+        ? location
+        : location && typeof location === "object"
+          ? Reflect.get(location, "pathname")
+          : undefined;
+    if (
+      typeof pathname !== "string" ||
+      (pathname !== OUTSIDE_BASEPATH_MARKER &&
+        !pathname.startsWith(`${OUTSIDE_BASEPATH_MARKER}/`))
+    ) {
+      return matches;
+    }
+    const boundaryMatch = matches.find((match) => {
+      const route = router.routesById[match.routeId];
+      return Reflect.get(
+        route?.options.staticData ?? {},
+        "__evjsOutsideBasepath",
+      );
+    });
+    if (boundaryMatch) return matches;
+    const rootMatch = matches[0];
+    return rootMatch ? [{ ...rootMatch, globalNotFound: true }] : matches;
+  }) as unknown as AnyRouter["matchRoutes"];
+}
+
+function createStrictBasepathRewrite(
+  basepath: string | undefined,
+): LocationRewrite | undefined {
+  if (!basepath) return undefined;
+  const trimmedBasepath = trimPath(basepath);
+  if (!trimmedBasepath || trimmedBasepath === "/") return undefined;
+  const normalizedBasepath = `/${trimmedBasepath}`;
+  const normalizedBasepathWithSlash = `${normalizedBasepath}/`;
+  const checkBasepath = normalizedBasepath.toLowerCase();
+  const checkBasepathWithSlash = normalizedBasepathWithSlash.toLowerCase();
+
+  return {
+    input: ({ url }) => {
+      const pathname = url.pathname.toLowerCase();
+      if (pathname === checkBasepath) {
+        url.pathname = "/";
+      } else if (pathname.startsWith(checkBasepathWithSlash)) {
+        url.pathname = url.pathname.slice(normalizedBasepath.length);
+      } else {
+        url.pathname =
+          url.pathname === "/"
+            ? OUTSIDE_BASEPATH_MARKER
+            : `${OUTSIDE_BASEPATH_MARKER}${url.pathname}`;
+      }
+      return url;
+    },
+    output: ({ url }) => {
+      if (url.pathname === OUTSIDE_BASEPATH_MARKER) {
+        url.pathname = "/";
+      } else if (url.pathname.startsWith(`${OUTSIDE_BASEPATH_MARKER}/`)) {
+        url.pathname = url.pathname.slice(OUTSIDE_BASEPATH_MARKER.length);
+      } else {
+        url.pathname =
+          url.pathname === "/"
+            ? normalizedBasepath
+            : `${normalizedBasepath}${url.pathname}`;
+      }
+      return url;
+    },
+  };
 }
 
 /** @internal */

--- a/packages/client/tests/page-route.test.ts
+++ b/packages/client/tests/page-route.test.ts
@@ -107,6 +107,158 @@ describe("createPagesApp", () => {
     expect(history.location.href).toBe(initialUrl);
   });
 
+  it("keeps locations outside the SPA basepath unmatched and unchanged", async () => {
+    function Console() {
+      return createElement("p", undefined, "console");
+    }
+    function NotFound() {
+      return createElement("h1", undefined, "not found");
+    }
+
+    const initialUrl = "/console?tab=recent#activity";
+    const history = client.createMemoryHistory({
+      initialEntries: [initialUrl],
+    });
+    const { app } = createPagesApp({
+      routes: [
+        {
+          path: "/",
+          module: {
+            default: Console,
+            notFoundComponent: NotFound,
+          },
+        },
+        { path: "/console", module: { default: Console } },
+        {
+          path: "/$productName/$applicationName",
+          kind: "redirect",
+          redirect: {
+            kind: "path",
+            path: "/$productName/$applicationName/sprints",
+          },
+        },
+      ],
+      basepath: "/next",
+      history,
+    });
+    const router = app.router as {
+      basepath: string;
+      latestLocation: {
+        pathname: string;
+        publicHref: string;
+      };
+      matchRoutes(location: unknown): Array<{
+        routeId: string;
+        globalNotFound?: boolean;
+      }>;
+      buildLocation(options: unknown): { publicHref: string };
+      routeTree: { options: { notFoundComponent?: unknown } };
+      load(): Promise<void>;
+      stores: {
+        matches: {
+          get(): Array<{
+            routeId: string;
+            status: string;
+            globalNotFound?: boolean;
+          }>;
+        };
+      };
+    };
+
+    expect(router.basepath).toBe("/next");
+    expect(router.latestLocation.publicHref).toBe(initialUrl);
+    expect(history.location.href).toBe(initialUrl);
+    expect(router.routeTree.options.notFoundComponent).toBe(NotFound);
+    expect(router.matchRoutes(router.latestLocation)).toEqual([
+      expect.objectContaining({ routeId: "__root__" }),
+      expect.objectContaining({
+        routeId: expect.stringContaining("__evjs_outside_basepath__"),
+      }),
+    ]);
+    expect(
+      router.buildLocation({
+        to: router.latestLocation.pathname,
+        search: true,
+        hash: true,
+      }).publicHref,
+    ).toBe(initialUrl);
+    await expect(router.load()).resolves.toBeUndefined();
+    expect(history.location.href).toBe(initialUrl);
+    expect(router.stores.matches.get()).toEqual([
+      expect.objectContaining({ routeId: "__root__", status: "success" }),
+      expect.objectContaining({ status: "notFound" }),
+    ]);
+    expect(
+      renderToStaticMarkup(
+        createElement(
+          QueryClientProvider,
+          { client: app.queryClient },
+          createElement(client.RouterProvider, {
+            router: router as client.AnyRouter,
+          }),
+        ),
+      ),
+    ).toContain("not found");
+  });
+
+  it("loads and prefixes application-relative navigation under a strict SPA basepath", async () => {
+    function Console() {
+      return createElement("p", undefined, "console");
+    }
+
+    const history = client.createMemoryHistory({
+      initialEntries: ["/next/console"],
+    });
+    const { app } = createPagesApp({
+      routes: [
+        { path: "/", module: { default: Console } },
+        { path: "/console", module: { default: Console } },
+      ],
+      basepath: "/next",
+      history,
+    });
+    const router = app.router as {
+      latestLocation: { pathname: string; publicHref: string };
+      buildLocation(options: unknown): {
+        pathname: string;
+        publicHref: string;
+      };
+      load(): Promise<void>;
+      stores: {
+        matches: {
+          get(): Array<{ routeId: string; status: string }>;
+        };
+      };
+    };
+
+    expect(router.latestLocation).toMatchObject({
+      pathname: "/console",
+      publicHref: "/next/console",
+    });
+    expect(
+      router.buildLocation({ to: "/console", search: { tab: "recent" } }),
+    ).toMatchObject({
+      pathname: "/console",
+      publicHref: "/next/console?tab=recent",
+    });
+    await expect(router.load()).resolves.toBeUndefined();
+    expect(router.stores.matches.get()).toEqual([
+      expect.objectContaining({ routeId: "__root__", status: "success" }),
+      expect.objectContaining({ routeId: "/console", status: "success" }),
+    ]);
+    expect(
+      renderToStaticMarkup(
+        createElement(
+          QueryClientProvider,
+          { client: app.queryClient },
+          createElement(client.RouterProvider, {
+            router: router as client.AnyRouter,
+          }),
+        ),
+      ),
+    ).toContain("console");
+  });
+
   it("replaces runtime Route overlays without removing generated Routes", async () => {
     function Home() {
       return null;


### PR DESCRIPTION
## Summary
- Enforce strict SPA mounts for configured `basepath` values.
- Keep browser locations outside the mount unchanged and render the application not-found boundary.

## Changes
- Replace the permissive TanStack basepath rewrite with an EVJS strict, reversible location rewrite.
- Add generated outside-basepath boundary routes so dynamic application routes cannot claim unmounted URLs.
- Preserve query strings, hashes, router metadata, custom rewrites, and application-relative navigation.
- Cover direct outside-mount loads, dynamic-route precedence, 404 rendering, and normal mounted navigation.

## Validation
- `npm run lint`
- `npm run check-types`
- `npm test`
- `npm run build`
- Manual Yuyan EVJS smoke: `/console?tab=recent#activity` kept its URL and rendered 404; the return link resolved to `/next`.

## Risk / rollout
- This intentionally changes SPA behavior outside a configured basepath from permissive matching to a strict not-found result.
- Applications without `routing.basepath` are unaffected.
- The generated router reserves an internal outside-basepath marker route.

## Reviewer notes
- Please focus on rewrite composition in `standalone/app.tsx` and not-found boundary precedence in `page-route.ts`.
- Publishing the next 0.3 patch release will be handled after merge.