### PR TITLE
fix(routing): preserve nested pages under layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- **Nested Pages below directory index Pages** — SPA Pages nested below a
+  directory that owns both `layout.tsx` and `page.tsx` now remain children of
+  the layout Route, so deep URLs match instead of falling through to the
+  application's not-found boundary.
+
 ---
 
 ## [0.3.18] — 2026-08-31

--- a/packages/ev/src/_internal/build/plan/create-build-plan.ts
+++ b/packages/ev/src/_internal/build/plan/create-build-plan.ts
@@ -126,6 +126,16 @@ function deriveBuildPlanFacts(
   const routes: BuildRouteFacts[] = [];
   const clientRoutes = graph.routes;
   const routeById = new Map(clientRoutes.map((route) => [route.id, route]));
+  // A Page colocated with a layout materializes as an index Route. Its
+  // descendants must stay attached to the layout because index Routes cannot
+  // own children in the client router.
+  const splitLayoutIdByRouteId = new Map(
+    clientRoutes.flatMap((route) =>
+      typeof route.facets.layout === "string" && route.target.kind === "page"
+        ? [[route.id, `${route.id}:layout`] as const]
+        : [],
+    ),
+  );
   const routesByPageId = new Map<string, CoreClientRouteNode[]>();
   const pageDocumentByPageId = new Map<
     string,
@@ -241,6 +251,9 @@ function deriveBuildPlanFacts(
 
   for (const route of clientRoutes) {
     const path = formatCoreRoutePattern(route.pattern);
+    const parentId = route.parentId
+      ? (splitLayoutIdByRouteId.get(route.parentId) ?? route.parentId)
+      : undefined;
     const page =
       route.target.kind === "page"
         ? graph.pages[route.target.pageId]
@@ -263,11 +276,16 @@ function deriveBuildPlanFacts(
     const layoutModule =
       typeof route.facets.layout === "string" ? route.facets.layout : undefined;
     if (layoutModule && route.target.kind === "page") {
-      const layoutId = `${route.id}:layout`;
+      const layoutId = splitLayoutIdByRouteId.get(route.id);
+      if (!layoutId) {
+        throw new Error(
+          `[evjs] Route "${route.id}" is missing its planned layout Route.`,
+        );
+      }
       routes.push({
         id: layoutId,
         path,
-        ...(route.parentId ? { parentId: route.parentId } : {}),
+        ...(parentId ? { parentId } : {}),
         kind: "layout",
         appId: route.applicationId,
         module: layoutModule,
@@ -291,7 +309,7 @@ function deriveBuildPlanFacts(
     routes.push({
       id: route.id,
       path,
-      ...(route.parentId ? { parentId: route.parentId } : {}),
+      ...(parentId ? { parentId } : {}),
       ...(layoutModule ? { kind: "layout" as const } : {}),
       appId: route.applicationId,
       ...(route.target.kind === "page"

--- a/packages/ev/tests/build-tools-graph-plan.test.ts
+++ b/packages/ev/tests/build-tools-graph-plan.test.ts
@@ -474,8 +474,21 @@ describe("canonical CoreGraph and BuildPlan integration", () => {
         type: "pages-app",
         routes: expect.arrayContaining([
           expect.objectContaining({
+            id: "users:layout",
+            path: "/users",
+            kind: "layout",
+            module: "./src/pages/users/layout.tsx",
+          }),
+          expect.objectContaining({
+            id: "users",
+            path: "/users",
+            parentId: "users:layout",
+            module: "./src/pages/users/page.tsx",
+          }),
+          expect.objectContaining({
             id: "users_userId",
             path: "/users/$userId",
+            parentId: "users:layout",
             module: "./src/pages/users/$userId/page.tsx",
           }),
         ]),


### PR DESCRIPTION
## Summary
- Fix SPA deep-route matching when a directory contains both `layout.tsx` and `page.tsx`.
- Keep nested Pages attached to the materialized layout Route because the colocated Page is an index Route.

## Changes
- Remap descendant parent ids from the directory Page to its synthetic layout Route during BuildPlan creation.
- Cover the generated layout, index Page, and child Page relationship in the graph-plan regression test.
- Document the fix in the unreleased changelog.

## Validation
- `npm run check-types`
- `npm run lint`
- `npm test`
- `git diff --check`
- Generated and matched the affected Yuyan route tree for `/next/frontarch/evjs/sprints/S090011871329` and its `/overview` child.

## Risk / rollout
- Limited to SPA routes whose directory owns both a layout and a Page.
- The Page remains the exact-path index leaf; only descendants move to the layout parent.

## Reviewer notes
- Please focus on the BuildPlan parent-id remapping and index-route semantics.