### PR TITLE
docs(changelog): prepare v0.3.18 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.18] — 2026-08-31
+
 ### 🐛 Bug Fixes
 
 - **Strict SPA basepath mounts** — Browser locations outside


### PR DESCRIPTION
## Summary
- Prepare the EVJS 0.3.18 patch release.

## Changes
- Move the strict SPA basepath mount fix from Unreleased into the 0.3.18 changelog section dated 2026-08-31.

## Validation
- `npm run lint`
- `npm run check-types`
- The implementation PR #127 passed the complete GitHub Build & Test workflow, including E2E.

## Risk / rollout
- Documentation-only release preparation.
- Publishing starts only after this PR is merged and the v0.3.18 GitHub release is created.

## Reviewer notes
- Verify the version and date in `CHANGELOG.md`.