### PR TITLE
docs(changelog): prepare v0.3.19 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.19] — 2026-08-31
+
 ### 🐛 Bug Fixes
 
 - **Nested Pages below directory index Pages** — SPA Pages nested below a


### PR DESCRIPTION
## Summary
- Prepare the EVJS 0.3.19 patch release.

## Changes
- Move the nested SPA Page routing fix from Unreleased into the 0.3.19 changelog section dated 2026-08-31.

## Validation
- `npm run lint`
- `npm --workspace evjs-docs run build`
- `git diff --check`
- Implementation PR #129 passed the complete GitHub Build & Test workflow, including E2E.

## Risk / rollout
- Documentation-only release preparation.
- Publishing starts only after this PR is merged and the v0.3.19 GitHub release is created.

## Reviewer notes
- Verify the version and date in `CHANGELOG.md`.