### PR TITLE
docs(changelog): prepare v0.3.20 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.20] — 2026-09-02
+
 ### ✨ Features
 
 - **Application-aware browser hrefs** — `useHref()` and `useHrefResolver()`


### PR DESCRIPTION
## Summary
- Prepare the changelog for the `v0.3.20` Core release.

## Changes
- Move the current unreleased routing features and basepath lifecycle fix under the dated `0.3.20` section.
- Leave the `Unreleased` section ready for subsequent changes.

## Validation
- `npm run lint`
- `npm run check-types`
- `git diff --check`

## Risk / rollout
- Documentation-only release metadata change.
- npm publication is not triggered by this PR; it will be triggered separately by creating the `v0.3.20` GitHub Release after merge.

## Reviewer notes
- Confirm the version and release date before merge.