### PR TITLE
docs(changelog): prepare v0.3.21 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to evjs are documented here. Releases follow [Semantic Versi
 
 ## [Unreleased]
 
+---
+
+## [0.3.21] — 2026-09-03
+
 ### ⚠️ Breaking Changes
 
 - **Explicit API middleware policies** — Stop discovering and inheriting


### PR DESCRIPTION
## Summary
- Prepare `v0.3.21` with Application component mode and explicit HTTP method middleware composition.

## Changes
- Move the current unreleased changelog entries under the dated `0.3.21` section and leave `Unreleased` ready for subsequent changes.

## Validation
- `npm run lint`
- `npm run check-types`
- `npm --workspace evjs-docs run build` (English and Chinese)
- `git diff --check`

## Risk / rollout
- This PR changes release metadata only.
- The release includes removal of automatic API directory middleware and relocation of middleware exports; migration requirements are documented in the changelog.
- Publish through the existing GitHub Release workflow after merge. The workflow sets all package versions and internal dependency versions to `0.3.21`.

## Reviewer notes
- Confirm the release version, date, and breaking-change guidance.
